### PR TITLE
feat(setup): kubeadm 3-script bare-metal cluster provisioning

### DIFF
--- a/setup/kubeadm/00-common.sh
+++ b/setup/kubeadm/00-common.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# 00-common.sh — Common node setup for ALL Kubernetes nodes (master + workers)
+#
+# Run this script on EVERY node before running 01-master.sh or 02-worker.sh.
+#
+# Usage:
+#   sudo bash 00-common.sh
+#
+# Override versions:
+#   K8S_VERSION=1.32 K8S_FULL_VERSION=1.32.0 CONTAINERD_VERSION=1.7.24 sudo bash 00-common.sh
+#
+# Tested on:
+#   - Ubuntu 22.04 LTS (Jammy)
+#   - Ubuntu 24.04 LTS (Noble)
+# ==============================================================================
+
+set -euo pipefail
+
+# ---- Versions (override with env vars) ----------------------------------------
+K8S_VERSION="${K8S_VERSION:-1.32}"
+K8S_FULL_VERSION="${K8S_FULL_VERSION:-1.32.0}"
+CONTAINERD_VERSION="${CONTAINERD_VERSION:-1.7.24}"
+
+# ---- Color helpers ------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+log_info()    { printf "${CYAN}[INFO]${RESET}  %s\n" "$*"; }
+log_ok()      { printf "${GREEN}[OK]${RESET}    %s\n" "$*"; }
+log_warn()    { printf "${YELLOW}[WARN]${RESET}  %s\n" "$*"; }
+log_error()   { printf "${RED}[ERROR]${RESET} %s\n" "$*" >&2; }
+log_section() { printf "\n${BOLD}=== %s ===${RESET}\n\n" "$*"; }
+
+# ---- Root check ---------------------------------------------------------------
+if [ "$(id -u)" -ne 0 ]; then
+  log_error "This script must be run as root (sudo)."
+  exit 1
+fi
+
+# ---- OS check -----------------------------------------------------------------
+if [ ! -f /etc/os-release ]; then
+  log_error "/etc/os-release not found. This script supports Ubuntu 22.04/24.04 only."
+  exit 1
+fi
+# shellcheck disable=SC1091
+. /etc/os-release
+if [[ "$ID" != "ubuntu" ]]; then
+  log_warn "This script is designed for Ubuntu. Detected: $ID $VERSION_ID"
+  log_warn "Proceeding anyway — adjust package manager commands if needed."
+fi
+
+# ==============================================================================
+log_section "Configuration"
+log_info "Kubernetes version:  ${K8S_FULL_VERSION} (apt track: ${K8S_VERSION})"
+log_info "Containerd version:  ${CONTAINERD_VERSION}"
+log_info "Hostname:            $(hostname)"
+log_info "OS:                  $PRETTY_NAME"
+
+# ==============================================================================
+# STEP 1: Disable swap
+# Kubelet requires swap to be disabled for stable performance guarantees.
+# ==============================================================================
+log_section "Step 1 — Disabling swap"
+
+swapoff -a
+log_ok "Swap disabled (runtime)."
+
+# Remove swap entries from /etc/fstab to persist across reboots
+if grep -qE '^\s*[^#].*\bswap\b' /etc/fstab; then
+  sed -i.bak '/\bswap\b/s/^/#/' /etc/fstab
+  log_ok "Swap entries commented out in /etc/fstab."
+else
+  log_info "No swap entries found in /etc/fstab."
+fi
+
+# Verify
+if swapon --show 2>/dev/null | grep -q .; then
+  log_warn "Swap is still active on some device. Check 'swapon --show'."
+else
+  log_ok "Swap is fully disabled."
+fi
+
+# ==============================================================================
+# STEP 2: Load required kernel modules
+# overlay:       required by containerd for overlay filesystem (container layers)
+# br_netfilter:  required for Kubernetes networking (iptables to see bridged traffic)
+# ==============================================================================
+log_section "Step 2 — Kernel modules"
+
+cat > /etc/modules-load.d/k8s.conf <<'EOF'
+overlay
+br_netfilter
+EOF
+
+modprobe overlay
+modprobe br_netfilter
+log_ok "Loaded kernel modules: overlay, br_netfilter"
+
+# Verify
+for mod in overlay br_netfilter; do
+  if lsmod | grep -q "^${mod}"; then
+    log_ok "Module loaded: $mod"
+  else
+    log_error "Failed to load module: $mod"
+    exit 1
+  fi
+done
+
+# ==============================================================================
+# STEP 3: Configure sysctl parameters for Kubernetes networking
+# net.bridge.bridge-nf-call-iptables:  allow iptables to see bridged IPv4 traffic
+# net.bridge.bridge-nf-call-ip6tables: allow iptables to see bridged IPv6 traffic
+# net.ipv4.ip_forward:                 enable IP forwarding (required for pod networking)
+# ==============================================================================
+log_section "Step 3 — sysctl networking parameters"
+
+cat > /etc/sysctl.d/k8s.conf <<'EOF'
+# Kubernetes networking requirements
+net.bridge.bridge-nf-call-iptables  = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward                 = 1
+EOF
+
+sysctl --system
+log_ok "sysctl parameters applied."
+
+# Verify key settings
+for param in \
+  net.bridge.bridge-nf-call-iptables \
+  net.bridge.bridge-nf-call-ip6tables \
+  net.ipv4.ip_forward; do
+  val=$(sysctl -n "$param" 2>/dev/null || echo "not found")
+  if [ "$val" = "1" ]; then
+    log_ok "$param = 1"
+  else
+    log_error "$param is not set to 1 (got: $val)"
+    exit 1
+  fi
+done
+
+# ==============================================================================
+# STEP 4: Install containerd from the official Docker repository
+# We use the Docker repository because it ships newer containerd builds than
+# the Ubuntu default repos. The docker packages (docker-ce etc.) are NOT installed.
+# ==============================================================================
+log_section "Step 4 — Install containerd ${CONTAINERD_VERSION}"
+
+# Install prerequisites
+apt-get update -qq
+apt-get install -y -qq \
+  apt-transport-https \
+  ca-certificates \
+  curl \
+  gnupg \
+  lsb-release \
+  software-properties-common
+
+# Add Docker GPG key
+log_info "Adding Docker GPG key..."
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+  -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add Docker apt repository
+log_info "Adding Docker apt repository..."
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+  https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+  > /etc/apt/sources.list.d/docker.list
+
+apt-get update -qq
+
+# Install containerd (pinned version)
+CONTAINERD_PKG="containerd.io=${CONTAINERD_VERSION}-*"
+log_info "Installing $CONTAINERD_PKG..."
+apt-get install -y "$CONTAINERD_PKG" || {
+  log_warn "Pinned version not found in repo. Installing latest containerd.io..."
+  apt-get install -y containerd.io
+}
+
+# ==============================================================================
+# STEP 5: Configure containerd
+# Key: SystemdCgroup = true — ensures cgroup management is delegated to systemd,
+# which is required when running on systems with systemd (all modern Ubuntu versions).
+# Without this, kubelet and containerd can fight over cgroup management.
+# ==============================================================================
+log_section "Step 5 — Configure containerd (SystemdCgroup=true)"
+
+# Generate default config and then patch it
+mkdir -p /etc/containerd
+containerd config default > /etc/containerd/config.toml
+
+# Set SystemdCgroup = true in the runc runtime section
+if grep -q "SystemdCgroup" /etc/containerd/config.toml; then
+  sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+  log_ok "Set SystemdCgroup = true in /etc/containerd/config.toml"
+else
+  # Inject the setting if it doesn't exist
+  sed -i '/\[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options\]/a\            SystemdCgroup = true' \
+    /etc/containerd/config.toml
+  log_ok "Injected SystemdCgroup = true into /etc/containerd/config.toml"
+fi
+
+# Enable and restart containerd
+systemctl enable containerd
+systemctl restart containerd
+log_ok "containerd restarted and enabled."
+
+# Verify containerd is running
+if systemctl is-active --quiet containerd; then
+  CONTAINERD_VER=$(containerd --version | awk '{print $3}')
+  log_ok "containerd is running: $CONTAINERD_VER"
+else
+  log_error "containerd failed to start."
+  journalctl -u containerd -n 20
+  exit 1
+fi
+
+# ==============================================================================
+# STEP 6: Install kubelet, kubeadm, kubectl from the official Kubernetes apt repo
+# ==============================================================================
+log_section "Step 6 — Install kubelet, kubeadm, kubectl (K8s ${K8S_FULL_VERSION})"
+
+# Add Kubernetes GPG key
+log_info "Adding Kubernetes GPG key..."
+curl -fsSL "https://pkgs.k8s.io/core:/stable:/v${K8S_VERSION}/deb/Release.key" \
+  | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+chmod a+r /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+# Add Kubernetes apt repository
+log_info "Adding Kubernetes apt repository (v${K8S_VERSION})..."
+echo \
+  "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] \
+  https://pkgs.k8s.io/core:/stable:/v${K8S_VERSION}/deb/ /" \
+  > /etc/apt/sources.list.d/kubernetes.list
+
+apt-get update -qq
+
+# Install kubelet, kubeadm, kubectl
+log_info "Installing kubelet kubeadm kubectl..."
+apt-get install -y \
+  "kubelet=${K8S_FULL_VERSION}-*" \
+  "kubeadm=${K8S_FULL_VERSION}-*" \
+  "kubectl=${K8S_FULL_VERSION}-*" || {
+  log_warn "Pinned version not found. Installing latest available in the ${K8S_VERSION} track..."
+  apt-get install -y kubelet kubeadm kubectl
+}
+
+# ==============================================================================
+# STEP 7: Hold packages to prevent uncontrolled upgrades
+# Kubernetes upgrades must be done intentionally (one minor version at a time).
+# apt-mark hold prevents apt upgrade from automatically upgrading these packages.
+# ==============================================================================
+log_section "Step 7 — Holding Kubernetes packages"
+
+apt-mark hold kubelet kubeadm kubectl containerd.io
+log_ok "Packages held: kubelet kubeadm kubectl containerd.io"
+
+# Enable kubelet (it will be started by kubeadm init/join)
+systemctl enable kubelet
+log_ok "kubelet enabled (not started yet — will be started by kubeadm)."
+
+# ==============================================================================
+# STEP 8: Verify all components
+# ==============================================================================
+log_section "Step 8 — Verification"
+
+log_ok "containerd : $(containerd --version)"
+log_ok "kubeadm    : $(kubeadm version -o short)"
+log_ok "kubelet    : $(kubelet --version)"
+log_ok "kubectl    : $(kubectl version --client --short 2>/dev/null || kubectl version --client)"
+
+log_section "Common setup complete"
+log_info "Next steps:"
+log_info "  On the MASTER node: sudo bash 01-master.sh"
+log_info "  On WORKER nodes:    sudo bash 02-worker.sh (after master is initialized)"

--- a/setup/kubeadm/01-master.sh
+++ b/setup/kubeadm/01-master.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# 01-master.sh — Initialize the Kubernetes control-plane node
+#
+# Run this script on the MASTER (control-plane) node ONLY, after running
+# 00-common.sh on all nodes.
+#
+# Usage:
+#   sudo bash 01-master.sh
+#
+# Override settings with environment variables:
+#   CONTROL_PLANE_IP=10.0.0.10 POD_CIDR=192.168.0.0/16 sudo bash 01-master.sh
+#
+# After this script completes:
+#   - The cluster will be initialized
+#   - Calico CNI will be installed
+#   - A kubeadm join command will be printed for worker nodes
+# ==============================================================================
+
+set -euo pipefail
+
+# ---- Configuration (override with env vars) -----------------------------------
+CONTROL_PLANE_IP="${CONTROL_PLANE_IP:-$(hostname -I | awk '{print $1}')}"
+POD_CIDR="${POD_CIDR:-192.168.0.0/16}"
+K8S_FULL_VERSION="${K8S_FULL_VERSION:-1.32.0}"
+CALICO_VERSION="${CALICO_VERSION:-3.29.0}"
+
+# The user whose home directory will receive the kubeconfig.
+# When running with sudo, SUDO_USER is the original user.
+KUBE_USER="${SUDO_USER:-${USER:-root}}"
+KUBE_HOME=$(eval echo "~${KUBE_USER}")
+
+# ---- Color helpers ------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+log_info()    { printf "${CYAN}[INFO]${RESET}  %s\n" "$*"; }
+log_ok()      { printf "${GREEN}[OK]${RESET}    %s\n" "$*"; }
+log_warn()    { printf "${YELLOW}[WARN]${RESET}  %s\n" "$*"; }
+log_error()   { printf "${RED}[ERROR]${RESET} %s\n" "$*" >&2; }
+log_section() { printf "\n${BOLD}=== %s ===${RESET}\n\n" "$*"; }
+
+# ---- Root check ---------------------------------------------------------------
+if [ "$(id -u)" -ne 0 ]; then
+  log_error "This script must be run as root (sudo)."
+  exit 1
+fi
+
+# ==============================================================================
+log_section "Configuration"
+log_info "Control-plane IP:  ${CONTROL_PLANE_IP}"
+log_info "Pod CIDR:          ${POD_CIDR}"
+log_info "K8s version:       ${K8S_FULL_VERSION}"
+log_info "Calico version:    ${CALICO_VERSION}"
+log_info "kubeconfig user:   ${KUBE_USER}"
+log_info "kubeconfig home:   ${KUBE_HOME}"
+
+# ==============================================================================
+# STEP 1: kubeadm init
+# ==============================================================================
+log_section "Step 1 — kubeadm init"
+
+# Pre-flight check
+log_info "Running kubeadm pre-flight checks..."
+kubeadm config images pull --kubernetes-version "v${K8S_FULL_VERSION}"
+
+log_info "Initializing control plane..."
+kubeadm init \
+  --apiserver-advertise-address="${CONTROL_PLANE_IP}" \
+  --pod-network-cidr="${POD_CIDR}" \
+  --kubernetes-version="v${K8S_FULL_VERSION}" \
+  --cri-socket="unix:///var/run/containerd/containerd.sock" \
+  --upload-certs \
+  2>&1 | tee /tmp/kubeadm-init.log
+
+log_ok "kubeadm init completed. Output saved to /tmp/kubeadm-init.log"
+
+# ==============================================================================
+# STEP 2: Configure kubeconfig for the current user
+# ==============================================================================
+log_section "Step 2 — Configure kubeconfig"
+
+# Setup for root
+mkdir -p /root/.kube
+cp -f /etc/kubernetes/admin.conf /root/.kube/config
+log_ok "kubeconfig copied to /root/.kube/config"
+
+# Setup for the non-root user (if running via sudo)
+if [ "$KUBE_USER" != "root" ] && [ -d "$KUBE_HOME" ]; then
+  mkdir -p "${KUBE_HOME}/.kube"
+  cp -f /etc/kubernetes/admin.conf "${KUBE_HOME}/.kube/config"
+  chown "${KUBE_USER}:${KUBE_USER}" "${KUBE_HOME}/.kube" "${KUBE_HOME}/.kube/config"
+  log_ok "kubeconfig copied to ${KUBE_HOME}/.kube/config (owner: ${KUBE_USER})"
+fi
+
+# Verify kubectl works
+export KUBECONFIG=/root/.kube/config
+log_info "Verifying kubectl access..."
+kubectl cluster-info
+
+# ==============================================================================
+# STEP 3: Install Calico CNI
+# Calico is the CNI plugin. It must be installed before nodes will become Ready.
+# The pod-network-cidr MUST match what was passed to kubeadm init.
+# ==============================================================================
+log_section "Step 3 — Install Calico CNI v${CALICO_VERSION}"
+
+CALICO_URL="https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests"
+
+log_info "Applying Calico Tigera operator..."
+kubectl apply -f "${CALICO_URL}/tigera-operator.yaml"
+
+log_info "Waiting for Tigera operator to be ready..."
+kubectl wait --namespace tigera-operator \
+  --for=condition=Available \
+  deployment/tigera-operator \
+  --timeout=120s
+
+log_info "Creating Calico Installation custom resource..."
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: operator.tigera.io/v1
+kind: Installation
+metadata:
+  name: default
+spec:
+  calicoNetwork:
+    ipPools:
+    - blockSize: 26
+      cidr: ${POD_CIDR}
+      encapsulation: VXLANCrossSubnet
+      natOutgoing: Enabled
+      nodeSelector: all()
+---
+apiVersion: operator.tigera.io/v1
+kind: APIServer
+metadata:
+  name: default
+spec: {}
+EOF
+
+log_info "Waiting for Calico system pods to become ready (this may take 2-3 minutes)..."
+kubectl wait --namespace calico-system \
+  --for=condition=Ready \
+  pod \
+  --selector=app.kubernetes.io/name=calico-node \
+  --timeout=300s || {
+  log_warn "Calico node pods not ready within timeout. Check status with:"
+  log_warn "  kubectl get pods -n calico-system"
+  log_warn "  kubectl get pods -n tigera-operator"
+}
+
+# ==============================================================================
+# STEP 4: Verify cluster health
+# ==============================================================================
+log_section "Step 4 — Cluster health check"
+
+log_info "Waiting for control-plane node to become Ready..."
+kubectl wait \
+  --for=condition=Ready \
+  node/"$(hostname)" \
+  --timeout=120s
+
+log_info "Cluster node status:"
+kubectl get nodes -o wide
+
+log_info "System pod status:"
+kubectl get pods -n kube-system
+
+# ==============================================================================
+# STEP 5: Generate and display the worker join command
+# ==============================================================================
+log_section "Step 5 — Worker join command"
+
+JOIN_COMMAND=$(kubeadm token create --print-join-command)
+
+log_ok "Cluster initialized successfully!"
+echo ""
+printf "${BOLD}${YELLOW}===============================================================${RESET}\n"
+printf "${BOLD}${YELLOW}  WORKER JOIN COMMAND (save this — token valid for 24 hours)   ${RESET}\n"
+printf "${BOLD}${YELLOW}===============================================================${RESET}\n"
+echo ""
+printf "${BOLD}${GREEN}%s \\\\${RESET}\n" "sudo $JOIN_COMMAND"
+printf "${BOLD}${GREEN}  --cri-socket unix:///var/run/containerd/containerd.sock${RESET}\n"
+echo ""
+printf "${BOLD}${YELLOW}===============================================================${RESET}\n"
+echo ""
+
+# Parse and display individual values for use with 02-worker.sh
+ENDPOINT=$(echo "$JOIN_COMMAND" | awk '{print $3}')
+TOKEN=$(echo "$JOIN_COMMAND" | awk '{print $5}')
+CA_HASH=$(echo "$JOIN_COMMAND" | awk '{print $7}')
+
+log_info "To use 02-worker.sh, set these environment variables on each worker:"
+echo ""
+printf "  export CONTROL_PLANE_ENDPOINT=\"%s\"\n" "$ENDPOINT"
+printf "  export JOIN_TOKEN=\"%s\"\n" "$TOKEN"
+printf "  export CA_CERT_HASH=\"%s\"\n" "$CA_HASH"
+echo ""
+log_info "Then run on each worker:"
+echo "  sudo -E bash 02-worker.sh"
+echo ""
+
+# Save join info to a file for convenience
+cat > /tmp/worker-join-info.sh <<JOINEOF
+#!/usr/bin/env bash
+# Generated by 01-master.sh on $(date)
+# Copy this file to worker nodes and source it before running 02-worker.sh
+
+export CONTROL_PLANE_ENDPOINT="${ENDPOINT}"
+export JOIN_TOKEN="${TOKEN}"
+export CA_CERT_HASH="${CA_HASH}"
+
+echo "Variables set. Now run: sudo -E bash 02-worker.sh"
+JOINEOF
+chmod 600 /tmp/worker-join-info.sh
+log_info "Join variables saved to /tmp/worker-join-info.sh"
+
+log_section "Master setup complete"
+log_info "Next: run 00-common.sh and then 02-worker.sh on each worker node."

--- a/setup/kubeadm/02-worker.sh
+++ b/setup/kubeadm/02-worker.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# 02-worker.sh — Join a worker node to an existing Kubernetes cluster
+#
+# Run this script on each WORKER node ONLY, after:
+#   1. Running 00-common.sh on this worker node.
+#   2. Running 01-master.sh on the control-plane node.
+#   3. Collecting the join command values from the master's output.
+#
+# Usage:
+#   export CONTROL_PLANE_ENDPOINT="<master-ip>:6443"
+#   export JOIN_TOKEN="<token>"
+#   export CA_CERT_HASH="sha256:<hash>"
+#   sudo -E bash 02-worker.sh
+#
+# Or inline:
+#   CONTROL_PLANE_ENDPOINT="10.0.0.10:6443" \
+#   JOIN_TOKEN="abc123.def456" \
+#   CA_CERT_HASH="sha256:abcdef..." \
+#   sudo -E bash 02-worker.sh
+#
+# The three required values are printed at the end of 01-master.sh.
+# ==============================================================================
+
+set -euo pipefail
+
+# ---- Required variables (must be provided via environment) --------------------
+# Using :? causes the script to exit with an error if the variable is unset or empty.
+CONTROL_PLANE_ENDPOINT="${CONTROL_PLANE_ENDPOINT:?Set CONTROL_PLANE_ENDPOINT to <master-ip>:6443}"
+JOIN_TOKEN="${JOIN_TOKEN:?Set JOIN_TOKEN to the token printed by 01-master.sh}"
+CA_CERT_HASH="${CA_CERT_HASH:?Set CA_CERT_HASH to the ca-cert-hash printed by 01-master.sh}"
+
+# ---- Color helpers ------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+log_info()    { printf "${CYAN}[INFO]${RESET}  %s\n" "$*"; }
+log_ok()      { printf "${GREEN}[OK]${RESET}    %s\n" "$*"; }
+log_warn()    { printf "${YELLOW}[WARN]${RESET}  %s\n" "$*"; }
+log_error()   { printf "${RED}[ERROR]${RESET} %s\n" "$*" >&2; }
+log_section() { printf "\n${BOLD}=== %s ===${RESET}\n\n" "$*"; }
+
+# ---- Root check ---------------------------------------------------------------
+if [ "$(id -u)" -ne 0 ]; then
+  log_error "This script must be run as root (sudo)."
+  exit 1
+fi
+
+# ==============================================================================
+log_section "Configuration"
+log_info "Control-plane endpoint: ${CONTROL_PLANE_ENDPOINT}"
+log_info "Join token:             ${JOIN_TOKEN}"
+log_info "CA cert hash:           ${CA_CERT_HASH}"
+log_info "Worker hostname:        $(hostname)"
+log_info "CRI socket:             unix:///var/run/containerd/containerd.sock"
+
+# ==============================================================================
+# STEP 1: Validate that 00-common.sh was run
+# ==============================================================================
+log_section "Step 1 — Pre-flight validation"
+
+# Check containerd is running
+if ! systemctl is-active --quiet containerd; then
+  log_error "containerd is not running."
+  log_error "Please run 00-common.sh on this node first, then retry."
+  exit 1
+fi
+log_ok "containerd is running."
+
+# Check kubeadm is installed
+if ! command -v kubeadm >/dev/null 2>&1; then
+  log_error "kubeadm not found."
+  log_error "Please run 00-common.sh on this node first, then retry."
+  exit 1
+fi
+log_ok "kubeadm is installed: $(kubeadm version -o short)"
+
+# Check that br_netfilter is loaded
+if ! lsmod | grep -q "^br_netfilter"; then
+  log_error "Kernel module br_netfilter is not loaded."
+  log_error "Please run 00-common.sh on this node first, then retry."
+  exit 1
+fi
+log_ok "Kernel module br_netfilter is loaded."
+
+# Check swap is disabled
+if swapon --show 2>/dev/null | grep -q .; then
+  log_error "Swap is still enabled. Kubelet requires swap to be disabled."
+  log_error "Please run 00-common.sh on this node first, then retry."
+  exit 1
+fi
+log_ok "Swap is disabled."
+
+# Check connectivity to the control plane
+log_info "Checking connectivity to control plane at ${CONTROL_PLANE_ENDPOINT}..."
+MASTER_IP=$(echo "$CONTROL_PLANE_ENDPOINT" | cut -d: -f1)
+MASTER_PORT=$(echo "$CONTROL_PLANE_ENDPOINT" | cut -d: -f2)
+if ! nc -z -w5 "$MASTER_IP" "$MASTER_PORT" 2>/dev/null; then
+  log_error "Cannot reach ${CONTROL_PLANE_ENDPOINT}."
+  log_error "Ensure the master node is running and port ${MASTER_PORT} is accessible."
+  log_error "Check firewall rules: ufw, iptables, or security groups."
+  exit 1
+fi
+log_ok "Control plane is reachable at ${CONTROL_PLANE_ENDPOINT}."
+
+# ==============================================================================
+# STEP 2: kubeadm reset — clean any previous state
+# This is important if this node was previously part of a cluster (e.g., during
+# re-provisioning). It removes any stale configuration and resets networking.
+# ==============================================================================
+log_section "Step 2 — Reset previous cluster state (kubeadm reset)"
+
+log_info "Running kubeadm reset to clean any previous configuration..."
+kubeadm reset \
+  --cri-socket="unix:///var/run/containerd/containerd.sock" \
+  --force
+
+# Clean up leftover CNI and networking files from a previous cluster join
+log_info "Cleaning up CNI configuration..."
+rm -rf /etc/cni/net.d/*
+rm -f /etc/kubernetes/kubelet.conf
+rm -f /etc/kubernetes/bootstrap-kubelet.conf
+rm -f /etc/kubernetes/pki/ca.crt
+
+# Clean up iptables rules left by the previous cluster
+log_info "Flushing iptables rules..."
+iptables -F && iptables -t nat -F && iptables -t mangle -F && iptables -X || true
+ip6tables -F && ip6tables -t nat -F && ip6tables -t mangle -F && ip6tables -X 2>/dev/null || true
+
+# Restart containerd and kubelet to ensure a clean state
+log_info "Restarting containerd..."
+systemctl restart containerd
+log_ok "kubeadm reset complete."
+
+# ==============================================================================
+# STEP 3: kubeadm join — join this node to the cluster
+# ==============================================================================
+log_section "Step 3 — Join the cluster (kubeadm join)"
+
+log_info "Joining cluster at ${CONTROL_PLANE_ENDPOINT}..."
+kubeadm join "${CONTROL_PLANE_ENDPOINT}" \
+  --token "${JOIN_TOKEN}" \
+  --discovery-token-ca-cert-hash "${CA_CERT_HASH}" \
+  --cri-socket="unix:///var/run/containerd/containerd.sock" \
+  2>&1 | tee /tmp/kubeadm-join.log
+
+log_ok "kubeadm join completed. Output saved to /tmp/kubeadm-join.log"
+
+# ==============================================================================
+# STEP 4: Verify the join from the worker's perspective
+# ==============================================================================
+log_section "Step 4 — Local verification"
+
+# Check kubelet is running
+log_info "Checking kubelet status..."
+if systemctl is-active --quiet kubelet; then
+  log_ok "kubelet is running."
+else
+  log_warn "kubelet is not running. Check: journalctl -u kubelet -n 50"
+fi
+
+# Display kubelet status
+systemctl status kubelet --no-pager || true
+
+log_section "Worker join complete"
+
+log_ok "This node has joined the cluster."
+echo ""
+log_info "To verify from the MASTER node, run:"
+echo "  kubectl get nodes -o wide"
+echo ""
+log_info "The node will show as 'Ready' once:"
+echo "  1. The kubelet is running (check above)."
+echo "  2. The CNI (Calico) pod is scheduled on this node."
+echo "  3. The node passes the control-plane health checks (~1-2 minutes)."
+echo ""
+log_info "Troubleshooting on this node:"
+echo "  journalctl -u kubelet -n 100 --no-pager"
+echo "  systemctl status containerd"
+echo "  cat /tmp/kubeadm-join.log"

--- a/setup/kubeadm/README.md
+++ b/setup/kubeadm/README.md
@@ -1,0 +1,242 @@
+# kubeadm — Bootstrap a Production-Grade Cluster
+
+This guide uses the 3-script approach to set up a Kubernetes cluster on Linux VMs or bare-metal machines using `kubeadm`. The scripts are designed to be run in order: common setup on all nodes, then master initialization, then worker join.
+
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Control Plane Node (master)                             │
+│  - kube-apiserver                                        │
+│  - kube-controller-manager                               │
+│  - kube-scheduler                                        │
+│  - etcd                                                  │
+│  - kubelet + containerd                                  │
+└──────────────────────────┬───────────────────────────────┘
+                           │
+               ┌───────────┴───────────┐
+               │                       │
+┌──────────────▼──────────┐  ┌────────▼──────────────────┐
+│  Worker Node 1          │  │  Worker Node 2             │
+│  - kubelet + containerd │  │  - kubelet + containerd    │
+│  - kube-proxy           │  │  - kube-proxy              │
+└─────────────────────────┘  └────────────────────────────┘
+```
+
+---
+
+## Prerequisites
+
+| Requirement | Specification |
+|-------------|---------------|
+| OS | Ubuntu 22.04 LTS (or 24.04 LTS) |
+| Control plane RAM | 2 GB minimum (4 GB recommended) |
+| Worker RAM | 1 GB minimum (4 GB recommended) |
+| CPU | 2+ vCPUs per node |
+| Disk | 20 GB+ per node |
+| Network | Full connectivity between all nodes |
+| Ports (control plane) | 6443, 2379-2380, 10250-10252 |
+| Ports (workers) | 10250, 30000-32767 |
+| Unique hostname | Each node must have a unique hostname |
+| MAC address | Each node must have a unique MAC address |
+| Swap | Must be disabled |
+
+---
+
+## The 3-Script Approach
+
+| Script | Runs On | Purpose |
+|--------|---------|---------|
+| `00-common.sh` | **All nodes** | Disables swap, installs containerd and Kubernetes packages |
+| `01-master.sh` | **Control-plane only** | Initializes the cluster with kubeadm, installs Calico CNI |
+| `02-worker.sh` | **Each worker node** | Joins the worker to the cluster |
+
+---
+
+## Step-by-Step Instructions
+
+### Step 1 — Prepare all nodes
+
+Run `00-common.sh` on **every node** (control-plane and all workers):
+
+```bash
+# Copy the script to each node
+scp setup/kubeadm/00-common.sh user@<node-ip>:/tmp/
+
+# SSH into each node and run
+ssh user@<node-ip>
+sudo bash /tmp/00-common.sh
+```
+
+Or override versions:
+
+```bash
+K8S_VERSION=1.32 K8S_FULL_VERSION=1.32.0 sudo bash /tmp/00-common.sh
+```
+
+What `00-common.sh` does:
+1. Disables swap permanently (required by kubelet).
+2. Loads required kernel modules: `overlay` and `br_netfilter`.
+3. Configures sysctl for bridge traffic and IP forwarding.
+4. Installs `containerd` from the official Docker repository.
+5. Configures containerd to use `SystemdCgroup = true` (required for kubeadm).
+6. Installs `kubelet`, `kubeadm`, and `kubectl` from the official Kubernetes apt repository.
+7. Pins packages to prevent uncontrolled upgrades.
+
+### Step 2 — Initialize the control plane
+
+Run `01-master.sh` on the **control-plane node only**:
+
+```bash
+scp setup/kubeadm/01-master.sh user@<master-ip>:/tmp/
+ssh user@<master-ip>
+sudo bash /tmp/01-master.sh
+```
+
+Or with custom settings:
+
+```bash
+CONTROL_PLANE_IP=10.0.0.10 POD_CIDR=192.168.0.0/16 sudo bash /tmp/01-master.sh
+```
+
+What `01-master.sh` does:
+1. Runs `kubeadm init` with the specified control-plane IP and pod CIDR.
+2. Copies the kubeconfig to `~/.kube/config` for the current user.
+3. Installs the Calico CNI plugin (compatible with the default pod CIDR `192.168.0.0/16`).
+4. Waits for all system pods to become ready.
+5. Prints the `kubeadm join` command for worker nodes.
+
+**Save the join command** — you will need it in Step 3.
+
+### Step 3 — Join worker nodes
+
+Run `02-worker.sh` on **each worker node**, using the values printed by Step 2:
+
+```bash
+scp setup/kubeadm/02-worker.sh user@<worker-ip>:/tmp/
+ssh user@<worker-ip>
+
+# Set the values from the join command printed by 01-master.sh
+export CONTROL_PLANE_ENDPOINT="10.0.0.10:6443"
+export JOIN_TOKEN="abc123.xyz789..."
+export CA_CERT_HASH="sha256:abcdef1234..."
+
+sudo -E bash /tmp/02-worker.sh
+```
+
+What `02-worker.sh` does:
+1. Runs `kubeadm reset` to clean any previous state.
+2. Runs `kubeadm join` with the specified endpoint, token, and CA hash.
+3. The worker registers with the control plane.
+
+### Step 4 — Verify the cluster
+
+Back on the **control-plane node**:
+
+```bash
+# Should show all nodes as Ready
+kubectl get nodes -o wide
+
+# Should show all system pods running
+kubectl get pods -n kube-system
+
+# Check Calico pods
+kubectl get pods -n calico-system
+```
+
+Expected output (after all nodes are ready):
+
+```
+NAME              STATUS   ROLES           AGE   VERSION
+master-node       Ready    control-plane   10m   v1.32.0
+worker-node-1     Ready    <none>          5m    v1.32.0
+worker-node-2     Ready    <none>          5m    v1.32.0
+```
+
+---
+
+## Useful kubeadm Commands
+
+```bash
+# Re-generate the join command (if token expired)
+kubeadm token create --print-join-command
+
+# List tokens
+kubeadm token list
+
+# Check cluster status
+kubeadm config view
+
+# Upgrade kubeadm (step 1 of cluster upgrade)
+apt-get update && apt-get install -y kubeadm=1.33.0-1.1
+
+# Plan an upgrade
+kubeadm upgrade plan
+
+# Apply the upgrade (on control plane)
+kubeadm upgrade apply v1.33.0
+
+# Reset a node (destructive — removes all cluster state)
+kubeadm reset --cri-socket unix:///var/run/containerd/containerd.sock
+```
+
+---
+
+## etcd Backup
+
+For production clusters, back up etcd regularly:
+
+```bash
+ETCDCTL_API=3 etcdctl snapshot save /backup/etcd-$(date +%Y%m%d-%H%M%S).db \
+  --endpoints=https://127.0.0.1:2379 \
+  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+  --cert=/etc/kubernetes/pki/etcd/server.crt \
+  --key=/etc/kubernetes/pki/etcd/server.key
+
+# Verify snapshot
+ETCDCTL_API=3 etcdctl snapshot status /backup/etcd-*.db
+```
+
+---
+
+## Troubleshooting
+
+### Node stuck in NotReady
+
+```bash
+# Check kubelet status
+systemctl status kubelet
+journalctl -u kubelet -n 50
+
+# Check containerd
+systemctl status containerd
+
+# Check events
+kubectl describe node <node-name>
+```
+
+### kubeadm init fails — port already in use
+
+```bash
+# Check what is using port 6443
+ss -tlnp | grep 6443
+
+# Reset and retry
+kubeadm reset --cri-socket unix:///var/run/containerd/containerd.sock
+```
+
+### Calico pods in CrashLoopBackOff
+
+```bash
+kubectl logs -n calico-system <calico-node-pod>
+# Common cause: POD_CIDR mismatch — ensure 192.168.0.0/16 matches kubeadm init --pod-network-cidr
+```
+
+### Token expired (worker join fails)
+
+```bash
+# Generate a new token on the master
+kubeadm token create --print-join-command
+```


### PR DESCRIPTION
## Summary
- Add `setup/kubeadm/README.md` — prerequisites, script sequence, and post-install verification
- Add `00-common.sh` — swap disable, kernel module loading, sysctl tuning, containerd (SystemdCgroup=true), kubelet/kubeadm/kubectl install with package hold
- Add `01-master.sh` — `kubeadm init` with parameterised CIDR and API server IP, kubeconfig setup, Calico CNI deploy
- Add `02-worker.sh` — required-variable enforcement (`:?`), pre-flight checks, `kubeadm reset` + join

All scripts use `set -euo pipefail` and are parameterised via env vars.

## Issues referenced
Closes #3

## Test plan
- [ ] `bash 00-common.sh` runs without error on Ubuntu 22.04
- [ ] `bash 01-master.sh` produces a join command
- [ ] `bash 02-worker.sh` joins the worker to the cluster