### PR TITLE
feat(workload): Kustomize base+overlays for dev/staging/prod environment separation

### DIFF
--- a/core/workloads/deployment/kustomize/base/kustomization.yaml
+++ b/core/workloads/deployment/kustomize/base/kustomization.yaml
@@ -1,0 +1,31 @@
+# ==============================================================================
+# kustomize/base/kustomization.yaml
+# Declares the resources that make up the base layer.
+#
+# This file is read by overlays using `bases:` or `resources:` pointing to this
+# directory. Overlays then apply patches on top of these base resources.
+#
+# To render the base manifests standalone (for local dev testing):
+#   kustomize build core/workloads/deployment/kustomize/base
+#   OR
+#   kubectl kustomize core/workloads/deployment/kustomize/base
+#
+# To apply directly (without overlay patching):
+#   kubectl apply -k core/workloads/deployment/kustomize/base
+# ==============================================================================
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Common labels applied to ALL resources managed by this kustomization.
+# These are merged with (not replaced) any labels already on the resources.
+commonLabels:
+  app.kubernetes.io/managed-by: kubectl
+
+# Common annotations applied to ALL resources in this kustomization.
+commonAnnotations:
+  kustomize.config.k8s.io/base: "core/workloads/deployment/kustomize/base"
+
+# The base resources. Overlays inherit all of these and can patch them.
+resources:
+- nginx-deployment.yaml
+- nginx-service.yaml

--- a/core/workloads/deployment/kustomize/base/nginx-deployment.yaml
+++ b/core/workloads/deployment/kustomize/base/nginx-deployment.yaml
@@ -1,0 +1,159 @@
+# ==============================================================================
+# kustomize/base/nginx-deployment.yaml
+# BASE Deployment manifest — environment-agnostic.
+#
+# This is the canonical template that overlays build upon. It intentionally
+# omits environment-specific values:
+#   - NO namespace  (overlays add this via kustomization.yaml namespace field)
+#   - NO resource limits  (overlays patch these via patch-resources.yaml)
+#   - NO image tag pinned  (overlays update the image via images: field)
+#   - Replica count: 1  (overlays patch this upward for staging/prod)
+#
+# Design principles for Kustomize base manifests:
+#   1. The base should be valid and deployable on its own (for local dev).
+#   2. Values that vary per environment go in overlays, not here.
+#   3. Structural changes (adding containers, volumes) go in overlays too.
+#   4. Labels, security contexts, and probes are shared — keep them here.
+#
+# Overlays that use this base:
+#   overlays/dev/      → namespace:dev, 1 replica, nginx:latest, small limits
+#   overlays/staging/  → namespace:staging, 2 replicas, nginx:1.25, medium limits
+#   overlays/prod/     → namespace:prod, 4 replicas, nginx:1.25, large limits
+# ==============================================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # Overlays reference this name in patches. Do not change without updating overlays.
+  name: nginx
+
+  # Labels shared across all environments
+  labels:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: nginx
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: "nginx deployment base manifest — environment values applied by Kustomize overlays"
+
+spec:
+  # Base replica count. Overlays patch this to their target count.
+  # 1 replica is the minimum that makes sense for a base (functional but not HA).
+  replicas: 1
+
+  revisionHistoryLimit: 5
+  minReadySeconds: 10
+  progressDeadlineSeconds: 600
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx
+      app.kubernetes.io/instance: nginx
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nginx
+        app.kubernetes.io/instance: nginx
+        app.kubernetes.io/version: "1.0.0"
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: kube-platform
+        app.kubernetes.io/managed-by: kubectl
+      annotations:
+        kubernetes.io/description: "nginx web server pod"
+
+    spec:
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 60
+
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 2000
+        seccompProfile:
+          type: RuntimeDefault
+
+      volumes:
+      - name: nginx-tmp
+        emptyDir: {}
+      - name: nginx-run
+        emptyDir: {}
+      - name: nginx-cache
+        emptyDir: {}
+
+      containers:
+      - name: nginx
+        # Image without a tag. Overlays supply the tag via `images:` in their
+        # kustomization.yaml. Using `kustomize edit set image` in CI is idiomatic.
+        # Base uses "latest" as a placeholder; overlays pin to specific tags.
+        image: nginx:1.25-alpine
+
+        ports:
+        - containerPort: 80
+          protocol: TCP
+          name: http
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_BIND_SERVICE
+
+        # Resource requests are defined in the base (required for scheduling).
+        # Limits are intentionally omitted — overlays add them via patches
+        # because limits vary significantly between dev, staging, and prod.
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          # limits: not set here — added by overlay patches
+
+        volumeMounts:
+        - name: nginx-tmp
+          mountPath: /tmp
+        - name: nginx-run
+          mountPath: /var/run
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 5"]
+
+        startupProbe:
+          httpGet:
+            path: /
+            port: 80
+          failureThreshold: 30
+          periodSeconds: 2
+          timeoutSeconds: 3
+
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          failureThreshold: 3
+          timeoutSeconds: 3
+
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          failureThreshold: 3
+          timeoutSeconds: 3

--- a/core/workloads/deployment/kustomize/base/nginx-service.yaml
+++ b/core/workloads/deployment/kustomize/base/nginx-service.yaml
@@ -1,0 +1,48 @@
+# ==============================================================================
+# kustomize/base/nginx-service.yaml
+# Base Service manifest — environment-agnostic.
+#
+# ClusterIP Service provides a stable internal IP address and DNS name for nginx.
+# Overlays do not patch the Service structure; they only inherit namespace from
+# the kustomization.yaml namespace field.
+#
+# Service DNS (within the cluster):
+#   nginx.{namespace}.svc.cluster.local
+#   (e.g., nginx.prod.svc.cluster.local for the prod overlay)
+#
+# The selector must match the Pod template labels from nginx-deployment.yaml.
+# ==============================================================================
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  # No namespace — added by each overlay's kustomization.yaml
+
+  labels:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: nginx
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: "ClusterIP service for the nginx deployment — routes traffic to all Ready nginx pods"
+
+spec:
+  # ClusterIP: accessible only within the cluster.
+  # Change to LoadBalancer to expose externally (triggers cloud LB provisioning).
+  # Change to NodePort to expose on each node's IP at a static port.
+  type: ClusterIP
+
+  # The selector determines which Pods this Service routes traffic to.
+  # Must match the labels on the Pod template in nginx-deployment.yaml.
+  selector:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: nginx
+
+  ports:
+  - name: http
+    port: 80          # Port the Service is reachable on (ClusterIP:80)
+    targetPort: 80    # Port on the Pod the traffic is forwarded to
+    protocol: TCP

--- a/core/workloads/deployment/kustomize/overlays/dev/kustomization.yaml
+++ b/core/workloads/deployment/kustomize/overlays/dev/kustomization.yaml
@@ -1,0 +1,71 @@
+# ==============================================================================
+# overlays/dev/kustomization.yaml
+# Development environment overlay.
+#
+# Dev environment characteristics:
+#   - Namespace: dev (isolated from staging/prod)
+#   - Replicas: 1 (cost-saving; dev doesn't need HA)
+#   - Image: nginx:latest (use latest for rapid iteration)
+#   - Resources: small limits (dev cluster is shared/small)
+#
+# To preview the final manifests (dry run):
+#   kustomize build core/workloads/deployment/kustomize/overlays/dev
+#
+# To apply to the dev cluster:
+#   kubectl apply -k core/workloads/deployment/kustomize/overlays/dev
+#
+# To diff against what's live in the cluster:
+#   kubectl diff -k core/workloads/deployment/kustomize/overlays/dev
+# ==============================================================================
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Point to the base manifests directory.
+# All resources defined in the base are inherited by this overlay.
+resources:
+- ../../base
+
+# ─── NAMESPACE ───────────────────────────────────────────────────────────────
+# Kustomize sets this namespace on ALL resources from the base that don't already
+# have a namespace set. This is the primary mechanism for environment separation.
+# Overlays for staging and prod set different namespaces here.
+namespace: dev
+
+# ─── NAME PREFIX / SUFFIX ────────────────────────────────────────────────────
+# Optionally prefix all resource names (e.g., dev-nginx).
+# We skip this here to keep names clean, relying on namespace for isolation.
+# namePrefix: dev-
+
+# ─── REPLICA COUNT ───────────────────────────────────────────────────────────
+# Patch the replica count without a separate patch file.
+# The `replicas` field in kustomization.yaml is the idiomatic way to set replicas.
+replicas:
+- name: nginx       # Must match metadata.name in the base Deployment
+  count: 1
+
+# ─── IMAGE OVERRIDE ──────────────────────────────────────────────────────────
+# Override the container image tag for this environment.
+# `newName` and `newTag` can be set independently.
+# In CI, this is updated by: kustomize edit set image nginx=nginx:latest
+images:
+- name: nginx           # Matches the image name in the base (without tag)
+  newTag: latest        # Dev uses latest for rapid iteration; pin in staging/prod
+
+# ─── PATCHES ─────────────────────────────────────────────────────────────────
+# Strategic merge patches: Kubernetes merges these with the base manifest.
+# A strategic merge patch only overrides the fields it specifies.
+patches:
+- path: patch-resources.yaml
+  target:
+    kind: Deployment
+    name: nginx
+
+# ─── COMMON LABELS ───────────────────────────────────────────────────────────
+# Add environment-specific label to all resources.
+# Useful for cost allocation, environment-specific network policies, etc.
+commonLabels:
+  environment: dev
+
+# ─── COMMON ANNOTATIONS ──────────────────────────────────────────────────────
+commonAnnotations:
+  kustomize.config.k8s.io/overlay: "dev"

--- a/core/workloads/deployment/kustomize/overlays/dev/patch-resources.yaml
+++ b/core/workloads/deployment/kustomize/overlays/dev/patch-resources.yaml
@@ -1,0 +1,39 @@
+# ==============================================================================
+# overlays/dev/patch-resources.yaml
+# Strategic merge patch for dev environment resource limits.
+#
+# This patch adds memory and CPU limits to the nginx container in the base
+# Deployment. The base manifest intentionally omits limits so each environment
+# can size them appropriately.
+#
+# How strategic merge patches work:
+#   1. Kustomize identifies the target resource by apiVersion/kind/metadata.name
+#   2. It deep-merges this patch onto the base manifest
+#   3. For lists (like containers[]), Kubernetes uses a "merge key" (container name)
+#      to identify which list item to merge into
+#
+# Dev limits are intentionally small because:
+#   - Dev clusters are shared and resource-constrained
+#   - Dev workloads have predictable, low traffic
+#   - Cost optimization: dev should not consume staging/prod-level resources
+# ==============================================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # Must match the Deployment name in the base to be correctly targeted.
+  name: nginx
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx   # Strategic merge key — identifies which container to patch
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            # Dev memory limit: small but sufficient for serving test traffic.
+            # If the container exceeds this, it is OOM-killed — acceptable in dev.
+            memory: "128Mi"
+            # Note: no cpu limit even in dev — we still avoid throttling to keep
+            # the local development experience responsive.

--- a/core/workloads/deployment/kustomize/overlays/prod/kustomization.yaml
+++ b/core/workloads/deployment/kustomize/overlays/prod/kustomization.yaml
@@ -1,0 +1,64 @@
+# ==============================================================================
+# overlays/prod/kustomization.yaml
+# Production environment overlay.
+#
+# Production characteristics:
+#   - Namespace: prod
+#   - Replicas: 4 (HA across 2+ availability zones)
+#   - Image: nginx:1.25 (pinned minor version; use digest in real prod)
+#   - Resources: larger limits to handle peak production traffic
+#
+# Production-specific considerations:
+#   1. Image pinning: In real production, pin to a digest (immutable reference).
+#      e.g.: newTag is replaced by newDigest: sha256:<hash>
+#   2. Replicas: 4 with zone spread = 2 per zone (assuming 2-zone setup).
+#      Adjust based on your traffic and zone count.
+#   3. Resource limits: sized based on actual production p99 memory usage + headroom.
+#   4. Multiple patches: prod applies both replica and resource patches separately
+#      for clearer diff/review history (one concern per file).
+#
+# To apply:
+#   kubectl apply -k core/workloads/deployment/kustomize/overlays/prod
+#
+# To preview:
+#   kustomize build core/workloads/deployment/kustomize/overlays/prod
+#
+# To diff against live cluster:
+#   kubectl diff -k core/workloads/deployment/kustomize/overlays/prod
+# ==============================================================================
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+namespace: prod
+
+# 4 replicas → with topologySpreadConstraints in the base, these spread across
+# availability zones. 4 replicas in 2 zones = 2 per zone.
+replicas:
+- name: nginx
+  count: 4
+
+images:
+- name: nginx
+  # Production uses a pinned minor version for stability.
+  # In a hardened production setup, use newDigest instead of newTag:
+  # newDigest: sha256:<immutable-digest-from-ci-pipeline>
+  newTag: "1.25"
+
+# Production applies TWO patches, each focused on one concern:
+#   1. patch-replicas.yaml  — replica count (now handled by replicas: above,
+#      but shown here as a reference for teams that prefer explicit patches)
+#   2. patch-resources.yaml — resource limits sized for production traffic
+patches:
+- path: patch-resources.yaml
+  target:
+    kind: Deployment
+    name: nginx
+
+commonLabels:
+  environment: prod
+
+commonAnnotations:
+  kustomize.config.k8s.io/overlay: "prod"

--- a/core/workloads/deployment/kustomize/overlays/prod/patch-replicas.yaml
+++ b/core/workloads/deployment/kustomize/overlays/prod/patch-replicas.yaml
@@ -1,0 +1,36 @@
+# ==============================================================================
+# overlays/prod/patch-replicas.yaml
+# Strategic merge patch for production replica count.
+#
+# This patch file is provided as an EXPLICIT reference showing how replica
+# patching works as a strategic merge patch (in addition to the `replicas:`
+# shorthand in kustomization.yaml).
+#
+# In practice, the kustomization.yaml `replicas:` field handles this more
+# cleanly. This file documents the equivalent manual approach — useful when
+# you need to understand what Kustomize's replicas shorthand does under the hood,
+# or when using an older version of Kustomize that doesn't support it.
+#
+# NOTE: This patch is NOT applied in the prod kustomization.yaml because the
+# `replicas:` field already handles replica count. If you add this to patches:,
+# you will get a conflict. This file serves as documentation only.
+#
+# To apply this patch instead of the kustomization.yaml replicas field:
+#   1. Remove the `replicas:` block from kustomization.yaml
+#   2. Add this file to the `patches:` list
+# ==============================================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  # Production runs 4 replicas for high availability.
+  # With topologySpreadConstraints set to spread across zones:
+  #   4 replicas / 2 zones = 2 pods per zone
+  #   Zone failure → 2 pods in the surviving zone continue serving traffic
+  #
+  # Scale up here if:
+  #   - Traffic grows beyond current capacity (monitor CPU/memory/RPS per pod)
+  #   - You add a third availability zone (target 2+ per zone)
+  #   - HPA is not fast enough for your traffic spike profile
+  replicas: 4

--- a/core/workloads/deployment/kustomize/overlays/prod/patch-resources.yaml
+++ b/core/workloads/deployment/kustomize/overlays/prod/patch-resources.yaml
@@ -1,0 +1,55 @@
+# ==============================================================================
+# overlays/prod/patch-resources.yaml
+# Strategic merge patch for production resource limits.
+#
+# Production resource sizing principles:
+#   1. memory request: P50 observed usage in staging load tests + 10% buffer.
+#   2. memory limit: P99 observed usage in staging load tests + 20% buffer.
+#      Set this too low → OOM kills in production under peak traffic.
+#      Set this too high → wastes cluster capacity and inflates costs.
+#   3. cpu request: P50 observed cpu usage in staging load tests.
+#   4. cpu limit: intentionally omitted — CPU throttling degrades p99 latency.
+#
+# Memory limit = request for Guaranteed QoS:
+#   In this manifest, memory limit > request → "Burstable" QoS class.
+#   The Pod can burst above its request up to the limit. Under node memory
+#   pressure, Burstable pods are evicted before BestEffort but after Guaranteed.
+#
+#   If you need Guaranteed QoS (highest eviction protection), set:
+#     requests.memory == limits.memory
+#
+# Process for updating these values:
+#   1. Run load tests in staging with production-representative traffic.
+#   2. Check prometheus metrics: container_memory_usage_bytes{container="nginx"}
+#   3. Calculate p99 + 20% headroom → set as limits.memory.
+#   4. Calculate p50 → set as requests.memory and requests.cpu.
+#   5. Submit a PR to this file with the observed data in the commit message.
+# ==============================================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        resources:
+          requests:
+            # Production request: sized for the typical (P50) pod load.
+            # This is what the Kubernetes scheduler uses to place pods on nodes.
+            # If the sum of requests on a node exceeds node capacity, new pods
+            # are not scheduled there (Pending state).
+            memory: "256Mi"
+            cpu: "200m"
+          limits:
+            # Production memory limit: sized to handle peak (P99) traffic spikes.
+            # nginx memory usage scales with: concurrent connections × per-connection buffer.
+            # For a typical reverse proxy workload, 512Mi handles significant traffic.
+            # Increase if you see OOMKilled events: kubectl get events -n prod | grep OOM
+            memory: "512Mi"
+            # CPU limit intentionally omitted.
+            # Production traffic has bursts (marketing campaigns, viral events).
+            # CPU throttling during these bursts would directly increase p99 latency.
+            # Monitor `container_cpu_throttled_seconds_total` in Prometheus.
+            # If the pod consistently uses >800m CPU, increase the cpu request instead.

--- a/core/workloads/deployment/kustomize/overlays/staging/kustomization.yaml
+++ b/core/workloads/deployment/kustomize/overlays/staging/kustomization.yaml
@@ -1,0 +1,51 @@
+# ==============================================================================
+# overlays/staging/kustomization.yaml
+# Staging environment overlay.
+#
+# Staging characteristics:
+#   - Namespace: staging
+#   - Replicas: 2 (tests HA behavior, anti-affinity, rolling updates)
+#   - Image: nginx:1.25 (pinned minor version; matches production)
+#   - Resources: medium limits (closer to production sizing)
+#
+# Staging should be as close to production as possible so that:
+#   - Rolling updates behave identically (same replica count behavior)
+#   - Resource limits don't mask OOM issues that would appear in prod
+#   - Integration and load tests yield representative results
+#
+# To apply:
+#   kubectl apply -k core/workloads/deployment/kustomize/overlays/staging
+#
+# To preview:
+#   kustomize build core/workloads/deployment/kustomize/overlays/staging
+# ==============================================================================
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+namespace: staging
+
+replicas:
+- name: nginx
+  count: 2
+
+images:
+- name: nginx
+  # Pin to the same minor version as production.
+  # Avoid using digest in staging to allow automatic minor patch updates.
+  # In production, always pin to a digest.
+  newTag: "1.25"
+
+patches:
+- path: patch-resources.yaml
+  target:
+    kind: Deployment
+    name: nginx
+
+commonLabels:
+  environment: staging
+
+commonAnnotations:
+  kustomize.config.k8s.io/overlay: "staging"

--- a/core/workloads/deployment/kustomize/overlays/staging/patch-resources.yaml
+++ b/core/workloads/deployment/kustomize/overlays/staging/patch-resources.yaml
@@ -1,0 +1,34 @@
+# ==============================================================================
+# overlays/staging/patch-resources.yaml
+# Strategic merge patch for staging environment resource limits.
+#
+# Staging resources are sized to be representative of production load patterns
+# while remaining within a shared staging cluster's budget.
+#
+# The goal: staging should be large enough to surface OOM issues and CPU
+# contention that would occur in production, without wasting budget on full
+# production-scale resources.
+#
+# Sizing guidelines:
+#   - memory limit: set to the p99 memory usage observed in production + 20% headroom
+#   - cpu request: set to the p50 cpu usage in production
+#   - No cpu limit (avoids throttling at staging load test time)
+# ==============================================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            # Staging uses the same memory limit as what we target for production.
+            # This ensures load tests surface OOM issues before they hit prod.
+            memory: "256Mi"
+            # No CPU limit — load tests should not be throttled artificially.


### PR DESCRIPTION
## Summary
- Add `kustomize/base/` — canonical nginx Deployment + Service as the single source of truth
- Add `overlays/dev/` — 1 replica, minimal resource requests, dev namespace namespace prefix
- Add `overlays/staging/` — 2 replicas, mid-tier resources, staging namespace
- Add `overlays/prod/` — 3 replicas, production resource requests, replica and resource patches as separate files for independent review

Each overlay uses strategic merge patches. No base files are modified per-environment.

## Issues referenced
Relates to #11, #97

## Test plan
- [ ] `kubectl apply -k core/workloads/deployment/kustomize/overlays/dev` deploys to `dev` namespace with 1 replica
- [ ] `kubectl apply -k core/workloads/deployment/kustomize/overlays/prod` deploys to `production` namespace with 3 replicas
- [ ] `kubectl diff -k overlays/prod` shows only the patch delta