### PR TITLE
feat(workload): Deployment manifests with production-grade rolling update config

### DIFF
--- a/core/workloads/deployment/README.md
+++ b/core/workloads/deployment/README.md
@@ -1,0 +1,328 @@
+# Deployments
+
+A Deployment is the standard way to run a stateless, replicated application in
+Kubernetes. It provides declarative updates, rolling rollouts, rollback, scaling,
+and self-healing for a set of identical Pods.
+
+Understanding the Deployment → ReplicaSet → Pod ownership chain is fundamental to
+debugging and operating production workloads.
+
+---
+
+## Table of Contents
+
+1. [What a Deployment Manages](#what-a-deployment-manages)
+2. [The ReplicaSet Chain](#the-replicaset-chain)
+3. [Rolling Update Mechanics](#rolling-update-mechanics)
+4. [Key Fields Explained](#key-fields-explained)
+5. [Common Operations](#common-operations)
+   - [Rollback Commands](#rollback-commands)
+   - [Scaling Commands](#scaling-commands)
+   - [Pause and Resume](#pause-and-resume-for-canary-testing)
+6. [Deployment vs. StatefulSet vs. DaemonSet](#deployment-vs-statefulset-vs-daemonset)
+7. [Interview Prep](#interview-prep)
+8. [Files in This Directory](#files-in-this-directory)
+
+---
+
+## What a Deployment Manages
+
+A Deployment declares the **desired state** of a set of Pods:
+- How many replicas should run (`spec.replicas`)
+- What container image to use (`spec.template.spec.containers[].image`)
+- How to update them (`spec.strategy`)
+- When an update is considered successful (`spec.minReadySeconds`, readiness probes)
+
+The Deployment does not manage Pods directly. It creates and manages **ReplicaSets**,
+which in turn create and manage **Pods**.
+
+```
+Deployment
+  └── ReplicaSet (v1 — current)
+        ├── Pod
+        ├── Pod
+        └── Pod
+  └── ReplicaSet (v2 — previous, scaled to 0, kept for rollback)
+  └── ReplicaSet (v3 — older, kept for rollback)
+```
+
+---
+
+## The ReplicaSet Chain
+
+When you update a Deployment's Pod template (e.g., change the image tag), Kubernetes
+does NOT modify the existing ReplicaSet. It:
+
+1. Creates a **new ReplicaSet** with the new template hash in its name.
+2. Scales the new ReplicaSet up (adds Pods).
+3. Scales the old ReplicaSet down (removes Pods).
+4. The old ReplicaSet is kept at 0 replicas (for rollback), up to
+   `spec.revisionHistoryLimit` (default 10, we set 5).
+
+```
+Before update:
+  deploy/nginx   replicas=3
+  └── rs/nginx-7d4f8bc   replicas=3  ← v1 ReplicaSet
+
+After update (in progress):
+  deploy/nginx   replicas=3
+  ├── rs/nginx-7d4f8bc   replicas=2  ← v1 scaling down
+  └── rs/nginx-9b1c3de   replicas=2  ← v2 scaling up (maxSurge=1)
+
+After update (complete):
+  deploy/nginx   replicas=3
+  ├── rs/nginx-7d4f8bc   replicas=0  ← v1 kept for rollback
+  └── rs/nginx-9b1c3de   replicas=3  ← v2 now live
+```
+
+This is why `kubectl rollout undo` is fast — it simply scales the previous
+ReplicaSet back up and scales the current one down.
+
+---
+
+## Rolling Update Mechanics
+
+With these settings:
+```yaml
+replicas: 4
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+minReadySeconds: 10
+```
+
+The update proceeds as follows:
+
+```
+Step 1: Create 1 new Pod (total: 5 = 4 + 1 surge)
+        Wait for new Pod to pass readinessProbe AND be Ready for 10s (minReadySeconds)
+
+Step 2: Terminate 1 old Pod (total: 4, with 1 new + 3 old)
+        0 unavailable (maxUnavailable=0 ensures no capacity is lost)
+
+Step 3: Create 1 new Pod (total: 5), wait for Ready + minReadySeconds
+
+Step 4: Terminate 1 old Pod (total: 4, with 2 new + 2 old)
+
+...repeat until all old Pods are replaced...
+
+Final: 4 new Pods running. Old ReplicaSet at 0. Rollout complete.
+```
+
+**What halts a rollout?**
+- A new Pod fails its `readinessProbe` — it never becomes "Ready", so the
+  Deployment controller never considers it available, and the rollout stalls.
+- The rollout stalls until `progressDeadlineSeconds` (default 600s) expires,
+  at which point the Deployment is marked `ProgressDeadlineExceeded`.
+- `kubectl rollout undo` can be run at any point to revert.
+
+---
+
+## Key Fields Explained
+
+```yaml
+spec:
+  replicas: 3
+  # Keep the last 5 ReplicaSets for rollback. Default is 10.
+  # Lower values reduce etcd storage but limit how far back you can roll back.
+  revisionHistoryLimit: 5
+
+  # A new Pod must be Ready for this many seconds before it counts as "available".
+  # Prevents a Pod that immediately crashes after becoming Ready from being
+  # treated as a successful update step. Set to your app's warm-up time.
+  minReadySeconds: 10
+
+  # If the rollout does not make progress within this window, the Deployment
+  # is marked as Failed (DeploymentCondition: ProgressDeadlineExceeded).
+  # This surfaces in monitoring and can be used as an alert condition.
+  progressDeadlineSeconds: 600
+
+  selector:
+    # The selector is IMMUTABLE after creation. Changing it requires deleting
+    # and recreating the Deployment. The selector must match the Pod template labels.
+    matchLabels:
+      app.kubernetes.io/name: nginx
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Number of Pods above the desired replica count during update.
+      # Can be absolute (1) or percentage ("25%").
+      # Larger values = faster rollout but more resource usage during update.
+      maxSurge: 1
+
+      # Number of Pods that can be unavailable during the update.
+      # 0 = zero-downtime (never drop below desired replica count).
+      # Can be absolute or percentage.
+      maxUnavailable: 0
+
+  template:
+    metadata:
+      labels:
+        # Pod template labels MUST match spec.selector.matchLabels
+        app.kubernetes.io/name: nginx
+    spec:
+      # ... pod spec ...
+```
+
+---
+
+## Common Operations
+
+### Rollback Commands
+
+```bash
+# Check the status of an in-progress rollout
+kubectl rollout status deployment/nginx -n workloads
+# Output: Waiting for deployment "nginx" rollout to finish: 1 out of 3 new replicas have been updated...
+
+# View the rollout history (shows revisions)
+kubectl rollout history deployment/nginx -n workloads
+
+# View the details of a specific revision (what changed)
+kubectl rollout history deployment/nginx -n workloads --revision=3
+
+# Rollback to the PREVIOUS revision (most common rollback)
+kubectl rollout undo deployment/nginx -n workloads
+
+# Rollback to a SPECIFIC revision number
+kubectl rollout undo deployment/nginx -n workloads --to-revision=2
+
+# Verify the rollback is complete
+kubectl rollout status deployment/nginx -n workloads
+```
+
+### Scaling Commands
+
+```bash
+# Scale a deployment manually (replaces spec.replicas in the live object)
+kubectl scale deployment/nginx --replicas=6 -n workloads
+
+# Scale to zero (stops all traffic; useful for emergency stop)
+kubectl scale deployment/nginx --replicas=0 -n workloads
+
+# Conditional scale: only scale if current replicas == 3
+kubectl scale deployment/nginx --replicas=6 --current-replicas=3 -n workloads
+
+# Enable HorizontalPodAutoscaler (automates scaling based on CPU)
+kubectl autoscale deployment/nginx --min=2 --max=10 --cpu-percent=70 -n workloads
+
+# Check HPA status
+kubectl get hpa nginx -n workloads
+```
+
+### Pause and Resume for Canary Testing
+
+Pause/resume is a lightweight "manual canary" technique using native Deployment
+features. It lets you ship a partial rollout and test it before proceeding.
+
+```bash
+# Pause the rollout (prevent the controller from continuing the update)
+kubectl rollout pause deployment/nginx -n workloads
+
+# Now update the image (or other fields) — the Deployment is paused,
+# so the controller will NOT apply these changes yet.
+kubectl set image deployment/nginx nginx=nginx:1.26 -n workloads
+
+# Check the current state (some Pods on v1.25, some on v1.26 — the paused state)
+kubectl get pods -n workloads -o wide
+
+# Run smoke tests against the cluster. Use a Service to test both versions,
+# or exec into a v1.26 Pod directly.
+kubectl exec -it <pod-name> -n workloads -- curl localhost/health
+
+# If tests pass: resume the rollout (continues updating remaining Pods)
+kubectl rollout resume deployment/nginx -n workloads
+
+# If tests fail: undo the paused update (reverts all changes including the pause)
+kubectl rollout undo deployment/nginx -n workloads
+
+# Verify final state
+kubectl rollout status deployment/nginx -n workloads
+```
+
+**Note:** Pause/resume is simpler than Argo Rollouts but coarser — you can't control
+the exact traffic percentage to the new version. For production-grade canary with
+traffic weighting, use Argo Rollouts with a service mesh.
+
+---
+
+## Deployment vs. StatefulSet vs. DaemonSet
+
+| | Deployment | StatefulSet | DaemonSet |
+|---|---|---|---|
+| **Use for** | Stateless apps (web servers, APIs, workers) | Stateful apps (databases, queues, search engines) | Node-level agents (monitoring, logging, CNI) |
+| **Pod names** | Random hash suffix (pod-abc12) | Stable ordinal (pod-0, pod-1, pod-2) | One per node, node name in pod name |
+| **Scaling order** | Simultaneous | Ordered (0 → 1 → 2) | N/A (one per node) |
+| **Deletion order** | Simultaneous | Reverse order (2 → 1 → 0) | N/A |
+| **Stable network identity** | No (Pod IP changes on restart) | Yes (headless Service gives stable DNS) | No |
+| **Stable storage** | No (use external storage) | Yes (VolumeClaimTemplates give per-pod PVC) | Per-node storage |
+| **Rolling update default** | Yes | Yes (ordered) | Yes (one at a time) |
+| **Example workloads** | nginx, API server, Celery worker | PostgreSQL, Kafka, Elasticsearch, ZooKeeper | Fluentd, Prometheus node-exporter, Calico node, kube-proxy |
+
+---
+
+## Interview Prep
+
+> **"What is the difference between a Deployment and a ReplicaSet?"**
+
+A ReplicaSet ensures N copies of a Pod template are running. It has no concept of
+versions or rollout history. A Deployment is a higher-level abstraction that manages
+ReplicaSets: when you update the Pod template, it creates a new ReplicaSet and
+coordinates the transition (rolling update) from the old ReplicaSet to the new one.
+The Deployment also keeps old ReplicaSets (scaled to 0) for rollback. In practice,
+you always use Deployments — you rarely interact with ReplicaSets directly.
+
+> **"How does a rolling update work? Can it cause downtime?"**
+
+With `maxUnavailable: 0` and a working `readinessProbe`, a rolling update should
+not cause downtime. The Deployment controller creates new Pods first (up to `maxSurge`
+above desired), waits for them to pass readiness (and `minReadySeconds`), then
+terminates old Pods. At no point does the available capacity drop below the desired
+replica count. However, rolling updates can cause downtime if: the readiness probe
+is misconfigured (reports Ready prematurely), `maxUnavailable > 0`, or the preStop
+hook is too short and requests are dropped during termination.
+
+> **"What happens to traffic during a rolling update?"**
+
+Traffic continues to flow to all Ready Pods throughout the update. During the update,
+some Pods serve the old version and some serve the new — they both receive traffic
+simultaneously. This means your old and new API versions must be backward-compatible.
+When a new Pod becomes Ready, it is added to the Service's EndpointSlice and starts
+receiving traffic. When an old Pod is terminated, it is removed from the
+EndpointSlice (the preStop hook gives time for the load balancer to drain it).
+
+> **"How do you roll back a Deployment in production?"**
+
+`kubectl rollout undo deployment/<name>` is the fastest path — it scales the
+previous ReplicaSet back up and the current one down, using the same rolling update
+mechanics. For a specific revision: `kubectl rollout undo --to-revision=N`.
+In a GitOps workflow, you would instead `git revert` the image tag change in the
+config repo and push, letting Argo CD re-sync. This keeps the Git history accurate.
+
+> **"What is `minReadySeconds` and why is it important?"**
+
+`minReadySeconds` is the time a newly created Pod must be in the Ready state
+(continuously) before the Deployment controller considers it truly Available and
+proceeds to the next step. Without `minReadySeconds: 0` (the default), a Pod that
+crashes 1 second after becoming Ready would still be counted as available, and the
+rollout would proceed even though the Pod is about to restart. Setting it to a
+reasonable value (e.g., 10–30s for most apps) prevents premature declaration of
+success for flaky Pods.
+
+---
+
+## Files in This Directory
+
+| File | Description |
+|---|---|
+| `README.md` | This file |
+| `nginx-deployment.yml` | Production-grade nginx Deployment with probes, configmap, security contexts |
+| `rolling-strategy.yml` | Demonstrates all rolling update fields with inline explanations |
+| `kustomize/` | Kustomize base + overlays (dev/staging/prod) |
+| `kustomize/base/` | Shared base manifests without environment-specific values |
+| `kustomize/overlays/dev/` | Dev environment: 1 replica, nginx:latest, small limits |
+| `kustomize/overlays/staging/` | Staging: 2 replicas, nginx:1.25, medium limits |
+| `kustomize/overlays/prod/` | Production: 4 replicas, nginx:1.25, larger limits |

--- a/core/workloads/deployment/nginx-deployment.yml
+++ b/core/workloads/deployment/nginx-deployment.yml
@@ -1,0 +1,373 @@
+# ==============================================================================
+# nginx-deployment.yml
+# Production-grade nginx Deployment with full security hardening, probes,
+# graceful shutdown, and a companion ConfigMap for nginx configuration.
+#
+# This file contains TWO Kubernetes documents (separated by ---):
+#   1. ConfigMap   — nginx.conf injected via volume mount
+#   2. Deployment  — nginx workload referencing the ConfigMap
+#
+# Key production patterns demonstrated:
+#   - ConfigMap-based configuration (change config without rebuilding image)
+#   - Distinct startupProbe, readinessProbe, livenessProbe endpoints
+#   - preStop sleep for zero-downtime rolling updates
+#   - readOnlyRootFilesystem with emptyDir volumes for nginx temp dirs
+#   - All 6 app.kubernetes.io/* labels on every resource
+#   - revisionHistoryLimit: 5 (limit etcd storage for old ReplicaSets)
+#   - minReadySeconds: 10 (avoid declaring a flaky pod as Available)
+#   - RollingUpdate with maxSurge:1, maxUnavailable:0 (zero-downtime)
+#
+# Usage:
+#   kubectl apply -f nginx-deployment.yml
+#   kubectl rollout status deployment/nginx -n workloads
+#   kubectl port-forward svc/nginx-svc 8080:80 -n workloads (if service exists)
+# ==============================================================================
+
+# ─── DOCUMENT 1: ConfigMap ────────────────────────────────────────────────────
+# Storing nginx configuration in a ConfigMap decouples configuration from the
+# container image. You can update nginx config with a ConfigMap change + pod
+# restart, without rebuilding or re-pushing a Docker image.
+#
+# The ConfigMap exposes three endpoints used by the probes:
+#   /healthz  — liveness check (is nginx process alive?)
+#   /ready    — readiness check (is nginx ready to serve traffic?)
+#   /metrics  — placeholder for future Prometheus metrics endpoint
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: workloads
+
+  labels:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: nginx
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: "nginx configuration for the nginx production deployment"
+
+data:
+  # The nginx.conf is embedded as a multi-line string value.
+  # It is mounted into the container at /etc/nginx/nginx.conf.
+  nginx.conf: |
+    # Run nginx as a non-daemon process so the container stays alive
+    # as long as the master process is running (PID 1 behavior).
+    daemon off;
+
+    # Number of worker processes. "auto" uses the number of CPU cores.
+    # With resource limits, this is bounded to our CPU quota.
+    worker_processes auto;
+
+    # Write the PID file to /var/run (mounted as emptyDir for write access)
+    pid /var/run/nginx.pid;
+
+    # Write error logs to stderr so the container runtime collects them
+    error_log /dev/stderr warn;
+
+    events {
+      # Maximum number of simultaneous connections per worker.
+      worker_connections 1024;
+    }
+
+    http {
+      # Write access logs to stdout so `kubectl logs` captures them.
+      # In production you might use a structured JSON format for log parsing.
+      access_log /dev/stdout combined;
+
+      # Use the temp directories that are mounted as emptyDir volumes.
+      client_body_temp_path /tmp/client_body;
+      proxy_temp_path        /tmp/proxy;
+      fastcgi_temp_path      /tmp/fastcgi;
+      uwsgi_temp_path        /tmp/uwsgi;
+      scgi_temp_path         /tmp/scgi;
+
+      # Security: remove the nginx version from the Server header.
+      server_tokens off;
+
+      # Standard performance settings
+      sendfile on;
+      tcp_nopush on;
+      tcp_nodelay on;
+      keepalive_timeout 65;
+      types_hash_max_size 2048;
+
+      include /etc/nginx/mime.types;
+      default_type application/octet-stream;
+
+      server {
+        listen 80;
+        server_name _;
+
+        # ── Health Endpoints (distinct for different probe types) ────────────
+        # Using distinct endpoints for startup, readiness, and liveness is a
+        # best practice: each probe can check a different condition.
+
+        # Liveness: Is the nginx process alive? If this fails, nginx has crashed
+        # or is stuck in a bad state. Always returns 200 if nginx is running.
+        location /healthz {
+          access_log off;          # Don't pollute access logs with probe traffic
+          return 200 "OK\n";
+          add_header Content-Type text/plain;
+        }
+
+        # Readiness: Is nginx ready to serve requests? Could check upstream
+        # availability, cache warmup, connection pool status, etc.
+        # Here it's the same as liveness, but in a real app they would differ.
+        location /ready {
+          access_log off;
+          return 200 "READY\n";
+          add_header Content-Type text/plain;
+        }
+
+        # Main application content
+        location / {
+          root /usr/share/nginx/html;
+          index index.html index.htm;
+
+          # Return 404 for missing files rather than directory listings
+          try_files $uri $uri/ =404;
+        }
+      }
+    }
+---
+# ─── DOCUMENT 2: Deployment ───────────────────────────────────────────────────
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: workloads
+
+  # ─── REQUIRED LABELS ──────────────────────────────────────────────────────
+  labels:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: nginx
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: "Production nginx deployment with full security hardening, probes, and rolling update configuration"
+
+spec:
+  # ─── REPLICA COUNT ─────────────────────────────────────────────────────────
+  replicas: 2
+
+  # ─── REVISION HISTORY ──────────────────────────────────────────────────────
+  # Keep the last 5 old ReplicaSets for rollback purposes. Default is 10.
+  # Each old ReplicaSet is an etcd entry; limiting this reduces etcd bloat.
+  # 5 revisions is usually sufficient for production rollback needs.
+  revisionHistoryLimit: 5
+
+  # ─── MIN READY SECONDS ─────────────────────────────────────────────────────
+  # A new Pod must be Ready for at least 10 seconds before it is considered
+  # "Available" and the rollout can proceed to the next Pod.
+  # This prevents a Pod that crashes immediately after becoming Ready from
+  # being counted as a successful rollout step.
+  minReadySeconds: 10
+
+  # ─── PROGRESS DEADLINE ─────────────────────────────────────────────────────
+  # If the Deployment hasn't made progress (scaled up new pods) within 600
+  # seconds, it is marked as Failed. This is visible in `kubectl describe`
+  # and can be alerted on via DeploymentCondition metrics.
+  progressDeadlineSeconds: 600
+
+  # ─── SELECTOR ──────────────────────────────────────────────────────────────
+  # IMMUTABLE after creation. Must match spec.template.metadata.labels.
+  # The Deployment controller uses this to identify which Pods it owns.
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx
+      app.kubernetes.io/instance: nginx
+
+  # ─── UPDATE STRATEGY ───────────────────────────────────────────────────────
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Create 1 extra Pod above `replicas` during the update.
+      # With 2 replicas, at peak there are 3 Pods (2 old + 1 new) briefly.
+      # Higher maxSurge speeds up the rollout but requires more node capacity.
+      maxSurge: 1
+
+      # Never take a Pod below the desired count during the update.
+      # 0 = no capacity loss during the rollout (zero-downtime guarantee).
+      # This is only as good as your readinessProbe — a pod that passes
+      # readiness prematurely can still serve errors.
+      maxUnavailable: 0
+
+  # ─── POD TEMPLATE ──────────────────────────────────────────────────────────
+  template:
+    metadata:
+      # Pod labels MUST include the fields referenced by spec.selector.matchLabels
+      labels:
+        app.kubernetes.io/name: nginx
+        app.kubernetes.io/instance: nginx
+        app.kubernetes.io/version: "1.0.0"
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: kube-platform
+        app.kubernetes.io/managed-by: kubectl
+      annotations:
+        kubernetes.io/description: "nginx web server pod"
+
+    spec:
+      # ─── SERVICE ACCOUNT ─────────────────────────────────────────────────
+      automountServiceAccountToken: false
+
+      # ─── GRACEFUL SHUTDOWN ───────────────────────────────────────────────
+      # Must be greater than preStop sleep (5s) + nginx's worker_shutdown_timeout.
+      # 60 seconds is a safe default for nginx.
+      terminationGracePeriodSeconds: 60
+
+      # ─── POD SECURITY CONTEXT ────────────────────────────────────────────
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 2000
+        seccompProfile:
+          type: RuntimeDefault
+
+      # ─── TOPOLOGY SPREAD ─────────────────────────────────────────────────
+      # Spread replicas evenly across availability zones.
+      # In production with 2+ replicas, this prevents both replicas landing
+      # on the same node or zone — a zone outage would then still be served.
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: nginx
+
+      # ─── VOLUMES ─────────────────────────────────────────────────────────
+      volumes:
+      # ConfigMap volume: mounts nginx.conf from the ConfigMap defined above.
+      # When the ConfigMap is updated, the mounted file is updated (within
+      # ~60s by default), but nginx won't pick it up until reloaded or restarted.
+      - name: nginx-config
+        configMap:
+          name: nginx-config
+          items:
+          - key: nginx.conf
+            path: nginx.conf
+
+      # emptyDir volumes for nginx's writable directories.
+      # Required because readOnlyRootFilesystem: true prevents writes to the
+      # container image's own filesystem.
+      - name: nginx-tmp
+        emptyDir: {}
+      - name: nginx-run
+        emptyDir: {}
+      - name: nginx-cache
+        emptyDir: {}
+
+      containers:
+      - name: nginx
+        # Pin to a specific minor version for production stability.
+        # In a real pipeline, use a digest: nginx@sha256:<digest>
+        image: nginx:1.25-alpine
+
+        ports:
+        - containerPort: 80
+          protocol: TCP
+          name: http
+
+        # ─── CONTAINER SECURITY CONTEXT ──────────────────────────────────
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_BIND_SERVICE
+
+        # ─── RESOURCE MANAGEMENT ─────────────────────────────────────────
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            # memory limit == request → Guaranteed QoS class
+            # (highest eviction priority; protected from OOM eviction)
+            memory: "128Mi"
+            # CPU limit intentionally omitted to avoid throttling.
+            # nginx CPU usage is bursty; capping it would increase p99 latency.
+
+        # ─── VOLUME MOUNTS ────────────────────────────────────────────────
+        volumeMounts:
+        # Mount the custom nginx.conf from the ConfigMap.
+        # This replaces the default /etc/nginx/nginx.conf inside the container.
+        - name: nginx-config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+          readOnly: true   # The config should never be modified by the running process
+
+        # Writable directories nginx needs at runtime
+        - name: nginx-tmp
+          mountPath: /tmp
+        - name: nginx-run
+          mountPath: /var/run
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+
+        # ─── LIFECYCLE ────────────────────────────────────────────────────
+        lifecycle:
+          preStop:
+            exec:
+              # Sleep 5s before nginx receives SIGTERM.
+              # This gives kube-proxy and cloud load balancers time to remove
+              # this Pod's IP from their routing tables.
+              # Without this, requests can arrive at a Pod that has already
+              # started shutting down, resulting in connection refused errors.
+              command: ["/bin/sh", "-c", "sleep 5"]
+
+        # ─── PROBES ───────────────────────────────────────────────────────
+        # Three probes serve three different purposes. ALL THREE should point
+        # to DIFFERENT endpoints where possible.
+
+        # startupProbe: Runs FIRST. liveness and readiness probes are DISABLED
+        # until the startup probe succeeds. This prevents premature restarts
+        # during slow application initialization (loading ML models, warming caches).
+        # With failureThreshold: 30 and periodSeconds: 2, the app has up to
+        # 60 seconds to start before being killed.
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 80
+          # Allow up to 30 * 2 = 60 seconds for nginx to start.
+          failureThreshold: 30
+          periodSeconds: 2
+          timeoutSeconds: 3
+
+        # readinessProbe: Controls Service endpoint inclusion.
+        # Failure removes this Pod from the Service's EndpointSlice → no traffic.
+        # It does NOT restart the container. Use this for transient "not ready"
+        # states (e.g., dependency temporarily unavailable, cache miss rate high).
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          failureThreshold: 3
+          # After 3 consecutive successes, the probe is considered passing again.
+          successThreshold: 1
+          timeoutSeconds: 3
+
+        # livenessProbe: Restarts the container if it fails.
+        # Use this for detecting deadlocks, hung goroutines, or processes that
+        # appear alive but can no longer handle requests.
+        # Starts ONLY AFTER the startupProbe succeeds.
+        # Use a HIGHER initialDelaySeconds than readinessProbe to avoid
+        # restarting a container that is merely slow to become ready.
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 80
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          failureThreshold: 3
+          timeoutSeconds: 3

--- a/core/workloads/deployment/rolling-strategy.yml
+++ b/core/workloads/deployment/rolling-strategy.yml
@@ -1,0 +1,317 @@
+# ==============================================================================
+# rolling-strategy.yml
+# A Deployment that explicitly demonstrates EVERY rolling update configuration
+# field, with detailed inline comments explaining the effect of each setting.
+#
+# This file is a learning reference — each field value is chosen to be obviously
+# illustrative, not necessarily optimal for production.
+#
+# Read this file top-to-bottom; the fields build on each other.
+#
+# Key concepts covered:
+#   - maxSurge          — burst capacity during rollout
+#   - maxUnavailable    — minimum capacity guarantee during rollout
+#   - minReadySeconds   — gate against flaky "Ready" pods
+#   - progressDeadlineSeconds — detect stuck rollouts
+#   - revisionHistoryLimit    — rollback window management
+#
+# Usage:
+#   kubectl apply -f rolling-strategy.yml
+#   kubectl rollout status deployment/rolling-demo -n workloads
+#   kubectl rollout history deployment/rolling-demo -n workloads
+#   # Trigger a rollout by changing the image:
+#   kubectl set image deployment/rolling-demo app=nginx:1.26-alpine -n workloads
+#   kubectl rollout status deployment/rolling-demo -n workloads --watch
+# ==============================================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rolling-demo
+  namespace: workloads
+
+  labels:
+    app.kubernetes.io/name: rolling-demo
+    app.kubernetes.io/instance: rolling-demo
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: "Reference deployment demonstrating all rolling update configuration fields"
+
+spec:
+  # ─── REPLICAS ──────────────────────────────────────────────────────────────
+  # Target number of Pod replicas. The rolling update parameters are calculated
+  # relative to this number.
+  # With replicas: 4, maxSurge: 1, maxUnavailable: 0:
+  #   - Peak pods during update: 5 (4 + 1 surge)
+  #   - Minimum pods during update: 4 (0 unavailable)
+  replicas: 4
+
+  # ─── REVISION HISTORY LIMIT ────────────────────────────────────────────────
+  # Kubernetes retains old ReplicaSets (scaled to 0 replicas) for rollback.
+  # Each retained ReplicaSet is stored in etcd and visible in `kubectl get rs`.
+  #
+  # revisionHistoryLimit: 5 means you can roll back to any of the last 5 versions.
+  # Lower = less etcd storage, smaller rollback window.
+  # Higher = more rollback options, more etcd storage.
+  # Default is 10. We use 5 as a balanced production default.
+  #
+  # Effect on rollback:
+  #   kubectl rollout history deployment/rolling-demo
+  #   → shows up to 5 REVISION entries you can undo to
+  revisionHistoryLimit: 5
+
+  # ─── MIN READY SECONDS ─────────────────────────────────────────────────────
+  # After a Pod becomes Ready (passes readinessProbe), the Deployment controller
+  # waits this many additional seconds before considering the Pod "Available"
+  # and proceeding to the next update step.
+  #
+  # Why this matters:
+  #   Without minReadySeconds (default: 0), a Pod that becomes Ready for 1 second
+  #   and then crashes would be counted as a successful update step, and the
+  #   rollout would proceed. minReadySeconds: 10 means the Pod must stay
+  #   continuously Ready for 10 seconds — catching flaps.
+  #
+  # Set this to your application's warm-up time:
+  #   - Static file servers (nginx): 5-10s
+  #   - Java applications with JIT: 30-60s
+  #   - ML model servers loading large models: 120s+
+  #
+  # Effect:
+  #   Each Pod replacement step takes at least minReadySeconds longer.
+  #   Total rollout time ≈ replicas * minReadySeconds (with maxUnavailable:0 and maxSurge:1)
+  minReadySeconds: 10
+
+  # ─── PROGRESS DEADLINE ─────────────────────────────────────────────────────
+  # The Deployment controller expects to make "progress" (create new Pods or
+  # mark new Pods as Available) at least every progressDeadlineSeconds.
+  #
+  # If the rollout stalls for this duration, the Deployment condition:
+  #   type: Progressing
+  #   status: "False"
+  #   reason: "ProgressDeadlineExceeded"
+  # is set on the Deployment object.
+  #
+  # This surfaces in:
+  #   kubectl describe deployment rolling-demo → Conditions section
+  #   kubectl get deployment rolling-demo → READY column shows 0/2
+  #   Prometheus metric: kube_deployment_status_condition
+  #
+  # Common causes of a stuck rollout:
+  #   - readinessProbe is failing on new Pods (wrong path, port, timing)
+  #   - Cluster is out of capacity (new Pods stay Pending)
+  #   - Image pull is failing (ImagePullBackOff)
+  #   - Init containers are hanging
+  #
+  # 600 seconds (10 minutes) is the default and a reasonable production value.
+  # Lower for fast-failing (e.g., 120s for services with quick startups).
+  progressDeadlineSeconds: 600
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rolling-demo
+      app.kubernetes.io/instance: rolling-demo
+
+  # ─── ROLLING UPDATE STRATEGY ───────────────────────────────────────────────
+  strategy:
+    type: RollingUpdate   # The other option is "Recreate" (all-at-once downtime)
+
+    rollingUpdate:
+      # ── maxSurge ───────────────────────────────────────────────────────────
+      # The maximum number of Pods that can be created ABOVE the desired `replicas`
+      # count during a rolling update.
+      #
+      # Can be:
+      #   - Absolute integer: maxSurge: 1  → create at most 1 extra Pod
+      #   - Percentage string: maxSurge: "25%"  → round UP to nearest integer
+      #     With replicas:4 and maxSurge:"25%": 4 * 0.25 = 1 extra Pod
+      #
+      # Effect on rollout:
+      #   maxSurge: 1 → only 1 new Pod is created at a time before removing 1 old Pod.
+      #                 Slowest but uses least extra resources.
+      #   maxSurge: 4 → all 4 new Pods are created first, then all 4 old Pods removed.
+      #                 Fastest but requires 2x the node capacity momentarily.
+      #
+      # Production recommendation: maxSurge: 1 for resource-constrained clusters.
+      # For fast rollouts on well-resourced clusters: maxSurge: "25%"
+      #
+      # Constraint: maxSurge and maxUnavailable cannot BOTH be 0.
+      maxSurge: 1
+
+      # ── maxUnavailable ─────────────────────────────────────────────────────
+      # The maximum number of Pods that can be UNAVAILABLE (not Ready) at any
+      # point during the rolling update.
+      #
+      # Can be absolute or percentage (rounded DOWN).
+      #
+      # Effect:
+      #   maxUnavailable: 0  → No Pod is removed until a new one is Available.
+      #                        Zero-downtime guarantee. Slowest. Requires maxSurge > 0.
+      #   maxUnavailable: 1  → 1 old Pod can be terminated before a new one is Ready.
+      #                        Faster rollout; briefly serves with replicas-1 capacity.
+      #   maxUnavailable: 100% → All old Pods are removed immediately (like Recreate).
+      #
+      # Production recommendation:
+      #   - maxUnavailable: 0 for user-facing services (zero-downtime mandate)
+      #   - maxUnavailable: 1 for background workers where brief under-capacity is ok
+      #   - maxUnavailable: "25%" for large fleets where faster rollouts are prioritized
+      maxUnavailable: 0
+
+      # ── Combined effect of maxSurge:1, maxUnavailable:0 (with replicas:4) ──
+      #
+      # T0: [v1][v1][v1][v1]           (4 pods, 4 available)
+      #
+      # T1: [v1][v1][v1][v1][v2]       (5 pods, 4 available, 1 new starting)
+      #     maxSurge=1: allowed to have 5 total
+      #     Wait for v2 to be Ready AND minReadySeconds to pass...
+      #
+      # T2: [v1][v1][v1]   [v2]        (4 pods, 4 available)
+      #     maxUnavailable=0: ok to remove 1 old since v2 is now Available
+      #
+      # T3: [v1][v1][v1][v2][v2]       (5 pods, 4 available, 1 new starting)
+      #     Next surge: create another v2 pod
+      #     Wait for it to be Available...
+      #
+      # T4: [v1][v1]   [v2][v2]        (4 pods, 4 available)
+      # ...continues until all v1 pods are replaced...
+      # TN: [v2][v2][v2][v2]           (4 pods, 4 available) ROLLOUT COMPLETE
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rolling-demo
+        app.kubernetes.io/instance: rolling-demo
+        app.kubernetes.io/version: "1.0.0"
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: kube-platform
+        app.kubernetes.io/managed-by: kubectl
+      annotations:
+        kubernetes.io/description: "rolling-demo web server pod"
+
+    spec:
+      automountServiceAccountToken: false
+
+      # ── terminationGracePeriodSeconds ───────────────────────────────────────
+      # When a Pod is deleted/evicted, kubelet sends SIGTERM to each container.
+      # After terminationGracePeriodSeconds, if the container is still running,
+      # kubelet sends SIGKILL (force kill).
+      #
+      # This value must be GREATER THAN:
+      #   preStop hook duration  +  application shutdown time
+      #
+      # Example: preStop sleep 5s + nginx drain 10s = needs at least 15s grace.
+      # We use 60s as a comfortable buffer.
+      #
+      # If your application needs a longer grace period (e.g., it waits for
+      # in-flight requests to complete), increase this accordingly.
+      terminationGracePeriodSeconds: 60
+
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 2000
+        seccompProfile:
+          type: RuntimeDefault
+
+      volumes:
+      - name: nginx-tmp
+        emptyDir: {}
+      - name: nginx-run
+        emptyDir: {}
+      - name: nginx-cache
+        emptyDir: {}
+
+      containers:
+      - name: app
+        image: nginx:1.25-alpine
+
+        ports:
+        - containerPort: 80
+          protocol: TCP
+          name: http
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_BIND_SERVICE
+
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "128Mi"
+
+        volumeMounts:
+        - name: nginx-tmp
+          mountPath: /tmp
+        - name: nginx-run
+          mountPath: /var/run
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+
+        lifecycle:
+          preStop:
+            exec:
+              # ── preStop hook relationship to rolling update ────────────────
+              # When a Pod is selected for termination during a rolling update:
+              # 1. Pod is removed from Service EndpointSlice (stops receiving new requests)
+              # 2. preStop hook runs (sleep 5s gives LB time to drain existing connections)
+              # 3. SIGTERM is sent to the container
+              # 4. nginx handles SIGTERM with graceful worker shutdown
+              # 5. SIGKILL sent after terminationGracePeriodSeconds if still running
+              #
+              # The 5-second sleep is the "connection drain" window. Without it,
+              # some load balancers (AWS ALB, kube-proxy iptables) may still route
+              # new requests to the Pod for a few seconds after it starts terminating,
+              # causing "connection refused" errors to clients.
+              command: ["/bin/sh", "-c", "sleep 5"]
+
+        # ── Probe relationship to rolling update ────────────────────────────
+        # The readinessProbe is the primary gate for the rolling update:
+        #   - A new Pod must pass readinessProbe to be counted as "Available"
+        #   - Combined with minReadySeconds, this is the "rollout gate"
+        #   - If the probe fails, the rollout stalls (no more old pods removed)
+        #   - `progressDeadlineSeconds` determines when the stall becomes a failure
+        startupProbe:
+          httpGet:
+            path: /
+            port: 80
+          # failureThreshold * periodSeconds = max startup time allowed
+          # 30 * 2s = 60 seconds for nginx to start
+          failureThreshold: 30
+          periodSeconds: 2
+          timeoutSeconds: 3
+
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          # initialDelaySeconds: wait before first probe attempt.
+          # For fast-starting apps, set this low. For slow-starting apps, use
+          # startupProbe instead (which gates readiness/liveness entirely).
+          initialDelaySeconds: 5
+          # periodSeconds: how often to probe.
+          # Lower = faster detection of readiness, more probe traffic.
+          periodSeconds: 10
+          # failureThreshold: how many consecutive failures before marking not-ready.
+          # 3 failures * 10s = 30 seconds of failure before traffic is removed.
+          failureThreshold: 3
+          timeoutSeconds: 3
+
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          # Higher initialDelay than readiness — give the app time to become
+          # ready before we start checking liveness (avoid restart loops).
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          failureThreshold: 3
+          timeoutSeconds: 3


### PR DESCRIPTION
## Summary
- Add `nginx-deployment.yml` — 2-replica nginx Deployment with: ConfigMap-backed nginx.conf (separate `/healthz`, `/ready`, `/` endpoints), `topologySpreadConstraints` across nodes, `preStop: sleep 5` for graceful drain, `revisionHistoryLimit: 5`, `minReadySeconds: 10`, full security context (`readOnlyRootFilesystem`, `runAsNonRoot`, `seccompProfile: RuntimeDefault`), and separate startup/readiness/liveness probes
- Add `rolling-strategy.yml` — maxSurge:1, maxUnavailable:0 rolling update with PodDisruptionBudget (`minAvailable: 1`) and `podAntiAffinity` across nodes
- Add `README.md` — `kubectl rollout` command reference, rollback procedure, strategy comparison, and deployment field explanations

## Issues referenced
Relates to #10, #89

## Test plan
- [ ] `kubectl apply -f core/workloads/deployment/nginx-deployment.yml` creates 2 Running pods
- [ ] `kubectl rollout status` shows successful rollout
- [ ] `curl localhost:8080/healthz` returns 200 after port-forward