### PR TITLE
feat(setup): KIND local cluster config and install script

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -1,0 +1,84 @@
+# Cluster Setup — Choosing the Right Method
+
+This directory contains setup guides and automation scripts for every major Kubernetes provisioning method. Use the comparison table below to decide which approach fits your situation, then follow the linked guide.
+
+---
+
+## Comparison Table
+
+| | **KIND** | **Minikube** | **kubeadm** | **EKS (eksctl)** |
+|---|---|---|---|---|
+| **What it is** | Kubernetes in Docker — runs the entire cluster as containers | Single-node (or multi-node) cluster using a VM or Docker | Official tool to bootstrap a "real" cluster on bare VMs/servers | Managed Kubernetes control plane on AWS |
+| **Control plane managed by** | You (via Docker) | You (via minikube CLI) | You (full responsibility) | AWS |
+| **Best for** | Local dev, CI pipelines, learning multi-node topologies | Local dev, add-on experimentation, demos | Learning kubeadm internals, home-lab, on-prem | Production workloads in AWS |
+| **Platform support** | Linux, macOS, Windows (Docker Desktop) | Linux, macOS, Windows | Linux VMs / bare metal | AWS cloud |
+| **Multi-node support** | Yes (via config) | Limited (experimental) | Yes (unlimited) | Yes (node groups) |
+| **Persistence across restarts** | No (containers restart) | Yes (VM disk) | Yes | Yes |
+| **Resource usage** | Very low (shares Docker daemon) | Medium (VM overhead) | Medium–High (full OS per node) | Pay-per-node |
+| **Setup time** | ~2 minutes | ~5 minutes | ~30–60 minutes | ~20–30 minutes |
+| **Ingress support** | Yes (port mapping in config) | Yes (minikube addons enable ingress) | Yes (install separately) | Yes (ALB/NLB Ingress Controller) |
+| **Load balancer support** | Requires MetalLB or cloud-provider-kind | Requires minikube tunnel | Requires MetalLB | Native (ELB) |
+| **Persistent volumes** | hostPath via extraMounts | hostPath / minikube mount | Manual PV or CSI driver | EBS CSI Driver |
+| **Add-ons / ecosystem** | Manual Helm installs | Built-in addon system | Manual installs | AWS Marketplace / add-ons |
+| **Production-grade** | No | No | Possible (with effort) | Yes |
+| **Cost** | Free | Free | Free (infra cost only) | AWS pricing |
+| **Guide** | [setup/local/kind/](local/kind/README.md) | [setup/local/minikube/](local/minikube/README.md) | [setup/kubeadm/](kubeadm/README.md) | [setup/cloud/eks/](cloud/eks/README.md) |
+
+---
+
+## When to Use Each
+
+### KIND — Use for:
+- Running this repository's examples locally.
+- CI pipelines (GitHub Actions, GitLab CI) that need a real cluster.
+- Testing multi-node behavior without VMs.
+- The fastest possible iteration loop during development.
+
+**Not for:** anything that needs to survive a laptop restart, or workloads that need GPU/real persistent volumes.
+
+### Minikube — Use for:
+- Exploring Kubernetes add-ons (dashboard, metrics-server, registry, ingress) with one command.
+- Demos and workshops where participants are on mixed OS (Linux/macOS/Windows).
+- Experimenting with Kubernetes features without modifying your Docker setup.
+
+**Not for:** CI pipelines (too slow to start), multi-node topology testing.
+
+### kubeadm — Use for:
+- Learning exactly how Kubernetes bootstrapping works under the hood.
+- Building a home-lab or on-premises cluster on real or virtual machines.
+- Interview preparation — kubeadm questions come up frequently.
+- Bare-metal production clusters (combined with a CNI like Calico and a storage solution).
+
+**Not for:** quick local dev (use KIND instead). kubeadm clusters require manual upgrades, etcd backups, and node maintenance.
+
+### EKS (eksctl) — Use for:
+- Production workloads on AWS.
+- Teams that need managed control-plane updates, AWS IAM integration, and native load balancers.
+- Workloads that need EBS/EFS persistent storage, AWS Secrets Manager integration, or Fargate serverless nodes.
+
+**Not for:** local development, cost-sensitive learning environments, or workloads with multi-cloud requirements.
+
+---
+
+## Quick Decision Tree
+
+```
+Do you need it to run in production?
+  YES → Is it on AWS?
+          YES → EKS
+          NO  → kubeadm (on-prem) or EKS alternative (GKE/AKS)
+  NO  → Is it for CI or local dev?
+          CI → KIND
+          Local dev → KIND (fastest) or Minikube (best add-on ecosystem)
+```
+
+---
+
+## Directory Index
+
+| Directory | Method | Guide |
+|-----------|--------|-------|
+| `local/kind/` | KIND | [README](local/kind/README.md) |
+| `local/minikube/` | Minikube | [README](local/minikube/README.md) |
+| `cloud/eks/` | EKS | [README](cloud/eks/README.md) |
+| `kubeadm/` | kubeadm | [README](kubeadm/README.md) |

--- a/setup/local/kind/README.md
+++ b/setup/local/kind/README.md
@@ -1,0 +1,261 @@
+# KIND — Kubernetes in Docker
+
+KIND (Kubernetes IN Docker) runs each Kubernetes node as a Docker container. It is the recommended method for running this repository's examples locally and in CI.
+
+---
+
+## Prerequisites
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Docker | 24.0+ | Container runtime for KIND nodes |
+| `kind` | 0.29.0 | Cluster lifecycle management |
+| `kubectl` | 1.30.0+ | Cluster interaction |
+
+---
+
+## Quick Install (automated)
+
+The `install.sh` script installs Docker (Linux only), KIND, and kubectl in an idempotent way. It skips tools that are already installed.
+
+```bash
+# Default versions
+bash setup/local/kind/install.sh
+
+# Override versions
+KIND_VERSION=0.29.0 KUBECTL_VERSION=1.32.0 bash setup/local/kind/install.sh
+```
+
+---
+
+## Manual Install
+
+### macOS
+
+```bash
+# Homebrew (recommended)
+brew install kind kubectl
+
+# Verify
+kind version
+kubectl version --client
+```
+
+### Linux (amd64)
+
+```bash
+# KIND
+KIND_VERSION="0.29.0"
+curl -Lo /tmp/kind \
+  "https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-linux-amd64"
+chmod +x /tmp/kind
+sudo mv /tmp/kind /usr/local/bin/kind
+
+# kubectl
+KUBECTL_VERSION="1.32.0"
+curl -Lo /tmp/kubectl \
+  "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+chmod +x /tmp/kubectl
+sudo mv /tmp/kubectl /usr/local/bin/kubectl
+```
+
+### Linux (arm64)
+
+```bash
+KIND_VERSION="0.29.0"
+curl -Lo /tmp/kind \
+  "https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-linux-arm64"
+chmod +x /tmp/kind
+sudo mv /tmp/kind /usr/local/bin/kind
+
+KUBECTL_VERSION="1.32.0"
+curl -Lo /tmp/kubectl \
+  "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/arm64/kubectl"
+chmod +x /tmp/kubectl
+sudo mv /tmp/kubectl /usr/local/bin/kubectl
+```
+
+### Windows
+
+```powershell
+# With Chocolatey
+choco install kind kubernetes-cli
+
+# Or with Scoop
+scoop install kind kubectl
+```
+
+---
+
+## Create the Cluster
+
+### Using the provided config (recommended)
+
+The `kind-config.yml` in this directory creates a production-like 3-node cluster (1 control-plane + 2 workers) with port mappings for Ingress.
+
+```bash
+kind create cluster \
+  --name kube-platform \
+  --config setup/local/kind/kind-config.yml \
+  --wait 120s
+```
+
+### Minimal single-node cluster
+
+```bash
+kind create cluster --name kube-platform
+```
+
+---
+
+## Verify the Cluster
+
+```bash
+# Check nodes (should show 1 control-plane + 2 workers)
+kubectl get nodes -o wide
+
+# Check system pods
+kubectl get pods -n kube-system
+
+# Check cluster info
+kubectl cluster-info --context kind-kube-platform
+```
+
+Expected output:
+
+```
+NAME                           STATUS   ROLES           AGE   VERSION
+kube-platform-control-plane    Ready    control-plane   2m    v1.32.0
+kube-platform-worker           Ready    <none>          90s   v1.32.0
+kube-platform-worker2          Ready    <none>          90s   v1.32.0
+```
+
+---
+
+## Using Ingress
+
+The KIND config maps host ports 8080 and 8443 to the control-plane container's ports 80 and 443. To use Ingress:
+
+1. Install the NGINX Ingress Controller:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.11.0/deploy/static/provider/kind/deploy.yaml
+
+# Wait for the controller to be ready
+kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=90s
+```
+
+2. Create an Ingress resource pointing to your Service.
+
+3. Access your application at `http://localhost:8080`.
+
+---
+
+## Loading Local Images
+
+KIND clusters do not automatically have access to locally built Docker images. Use `kind load` to push images into the cluster nodes:
+
+```bash
+# Build an image
+docker build -t my-app:latest .
+
+# Load into KIND cluster
+kind load docker-image my-app:latest --name kube-platform
+
+# Reference in your manifest
+# image: my-app:latest
+# imagePullPolicy: Never
+```
+
+---
+
+## Multiple Clusters
+
+You can run multiple KIND clusters simultaneously (useful for testing multi-cluster scenarios):
+
+```bash
+kind create cluster --name cluster-a
+kind create cluster --name cluster-b
+
+# Switch between them
+kubectl config use-context kind-cluster-a
+kubectl config use-context kind-cluster-b
+
+# List all contexts
+kubectl config get-contexts
+```
+
+---
+
+## Useful KIND Commands
+
+```bash
+# List clusters
+kind get clusters
+
+# Get nodes in a cluster
+kind get nodes --name kube-platform
+
+# Export kubeconfig
+kind export kubeconfig --name kube-platform --kubeconfig /tmp/kube-platform.kubeconfig
+
+# Inspect cluster logs
+kind export logs --name kube-platform /tmp/kind-logs
+
+# Delete cluster
+kind delete cluster --name kube-platform
+
+# Delete all clusters
+kind delete clusters --all
+```
+
+---
+
+## Troubleshooting
+
+### Nodes stuck in NotReady
+
+```bash
+# Check events
+kubectl get events -n kube-system --sort-by='.lastTimestamp'
+
+# Describe a node
+kubectl describe node kube-platform-control-plane
+```
+
+### Port 8080 already in use
+
+Edit `kind-config.yml` and change the `hostPort` value, or stop the conflicting process:
+
+```bash
+sudo lsof -i :8080
+```
+
+### Docker not running
+
+```bash
+# macOS / Linux
+docker info
+# Start Docker Desktop (macOS) or: sudo systemctl start docker (Linux)
+```
+
+### KIND cluster creation times out
+
+Increase the `--wait` flag or check Docker has enough resources (recommended: 4 CPU, 8 GB RAM).
+
+---
+
+## Cleanup
+
+```bash
+kind delete cluster --name kube-platform
+```
+
+Or using the Makefile:
+
+```bash
+make cluster-down
+```

--- a/setup/local/kind/install.sh
+++ b/setup/local/kind/install.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# install.sh — Idempotent installer for Docker (Linux), KIND, and kubectl
+#
+# Usage:
+#   bash install.sh
+#
+# Override versions with environment variables:
+#   KIND_VERSION=0.29.0 KUBECTL_VERSION=1.32.0 bash install.sh
+#
+# Supported platforms:
+#   - Linux  (amd64 / arm64)
+#   - macOS  (amd64 / arm64 / Apple Silicon)
+#
+# This script is idempotent: it checks whether each tool is already installed
+# at the required version before attempting to install or upgrade it.
+# ==============================================================================
+
+set -euo pipefail
+
+# ---- Versions (override with env vars) ----------------------------------------
+KIND_VERSION="${KIND_VERSION:-0.29.0}"
+KUBECTL_VERSION="${KUBECTL_VERSION:-1.32.0}"
+
+# ---- Platform detection -------------------------------------------------------
+ARCH="${ARCH:-$(uname -m)}"
+OS="${OS:-$(uname -s | tr '[:upper:]' '[:lower:]')}"
+
+# Normalize architecture names to match download URLs
+case "$ARCH" in
+  x86_64)  ARCH_KIND="amd64"; ARCH_KUBECTL="amd64" ;;
+  aarch64) ARCH_KIND="arm64"; ARCH_KUBECTL="arm64" ;;
+  arm64)   ARCH_KIND="arm64"; ARCH_KUBECTL="arm64" ;;
+  *)
+    echo "[ERROR] Unsupported architecture: $ARCH"
+    echo "        Supported: x86_64, aarch64, arm64"
+    exit 1
+    ;;
+esac
+
+# ---- Color helpers ------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+log_info()    { printf "${CYAN}[INFO]${RESET}  %s\n" "$*"; }
+log_ok()      { printf "${GREEN}[OK]${RESET}    %s\n" "$*"; }
+log_warn()    { printf "${YELLOW}[WARN]${RESET}  %s\n" "$*"; }
+log_error()   { printf "${RED}[ERROR]${RESET} %s\n" "$*" >&2; }
+log_section() { printf "\n${BOLD}=== %s ===${RESET}\n" "$*"; }
+
+# ---- Helper: require a command -----------------------------------------------
+require() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    log_error "Required command not found: $1"
+    log_error "Install '$1' and re-run this script."
+    exit 1
+  fi
+}
+
+# ---- Helper: compare semver (returns 0 if $1 >= $2) --------------------------
+version_ge() {
+  # Uses sort -V for version comparison
+  [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+}
+
+# ==============================================================================
+# SECTION 1: Docker
+# ==============================================================================
+
+install_docker() {
+  log_section "Docker"
+
+  if command -v docker >/dev/null 2>&1; then
+    DOCKER_VER=$(docker version --format '{{.Client.Version}}' 2>/dev/null || echo "unknown")
+    log_ok "Docker already installed: $DOCKER_VER"
+    return 0
+  fi
+
+  if [ "$OS" = "darwin" ]; then
+    log_warn "Docker not found on macOS."
+    log_warn "Install Docker Desktop from: https://www.docker.com/products/docker-desktop/"
+    log_warn "Or install with: brew install --cask docker"
+    exit 1
+  fi
+
+  # Linux: install Docker Engine from the official Docker apt repository
+  log_info "Installing Docker Engine on Linux..."
+  require curl
+  require apt-get 2>/dev/null || { log_error "Non-Debian/Ubuntu Linux detected. Install Docker manually."; exit 1; }
+
+  # Remove old versions
+  log_info "Removing old Docker packages if present..."
+  apt-get remove -y docker docker-engine docker.io containerd runc 2>/dev/null || true
+
+  # Install prerequisites
+  log_info "Installing Docker prerequisites..."
+  apt-get update -qq
+  apt-get install -y -qq \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+
+  # Add Docker GPG key
+  log_info "Adding Docker GPG key..."
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  chmod a+r /etc/apt/keyrings/docker.gpg
+
+  # Add Docker apt repository
+  log_info "Adding Docker apt repository..."
+  echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+    https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" \
+    | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+  # Install Docker Engine
+  apt-get update -qq
+  apt-get install -y -qq \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin
+
+  # Enable and start Docker
+  systemctl enable docker
+  systemctl start docker
+
+  # Add current user to the docker group (takes effect on next login)
+  if [ -n "${SUDO_USER:-}" ]; then
+    usermod -aG docker "$SUDO_USER"
+    log_ok "Added $SUDO_USER to the 'docker' group (re-login required)."
+  fi
+
+  log_ok "Docker installed successfully."
+}
+
+# ==============================================================================
+# SECTION 2: KIND
+# ==============================================================================
+
+install_kind() {
+  log_section "KIND (Kubernetes in Docker)"
+
+  KIND_URL="https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-${OS}-${ARCH_KIND}"
+
+  if command -v kind >/dev/null 2>&1; then
+    INSTALLED_KIND=$(kind version | awk '{print $2}' | tr -d 'v')
+    if version_ge "$INSTALLED_KIND" "$KIND_VERSION"; then
+      log_ok "KIND already installed: v${INSTALLED_KIND} (required: v${KIND_VERSION})"
+      return 0
+    else
+      log_warn "KIND v${INSTALLED_KIND} is older than required v${KIND_VERSION}. Upgrading..."
+    fi
+  else
+    log_info "KIND not found. Installing v${KIND_VERSION} (${OS}/${ARCH_KIND})..."
+  fi
+
+  log_info "Downloading KIND from: $KIND_URL"
+  curl -fsSL -o /tmp/kind "$KIND_URL"
+  chmod +x /tmp/kind
+
+  if [ "$OS" = "linux" ]; then
+    sudo mv /tmp/kind /usr/local/bin/kind
+  else
+    # macOS — prefer /usr/local/bin or ~/.local/bin
+    if [ -d "/usr/local/bin" ] && [ -w "/usr/local/bin" ]; then
+      mv /tmp/kind /usr/local/bin/kind
+    else
+      mkdir -p "$HOME/.local/bin"
+      mv /tmp/kind "$HOME/.local/bin/kind"
+      log_warn "Installed KIND to ~/.local/bin/kind — ensure this is on your PATH."
+    fi
+  fi
+
+  log_ok "KIND v${KIND_VERSION} installed at: $(command -v kind)"
+}
+
+# ==============================================================================
+# SECTION 3: kubectl
+# ==============================================================================
+
+install_kubectl() {
+  log_section "kubectl"
+
+  KUBECTL_URL="https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/${OS}/${ARCH_KUBECTL}/kubectl"
+
+  if command -v kubectl >/dev/null 2>&1; then
+    INSTALLED_KUBECTL=$(kubectl version --client --output=json 2>/dev/null \
+      | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['clientVersion']['gitVersion'].lstrip('v'))" \
+      2>/dev/null || kubectl version --client --short 2>/dev/null | awk '{print $3}' | tr -d 'v')
+    if version_ge "$INSTALLED_KUBECTL" "$KUBECTL_VERSION"; then
+      log_ok "kubectl already installed: v${INSTALLED_KUBECTL} (required: v${KUBECTL_VERSION})"
+      return 0
+    else
+      log_warn "kubectl v${INSTALLED_KUBECTL} is older than required v${KUBECTL_VERSION}. Upgrading..."
+    fi
+  else
+    log_info "kubectl not found. Installing v${KUBECTL_VERSION} (${OS}/${ARCH_KUBECTL})..."
+  fi
+
+  log_info "Downloading kubectl from: $KUBECTL_URL"
+  curl -fsSL -o /tmp/kubectl "$KUBECTL_URL"
+  chmod +x /tmp/kubectl
+
+  # Verify checksum
+  log_info "Verifying kubectl checksum..."
+  curl -fsSL -o /tmp/kubectl.sha256 "${KUBECTL_URL}.sha256"
+  (cd /tmp && echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check) \
+    || { log_error "kubectl checksum verification failed!"; exit 1; }
+
+  if [ "$OS" = "linux" ]; then
+    sudo mv /tmp/kubectl /usr/local/bin/kubectl
+  else
+    if [ -d "/usr/local/bin" ] && [ -w "/usr/local/bin" ]; then
+      mv /tmp/kubectl /usr/local/bin/kubectl
+    else
+      mkdir -p "$HOME/.local/bin"
+      mv /tmp/kubectl "$HOME/.local/bin/kubectl"
+      log_warn "Installed kubectl to ~/.local/bin/kubectl — ensure this is on your PATH."
+    fi
+  fi
+
+  log_ok "kubectl v${KUBECTL_VERSION} installed at: $(command -v kubectl)"
+}
+
+# ==============================================================================
+# MAIN
+# ==============================================================================
+
+main() {
+  log_section "kube-platform installer"
+  log_info "Platform: ${OS}/${ARCH} (KIND arch: ${ARCH_KIND}, kubectl arch: ${ARCH_KUBECTL})"
+  log_info "Versions to install:"
+  log_info "  KIND:    v${KIND_VERSION}"
+  log_info "  kubectl: v${KUBECTL_VERSION}"
+  echo ""
+
+  install_docker
+  install_kind
+  install_kubectl
+
+  # ---- Summary ---------------------------------------------------------------
+  log_section "Installation Summary"
+
+  if command -v docker >/dev/null 2>&1; then
+    DOCKER_VER=$(docker version --format '{{.Client.Version}}' 2>/dev/null || echo "installed")
+    log_ok "docker    : $DOCKER_VER"
+  else
+    log_warn "docker    : not found (manual install required on macOS)"
+  fi
+
+  if command -v kind >/dev/null 2>&1; then
+    log_ok "kind      : $(kind version)"
+  else
+    log_error "kind      : not found"
+  fi
+
+  if command -v kubectl >/dev/null 2>&1; then
+    log_ok "kubectl   : $(kubectl version --client --short 2>/dev/null || kubectl version --client)"
+  else
+    log_error "kubectl   : not found"
+  fi
+
+  echo ""
+  log_ok "All tools installed. Next steps:"
+  echo "  1. Ensure Docker is running."
+  echo "  2. Create the cluster:"
+  echo "       kind create cluster --name kube-platform --config setup/local/kind/kind-config.yml"
+  echo "  3. Verify:"
+  echo "       kubectl get nodes"
+  echo ""
+  echo "Or simply run:  make bootstrap"
+}
+
+main "$@"

--- a/setup/local/kind/kind-config.yml
+++ b/setup/local/kind/kind-config.yml
@@ -1,0 +1,113 @@
+---
+# KIND cluster configuration
+# API reference: https://kind.sigs.k8s.io/docs/user/configuration/
+#
+# Topology: 1 control-plane node + 2 worker nodes
+# Kubernetes version: v1.32.0 (kindest/node:v1.32.0)
+# Cluster name: kube-platform (set with --name flag, not in this file)
+#
+# Port mappings:
+#   HTTP  -> localhost:8080  (for Ingress / NodePort services)
+#   HTTPS -> localhost:8443  (for TLS Ingress)
+#
+# Usage:
+#   kind create cluster --name kube-platform --config kind-config.yml --wait 120s
+
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+
+# ---- Networking --------------------------------------------------------------
+networking:
+  # Pod CIDR (must not overlap with host network)
+  podSubnet: "10.244.0.0/16"
+  # Service CIDR
+  serviceSubnet: "10.96.0.0/12"
+  # Disable default CNI so we can install Calico or Flannel manually (optional)
+  # Set to true to use KIND's default (kindnet)
+  disableDefaultCNI: false
+  # kube-proxy mode: iptables or ipvs
+  kubeProxyMode: "iptables"
+
+# ---- Nodes -------------------------------------------------------------------
+nodes:
+
+  # --------------------------------------------------------------------------
+  # Control-plane node
+  # --------------------------------------------------------------------------
+  - role: control-plane
+    image: kindest/node:v1.32.0
+
+    # Ingress port mappings — map host ports to the container's ports
+    # These must match the Ingress controller's NodePort or hostPort
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 8080
+        listenAddress: "127.0.0.1"
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 8443
+        listenAddress: "127.0.0.1"
+        protocol: TCP
+      # NodePort range for manual testing
+      - containerPort: 30000
+        hostPort: 30000
+        listenAddress: "127.0.0.1"
+        protocol: TCP
+      - containerPort: 30001
+        hostPort: 30001
+        listenAddress: "127.0.0.1"
+        protocol: TCP
+
+    # kubeadm config patches — customize control-plane components
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+
+    # Host path mounts (persistent data that survives pod restarts within the cluster)
+    extraMounts:
+      - hostPath: /tmp/kube-platform-data
+        containerPath: /data
+        readOnly: false
+        selinuxRelabel: false
+        propagation: HostToContainer
+
+  # --------------------------------------------------------------------------
+  # Worker node 1
+  # --------------------------------------------------------------------------
+  - role: worker
+    image: kindest/node:v1.32.0
+
+    extraMounts:
+      - hostPath: /tmp/kube-platform-data
+        containerPath: /data
+        readOnly: false
+        selinuxRelabel: false
+        propagation: HostToContainer
+
+  # --------------------------------------------------------------------------
+  # Worker node 2
+  # --------------------------------------------------------------------------
+  - role: worker
+    image: kindest/node:v1.32.0
+
+    extraMounts:
+      - hostPath: /tmp/kube-platform-data
+        containerPath: /data
+        readOnly: false
+        selinuxRelabel: false
+        propagation: HostToContainer
+
+# ---- Feature Gates -----------------------------------------------------------
+# Enable additional feature gates if needed for testing
+# featureGates:
+#   "TopologyAwareHints": true
+
+# ---- Containerd config patches -----------------------------------------------
+# Uncomment to configure containerd, e.g. for insecure registries
+# containerdConfigPatches:
+#   - |-
+#     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+#       endpoint = ["http://registry:5000"]


### PR DESCRIPTION
## Summary
- Add `kind-config.yml` — 3-node cluster (1 control-plane + 2 workers) with host port mappings for Ingress (8080/8443) and NodePort (30000-30001), `ingress-ready` label on control-plane
- Add `install.sh` — parameterised, idempotent install for KIND and kubectl; detects OS/arch (linux/darwin, amd64/arm64); checksum verification for kubectl binary; uses `set -euo pipefail`
- Add `setup/README.md` — overview of all cluster setup paths
- Add `setup/local/kind/README.md` — cluster lifecycle, port mapping explanation, image loading workflow

## Issues referenced
Closes #5

## Test plan
- [ ] `bash setup/local/kind/install.sh` completes without error on macOS arm64
- [ ] `make cluster-up` creates cluster with 3 nodes
- [ ] `kubectl get nodes` shows all 3 nodes Ready