### PR TITLE
feat(workload): all 4 deployment strategies — Recreate, RollingUpdate, Blue-Green, Canary

### DIFF
--- a/core/workloads/deployment-strategies/README.md
+++ b/core/workloads/deployment-strategies/README.md
@@ -1,0 +1,48 @@
+# Deployment Strategies — Overview
+
+Kubernetes supports multiple patterns for deploying new versions of your application. Each strategy involves different tradeoffs between downtime risk, resource cost, rollback speed, and operational complexity.
+
+## Strategies Covered
+
+| Strategy | Subdirectory | Summary |
+|---|---|---|
+| **Recreate** | [`recreate/`](./recreate/) | Kill all old pods, then start new ones. Causes downtime. Only for dev/staging. |
+| **Rolling Update** | [`rolling-update/`](./rolling-update/) | Replace pods incrementally. Zero downtime when done correctly. Default Kubernetes behavior. |
+| **Blue-Green** | [`blue-green/`](./blue-green/) | Run two complete environments; switch traffic instantly by flipping a service selector. |
+| **Canary** | [`canary/`](./canary/) | Route a small percentage of traffic to the new version; promote or roll back based on metrics. |
+
+## Decision Guide
+
+```
+Is downtime acceptable?
+├── Yes → Recreate (only for dev/staging)
+└── No → Continue...
+    │
+    Do you need instant rollback capability?
+    ├── Yes, and you can afford 2x resources → Blue-Green
+    └── No, or resource cost is a concern → Continue...
+        │
+        Do you need to validate with real user traffic before full rollout?
+        ├── Yes → Canary
+        └── No → Rolling Update (default — use this for most deployments)
+```
+
+## Full Comparison
+
+See [`comparison.md`](./comparison.md) for a detailed comparison table including downtime, resource overhead, rollback speed, risk level, complexity, and industry examples.
+
+## How to Apply Each Strategy
+
+```bash
+# Recreate
+kubectl apply -f recreate/
+
+# Rolling Update
+kubectl apply -f rolling-update/
+
+# Blue-Green (apply both deployments, traffic goes to blue initially)
+kubectl apply -f blue-green/
+
+# Canary (apply stable first, then canary — ~80/20 traffic split)
+kubectl apply -f canary/
+```

--- a/core/workloads/deployment-strategies/blue-green/README.md
+++ b/core/workloads/deployment-strategies/blue-green/README.md
@@ -1,0 +1,122 @@
+# Blue-Green Deployment Strategy
+
+## What Is It?
+
+Blue-Green deployment maintains **two identical production environments** — "blue" (current live version) and "green" (new version). Traffic is served entirely by one environment at a time. When the green environment is ready and verified, a single switch redirects all traffic from blue to green instantly.
+
+The previous environment (blue after switching to green) is kept as a hot standby for instant rollback.
+
+---
+
+## How Traffic Switching Works
+
+In Kubernetes, the traffic switch is implemented by changing the Service's label selector:
+
+**Initial state:** Service points to blue (v1)
+```yaml
+selector:
+  app.kubernetes.io/name: nginx-bluegreen
+  version: v1   # Traffic goes to blue deployment
+```
+
+**After verification:** Switch to green (v2)
+```bash
+kubectl patch service nginx-bluegreen -n blue-green-demo \
+  -p '{"spec":{"selector":{"version":"v2"}}}'
+```
+
+**Service now routes:** 100% of traffic goes to green pods. Blue pods still exist but receive no traffic.
+
+The switch propagates via kube-proxy's iptables/ipvs rules — typically within milliseconds cluster-wide.
+
+---
+
+## Step-by-Step Deployment Procedure
+
+```bash
+# Step 1: Apply blue deployment (this is your current production)
+kubectl apply -f blue-deployment.yml
+
+# Step 2: Deploy green (new version) — no traffic goes to it yet
+kubectl apply -f green-deployment.yml
+
+# Step 3: Verify green is healthy and Ready
+kubectl rollout status deployment/nginx-green -n blue-green-demo
+kubectl get pods -n blue-green-demo -l version=v2
+
+# Step 4: Smoke test green BEFORE switching (optional: use port-forward to test directly)
+kubectl port-forward deployment/nginx-green 8080:8080 -n blue-green-demo &
+curl http://localhost:8080/
+# Verify the response is correct for v2
+
+# Step 5: Switch traffic from blue to green
+kubectl patch service nginx-bluegreen -n blue-green-demo \
+  -p '{"spec":{"selector":{"version":"v2"}}}'
+
+# Step 6: Verify traffic is going to green
+kubectl describe service nginx-bluegreen -n blue-green-demo
+# Check 'Endpoints' — should show green pod IPs
+
+# Step 7: Monitor for errors in green
+kubectl logs -n blue-green-demo -l version=v2 --tail=100 -f
+
+# Step 8: (After confidence period) Scale down blue to save resources
+kubectl scale deployment/nginx-blue --replicas=0 -n blue-green-demo
+# Do NOT delete blue yet — keep it for emergency rollback for at least 24h
+```
+
+---
+
+## Rollback Procedure
+
+If green has problems after the switch:
+
+```bash
+# Instant rollback — switch selector back to blue (v1)
+kubectl patch service nginx-bluegreen -n blue-green-demo \
+  -p '{"spec":{"selector":{"version":"v1"}}}'
+
+# Verify rollback took effect
+kubectl describe endpoints nginx-bluegreen -n blue-green-demo
+# Should show blue pod IPs again
+```
+
+Rollback is instant because blue pods are still running — no pod creation or startup time required. This is blue-green's key advantage over rolling update rollback (which requires starting old pods).
+
+---
+
+## Resource Cost
+
+Blue-green requires **2x the normal pod count** for the duration of the release window. With 4 replicas in production, blue-green means 8 pods running simultaneously (4 blue + 4 green) during the switchover.
+
+For large deployments, this is significant. Mitigation strategies:
+- Scale green down to 1 replica for testing, scale to full replicas just before the switch.
+- Use cluster autoscaling so the extra capacity is provisioned only when needed.
+- Limit the release window — switch quickly and scale down blue within hours.
+
+---
+
+## Database Schema Compatibility
+
+Blue-green requires that the database schema is compatible with both versions simultaneously (during the brief window where green is deployed but before the switch). The recommended pattern:
+
+1. **Expand:** Deploy a migration that adds new columns/tables but keeps old ones. Blue and green both work with the expanded schema.
+2. **Switch:** Flip the service selector to green.
+3. **Contract:** After confidence, deploy another migration to drop the old columns (now only green is running).
+
+This "expand-contract" pattern avoids schema-induced downtime in blue-green deployments.
+
+---
+
+## When to Use Blue-Green
+
+**Use when:**
+- High-stakes releases where instant rollback is non-negotiable.
+- You need to test the new version with production-like traffic before declaring success.
+- Your release involves multiple coordinated components that must all switch simultaneously.
+- Regulatory requirements mandate zero-downtime with a verified rollback path.
+
+**Do NOT use when:**
+- You cannot afford 2x resource cost.
+- Your application has many stateful dependencies that cannot easily be duplicated.
+- You deploy many times per day (cost of maintaining two environments adds up).

--- a/core/workloads/deployment-strategies/blue-green/blue-deployment.yml
+++ b/core/workloads/deployment-strategies/blue-green/blue-deployment.yml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-blue
+  namespace: blue-green-demo
+  labels:
+    app.kubernetes.io/name: nginx-bluegreen
+    app.kubernetes.io/instance: nginx-blue
+    app.kubernetes.io/version: "1.24"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+    # The 'slot' label identifies this as the blue environment.
+    # This is for operational clarity — it doesn't directly affect traffic routing.
+    slot: blue
+  annotations:
+    kubernetes.io/description: "Blue deployment (v1 — nginx:1.24) — current production. Traffic is served from blue until the service selector is switched to green."
+spec:
+  replicas: 4
+
+  revisionHistoryLimit: 5
+  minReadySeconds: 10
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx-bluegreen
+      app.kubernetes.io/instance: nginx-blue
+
+  # Blue deployment itself uses RollingUpdate for internal updates.
+  # The blue-green TRAFFIC SWITCH is done at the Service layer, not here.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nginx-bluegreen
+        app.kubernetes.io/instance: nginx-blue
+        app.kubernetes.io/version: "1.24"
+        app.kubernetes.io/component: webserver
+        app.kubernetes.io/part-of: kube-platform
+        app.kubernetes.io/managed-by: kubectl
+        slot: blue
+        # THE KEY LABEL FOR BLUE-GREEN ROUTING:
+        # The service.yml selector includes 'version: v1' to route traffic to blue pods.
+        # When we want to switch to green, we change the service selector to 'version: v2'.
+        # Blue pods keep version: v1 and green pods have version: v2 — they never conflict.
+        version: v1
+      annotations:
+        kubernetes.io/description: "Blue (v1) NGINX pod — serves production traffic until green is promoted"
+    spec:
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 60
+
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+
+      containers:
+      - name: nginx
+        # v1 image — the current production version.
+        image: nginx:1.24
+        imagePullPolicy: IfNotPresent
+
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 5"]
+
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
+
+        volumeMounts:
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
+        - name: tmp
+          mountPath: /tmp
+
+      volumes:
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}

--- a/core/workloads/deployment-strategies/blue-green/green-deployment.yml
+++ b/core/workloads/deployment-strategies/blue-green/green-deployment.yml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-green
+  namespace: blue-green-demo
+  labels:
+    app.kubernetes.io/name: nginx-bluegreen
+    app.kubernetes.io/instance: nginx-green
+    app.kubernetes.io/version: "1.25"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+    slot: green
+  annotations:
+    kubernetes.io/description: "Green deployment (v2 — nginx:1.25) — staged environment. Apply this, verify health, then switch the service selector to route traffic here."
+spec:
+  # Green starts with the same replica count as blue.
+  # In cost-sensitive environments, you may start green with 1 replica for testing,
+  # then scale to full replicas just before the traffic switch:
+  # kubectl scale deployment/nginx-green --replicas=4 -n blue-green-demo
+  replicas: 4
+
+  revisionHistoryLimit: 5
+  minReadySeconds: 10
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx-bluegreen
+      app.kubernetes.io/instance: nginx-green
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nginx-bluegreen
+        app.kubernetes.io/instance: nginx-green
+        app.kubernetes.io/version: "1.25"
+        app.kubernetes.io/component: webserver
+        app.kubernetes.io/part-of: kube-platform
+        app.kubernetes.io/managed-by: kubectl
+        slot: green
+        # THE KEY LABEL FOR BLUE-GREEN ROUTING:
+        # The service.yml selector must be changed from 'version: v1' to 'version: v2'
+        # to route traffic here. The switch command:
+        # kubectl patch service nginx-bluegreen -n blue-green-demo \
+        #   -p '{"spec":{"selector":{"version":"v2"}}}'
+        version: v2
+      annotations:
+        kubernetes.io/description: "Green (v2) NGINX pod — staged for release. Receives no traffic until the service selector is switched."
+    spec:
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 60
+
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+
+      containers:
+      - name: nginx
+        # v2 image — the new version to be promoted.
+        image: nginx:1.25
+        imagePullPolicy: IfNotPresent
+
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 5"]
+
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
+
+        volumeMounts:
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
+        - name: tmp
+          mountPath: /tmp
+
+      volumes:
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}

--- a/core/workloads/deployment-strategies/blue-green/namespace.yml
+++ b/core/workloads/deployment-strategies/blue-green/namespace.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: blue-green-demo
+  labels:
+    app.kubernetes.io/part-of: kube-platform
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+  annotations:
+    kubernetes.io/description: "Demo namespace for Blue-Green deployment strategy — illustrates instant traffic switching between two parallel environments"

--- a/core/workloads/deployment-strategies/blue-green/service.yml
+++ b/core/workloads/deployment-strategies/blue-green/service.yml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-bluegreen
+  namespace: blue-green-demo
+  labels:
+    app.kubernetes.io/name: nginx-bluegreen
+    app.kubernetes.io/instance: nginx-bluegreen
+    app.kubernetes.io/version: "1.24"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "Traffic control point for Blue-Green deployment — change selector.version from v1 to v2 to switch all traffic to green"
+spec:
+  type: ClusterIP
+
+  # THE TRAFFIC SWITCH — THE HEART OF BLUE-GREEN:
+  # This selector currently routes 100% of traffic to blue pods (version: v1).
+  #
+  # To switch to green (v2), run:
+  #   kubectl patch service nginx-bluegreen -n blue-green-demo \
+  #     -p '{"spec":{"selector":{"version":"v2"}}}'
+  #
+  # To roll back to blue (v1), run:
+  #   kubectl patch service nginx-bluegreen -n blue-green-demo \
+  #     -p '{"spec":{"selector":{"version":"v1"}}}'
+  #
+  # The switch takes effect within milliseconds — kube-proxy updates iptables/ipvs
+  # rules on all nodes as soon as the Endpoints object is updated by the endpointslice
+  # controller. In-flight connections to the old version complete normally (no RST).
+  # New connections immediately go to the new version.
+  #
+  # WHY NOT CHANGE THE DEPLOYMENT'S LABELS?
+  # We change the service selector, not the pod labels. This is because:
+  # 1. Changing pod labels on a Deployment requires a rollout (pod restart), which
+  #    takes time and defeats the purpose of instant switching.
+  # 2. Changing the service selector is a non-destructive, instantly reversible
+  #    control-plane operation that requires no pod restarts.
+  selector:
+    app.kubernetes.io/name: nginx-bluegreen
+    version: v1   # CHANGE TO v2 TO SWITCH TRAFFIC TO GREEN
+
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+    protocol: TCP

--- a/core/workloads/deployment-strategies/canary/README.md
+++ b/core/workloads/deployment-strategies/canary/README.md
@@ -1,0 +1,147 @@
+# Canary Deployment Strategy
+
+## What Is It?
+
+A canary deployment routes a **small percentage of production traffic** to a new version of the application while the majority of traffic continues to go to the stable version. The name comes from the "canary in a coal mine" — a small indicator that detects problems before they affect everyone.
+
+If the canary version shows elevated error rates, increased latency, or unexpected behavior, it is rolled back. If metrics look good, the canary is gradually promoted to handle all traffic.
+
+---
+
+## How Traffic Split Works (Kubernetes-Native)
+
+Kubernetes does not have native traffic weighting by percentage. Instead, canary in "plain Kubernetes" relies on **replica ratio**.
+
+The Service selects pods from both the stable and canary deployments (using a shared label). Traffic is distributed proportionally to the number of Ready pods.
+
+```
+Stable:  4 replicas  →  4/(4+1) = 80% of traffic
+Canary:  1 replica   →  1/(4+1) = 20% of traffic
+```
+
+To adjust the traffic split:
+- Increase canary replicas to send more traffic to canary.
+- Decrease stable replicas (while adding canary replicas) to shift traffic progressively.
+
+**Limitations of replica-based splitting:**
+- Minimum granularity is 1 replica = 1/(total replicas). With 4 stable + 1 canary, minimum canary traffic is 20%.
+- Cannot route specific users or requests to canary (it's random load balancing).
+- Cannot do sub-5% canary without many total replicas.
+
+For fine-grained control, use the **Ingress-based approach** (see `ingress.yml`) or a **service mesh**.
+
+---
+
+## Ingress-Based Traffic Splitting (NGINX Ingress)
+
+The NGINX Ingress Controller supports canary annotations for precise traffic control:
+
+```yaml
+annotations:
+  nginx.ingress.kubernetes.io/canary: "true"
+  nginx.ingress.kubernetes.io/canary-weight: "5"   # Exactly 5% to canary
+```
+
+This is independent of replica count — you can send 5% of traffic to 1 canary pod without changing anything else. See `ingress.yml` for the full example.
+
+---
+
+## Service Mesh Traffic Splitting (Istio)
+
+With Istio's VirtualService, you get exact percentage routing:
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+spec:
+  http:
+  - route:
+    - destination:
+        host: myapp
+        subset: stable
+      weight: 95
+    - destination:
+        host: myapp
+        subset: canary
+      weight: 5
+```
+
+Service meshes also enable:
+- **Header-based routing:** Route requests with `X-Beta-User: true` header to canary.
+- **Cookie-based routing:** Sticky sessions to canary for specific users.
+- **Shadow mirroring:** Copy 100% of traffic to canary without serving responses from it (risk-free testing).
+
+---
+
+## Promotion Procedure
+
+```bash
+# Step 1: Start with small canary (1 replica = 20% with 4 stable)
+kubectl apply -f stable-deployment.yml
+kubectl apply -f canary-deployment.yml
+
+# Step 2: Observe metrics for 30-60 minutes
+# - Error rate in canary vs stable
+# - P99 latency in canary vs stable
+# - Business metrics (conversion rate, etc.)
+
+# Step 3a: Promote — gradually shift traffic to canary
+kubectl scale deployment/nginx-canary --replicas=2 -n canary-demo    # 33%
+kubectl scale deployment/nginx-stable --replicas=3 -n canary-demo
+# Wait and observe...
+kubectl scale deployment/nginx-canary --replicas=4 -n canary-demo    # 50%
+kubectl scale deployment/nginx-stable --replicas=2 -n canary-demo
+# Wait and observe...
+kubectl scale deployment/nginx-canary --replicas=4 -n canary-demo    # 80%
+kubectl scale deployment/nginx-stable --replicas=1 -n canary-demo
+# Full promotion:
+kubectl scale deployment/nginx-stable --replicas=0 -n canary-demo
+# Now update stable to v2 and restart:
+kubectl set image deployment/nginx-stable nginx=nginx:1.25 -n canary-demo
+kubectl scale deployment/nginx-stable --replicas=4 -n canary-demo
+kubectl delete deployment/nginx-canary -n canary-demo
+
+# Step 3b: Rollback — if canary has problems
+kubectl delete deployment/nginx-canary -n canary-demo
+# Stable continues serving 100% of traffic — no other action needed
+```
+
+---
+
+## Rollback Procedure
+
+```bash
+# Simply delete the canary deployment.
+# The service selector routes only to the app label (shared by both),
+# so removing canary pods means 100% of traffic goes to stable immediately.
+kubectl delete deployment/nginx-canary -n canary-demo
+```
+
+Rollback is immediate and requires no restarts.
+
+---
+
+## When to Use Canary
+
+**Use when:**
+- You want to validate new code with real user traffic before full rollout.
+- Your change has a measurable impact you can observe in metrics (error rate, latency, conversion rate).
+- You have monitoring infrastructure to detect regressions quickly.
+- Risk aversion is high (critical service, revenue-impacting changes).
+
+**Do NOT use when:**
+- The change is a breaking API change (some users on v1, some on v2 = unpredictable behavior).
+- The change involves a non-backward-compatible database schema (split-brain between v1 and v2 clients writing to the same schema).
+- You don't have metrics to evaluate canary health (canary without metrics is just a slower rollout with unknown risk).
+
+---
+
+## Files in This Directory
+
+| File | Purpose |
+|---|---|
+| `namespace.yml` | Namespace for canary demo |
+| `stable-deployment.yml` | v1 stable deployment (4 replicas, 80% traffic) |
+| `canary-deployment.yml` | v2 canary deployment (1 replica, 20% traffic) |
+| `service.yml` | Service selecting both stable and canary pods |
+| `ingress.yml` | NGINX Ingress canary annotation approach (alternative to replica ratio) |

--- a/core/workloads/deployment-strategies/canary/canary-deployment.yml
+++ b/core/workloads/deployment-strategies/canary/canary-deployment.yml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-canary
+  namespace: canary-demo
+  labels:
+    app.kubernetes.io/name: nginx-canary-demo
+    app.kubernetes.io/instance: nginx-canary
+    app.kubernetes.io/version: "1.25"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+    track: canary
+  annotations:
+    kubernetes.io/description: "Canary v2 deployment (nginx:1.25) — serves ~20% of traffic with 1 replica alongside stable's 4 replicas. Monitor metrics before promoting."
+spec:
+  # 1 replica = 1/(4+1) = 20% of traffic when stable has 4 replicas.
+  # Adjust this value to control traffic percentage:
+  #   1 replica with 4 stable = 20%
+  #   1 replica with 9 stable = 10%
+  #   1 replica with 19 stable = 5%
+  # For sub-5% canary, use the Ingress annotation approach (see ingress.yml).
+  replicas: 1
+
+  revisionHistoryLimit: 5
+  minReadySeconds: 10
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx-canary-demo
+      app.kubernetes.io/instance: nginx-canary
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nginx-canary-demo
+        app.kubernetes.io/instance: nginx-canary
+        app.kubernetes.io/version: "1.25"
+        app.kubernetes.io/component: webserver
+        app.kubernetes.io/part-of: kube-platform
+        app.kubernetes.io/managed-by: kubectl
+        # track: canary allows operators to filter canary pod logs and metrics separately
+        # from stable pods — critical for measuring canary health independently.
+        # kubectl logs -n canary-demo -l track=canary
+        # kubectl top pods -n canary-demo -l track=canary
+        track: canary
+        version: v2
+      annotations:
+        kubernetes.io/description: "Canary v2 pod — receives ~20% of traffic. Delete this deployment to roll back to 100% stable."
+    spec:
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 60
+
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+
+      containers:
+      - name: nginx
+        # v2 image — the candidate being tested.
+        image: nginx:1.25
+        imagePullPolicy: IfNotPresent
+
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 5"]
+
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
+
+        volumeMounts:
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
+        - name: tmp
+          mountPath: /tmp
+
+      volumes:
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}

--- a/core/workloads/deployment-strategies/canary/ingress.yml
+++ b/core/workloads/deployment-strategies/canary/ingress.yml
@@ -1,0 +1,147 @@
+# NGINX Ingress Canary Approach — Alternative to Replica Ratio
+#
+# This file demonstrates the NGINX Ingress Controller's canary annotation feature,
+# which provides PRECISE percentage-based traffic splitting independent of replica count.
+#
+# PREREQUISITES:
+# 1. NGINX Ingress Controller must be installed:
+#    helm install ingress-nginx ingress-nginx/ingress-nginx
+# 2. The stable service (nginx-canary-demo) and canary service (nginx-canary) must exist.
+#    This requires two separate Services — one per deployment.
+#
+# HOW IT WORKS:
+# You create TWO Ingress resources for the SAME host and path:
+#   1. A primary (stable) Ingress — normal, no canary annotations
+#   2. A canary Ingress — annotated with canary=true and a weight or header rule
+# The NGINX Ingress Controller merges these and applies the routing rule.
+#
+# Apply with: kubectl apply -f ingress.yml
+# Toggle canary weight: kubectl annotate ingress nginx-canary-ingress \
+#   nginx.ingress.kubernetes.io/canary-weight="10" --overwrite -n canary-demo
+---
+# Service for canary pods only — needed for the ingress to route specifically to canary.
+# The service.yml in this directory selects BOTH stable and canary (for replica-ratio split).
+# This separate service selects ONLY canary pods (for ingress annotation split).
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-canary-only
+  namespace: canary-demo
+  labels:
+    app.kubernetes.io/name: nginx-canary-demo
+    app.kubernetes.io/instance: nginx-canary-only
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "Service for canary pods only — used by the canary Ingress for precise percentage routing"
+spec:
+  type: ClusterIP
+  selector:
+    # Select ONLY canary pods by using the track label
+    app.kubernetes.io/name: nginx-canary-demo
+    track: canary   # Only matches canary deployment pods (track: canary)
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+    protocol: TCP
+---
+# Primary (stable) Ingress — routes the majority of traffic to the stable service.
+# This is the baseline Ingress that exists even without a canary.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-stable-ingress
+  namespace: canary-demo
+  labels:
+    app.kubernetes.io/name: nginx-canary-demo
+    app.kubernetes.io/instance: nginx-stable-ingress
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "Primary (stable) Ingress for canary demo — routes traffic to stable v1 service"
+    # Specify which ingress controller handles this Ingress.
+    # Required when multiple ingress controllers are installed.
+    kubernetes.io/ingress.class: nginx
+    # Enable SSL redirect in production:
+    # nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: nginx-canary-demo.example.com   # Replace with your actual domain
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            # Points to the combined service (stable + canary pods) for baseline traffic.
+            # The canary Ingress will intercept its percentage before routing to this service.
+            name: nginx-canary-demo
+            port:
+              number: 80
+---
+# Canary Ingress — routes a precise percentage of traffic to the canary service.
+# NGINX Ingress Controller evaluates canary annotations and splits traffic before
+# forwarding to either the stable or canary backend.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-canary-ingress
+  namespace: canary-demo
+  labels:
+    app.kubernetes.io/name: nginx-canary-demo
+    app.kubernetes.io/instance: nginx-canary-ingress
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "Canary Ingress for canary demo — routes 20% of traffic to canary v2 service via NGINX annotation"
+    kubernetes.io/ingress.class: nginx
+
+    # CANARY ANNOTATIONS — These tell NGINX Ingress this is a canary route:
+
+    # Mark this Ingress as a canary (required — enables all other canary annotations)
+    nginx.ingress.kubernetes.io/canary: "true"
+
+    # OPTION 1: Weight-based canary (0-100 integer representing percentage)
+    # 20 = 20% of traffic goes to canary service, 80% to stable service.
+    # Change this value to adjust the split:
+    #   5  = 5% canary (early validation)
+    #   20 = 20% canary (broader validation)
+    #   50 = 50% canary (A/B test)
+    #   95 = 95% canary (almost full promotion)
+    nginx.ingress.kubernetes.io/canary-weight: "20"
+
+    # OPTION 2: Header-based canary (mutually exclusive approaches — comment out weight above)
+    # Route requests to canary if the request has this HTTP header set to 'always'.
+    # Other values of the header still go to stable. No header = stable.
+    # Use case: beta users opt in via header; all other users get stable.
+    # nginx.ingress.kubernetes.io/canary-by-header: "X-Canary"
+    # nginx.ingress.kubernetes.io/canary-by-header-value: "true"
+
+    # OPTION 3: Cookie-based canary
+    # Route requests to canary if this cookie is set to 'always'.
+    # Enables sticky canary sessions for logged-in users.
+    # nginx.ingress.kubernetes.io/canary-by-cookie: "canary_user"
+
+    # canary-weight-total: defines the total weight denominator (default 100).
+    # Useful for fine-grained control: set total=1000 and weight=50 for 5% canary.
+    nginx.ingress.kubernetes.io/canary-weight-total: "100"
+
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: nginx-canary-demo.example.com   # Must match the primary Ingress host exactly
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            # Points to the canary-only service (selects only canary pods)
+            name: nginx-canary-only
+            port:
+              number: 80

--- a/core/workloads/deployment-strategies/canary/namespace.yml
+++ b/core/workloads/deployment-strategies/canary/namespace.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: canary-demo
+  labels:
+    app.kubernetes.io/part-of: kube-platform
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+  annotations:
+    kubernetes.io/description: "Demo namespace for Canary deployment strategy — illustrates gradual traffic shifting between stable and canary versions"

--- a/core/workloads/deployment-strategies/canary/service.yml
+++ b/core/workloads/deployment-strategies/canary/service.yml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-canary-demo
+  namespace: canary-demo
+  labels:
+    app.kubernetes.io/name: nginx-canary-demo
+    app.kubernetes.io/instance: nginx-canary-demo
+    app.kubernetes.io/version: "1.24"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "Service for canary demo — selects both stable and canary pods via shared app label, distributing traffic ~80/20 by replica ratio"
+spec:
+  type: ClusterIP
+
+  # THE KEY TO KUBERNETES-NATIVE CANARY ROUTING:
+  # This selector matches pods from BOTH the stable and canary deployments.
+  # It selects only on 'app.kubernetes.io/name', which is shared by both.
+  # It does NOT select on 'track' (stable vs canary) or 'version' (v1 vs v2).
+  #
+  # With stable=4 replicas and canary=1 replica, the EndpointSlice will contain
+  # 5 pod IPs. kube-proxy distributes connections across all 5 equally:
+  #   ~80% go to stable pods (4 out of 5)
+  #   ~20% go to the canary pod (1 out of 5)
+  #
+  # This is probabilistic, not deterministic — a given user's requests may all
+  # go to stable or all to canary depending on random load balancing.
+  # For sticky canary (same user always hits canary), use a service mesh.
+  selector:
+    app.kubernetes.io/name: nginx-canary-demo
+    # Deliberately NOT including:
+    # - track: stable/canary   (would exclude one or the other)
+    # - version: v1/v2         (would exclude one or the other)
+    # - app.kubernetes.io/instance (different for stable vs canary)
+
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+    protocol: TCP

--- a/core/workloads/deployment-strategies/canary/stable-deployment.yml
+++ b/core/workloads/deployment-strategies/canary/stable-deployment.yml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-stable
+  namespace: canary-demo
+  labels:
+    app.kubernetes.io/name: nginx-canary-demo
+    app.kubernetes.io/instance: nginx-stable
+    app.kubernetes.io/version: "1.24"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+    track: stable
+  annotations:
+    kubernetes.io/description: "Stable v1 deployment (nginx:1.24) — serves 80% of traffic with 4 replicas. The canary deployment serves the remaining 20% with 1 replica."
+spec:
+  # 4 replicas = 4/(4+1) = 80% of traffic when canary has 1 replica.
+  # The traffic split is determined by the ratio of Ready pods across both deployments.
+  replicas: 4
+
+  revisionHistoryLimit: 5
+  minReadySeconds: 10
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx-canary-demo
+      app.kubernetes.io/instance: nginx-stable
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nginx-canary-demo
+        app.kubernetes.io/instance: nginx-stable
+        app.kubernetes.io/version: "1.24"
+        app.kubernetes.io/component: webserver
+        app.kubernetes.io/part-of: kube-platform
+        app.kubernetes.io/managed-by: kubectl
+        # THE KEY LABEL FOR CANARY TRAFFIC ROUTING:
+        # The service.yml selects on 'app.kubernetes.io/name: nginx-canary-demo' ONLY.
+        # Both stable (track: stable) and canary (track: canary) pods match this selector.
+        # The service routes traffic to ALL matching pods, splitting by replica count.
+        # The 'track' label is NOT in the service selector — it's for operational filtering.
+        track: stable
+        version: v1
+      annotations:
+        kubernetes.io/description: "Stable v1 pod — receives 80% of traffic"
+    spec:
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 60
+
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+
+      containers:
+      - name: nginx
+        image: nginx:1.24
+        imagePullPolicy: IfNotPresent
+
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 5"]
+
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
+
+        volumeMounts:
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
+        - name: tmp
+          mountPath: /tmp
+
+      volumes:
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}

--- a/core/workloads/deployment-strategies/comparison.md
+++ b/core/workloads/deployment-strategies/comparison.md
@@ -1,0 +1,147 @@
+# Deployment Strategies — Full Comparison
+
+## At a Glance
+
+| Attribute | Recreate | Rolling Update | Blue-Green | Canary |
+|---|---|---|---|---|
+| **Downtime** | Yes (brief) | None (with readinessProbe) | None | None |
+| **Rollback Speed** | Slow (redeploy) | Medium (rollout undo) | Instant (selector flip) | Fast (delete canary) |
+| **Resource Overhead** | None | Minimal (maxSurge pods) | 2x (full duplicate env) | Small (few extra pods) |
+| **Risk Level** | High (all users affected) | Low-Medium | Low | Lowest |
+| **Traffic Control** | None | None | All-or-nothing switch | Gradual (replica ratio or ingress weights) |
+| **Rollback Control** | None | `kubectl rollout undo` | Change service selector | Delete canary deployment |
+| **Complexity** | Very Low | Low | Medium | Medium-High |
+| **Environment Parity** | N/A | High | Highest (exact duplicate) | High |
+| **Schema Migration Compatible?** | Yes (downtime window) | Only if backward-compatible | Yes (run migration on green before switch) | Requires dual-write compatibility |
+
+---
+
+## Detailed Analysis
+
+### Recreate
+
+**How it works:** The Deployment controller scales the old ReplicaSet down to 0, waits for all old pods to terminate, then scales the new ReplicaSet up. All pods are on the new version simultaneously.
+
+**Downtime:** Yes — the time between the last old pod dying and the first new pod becoming Ready. Typically 10–60 seconds depending on startup time.
+
+**When to use:**
+- Development and staging environments where downtime is acceptable.
+- Applications that cannot run two versions simultaneously (e.g., schema changes that are incompatible with the old binary).
+- Singleton processes that must not overlap (e.g., a worker that holds an exclusive lock).
+
+**When NOT to use:** Production environments with SLO requirements. Any user-facing service.
+
+**Industry example:** Dev environments everywhere. Netflix uses recreate for internal tooling with no SLA.
+
+---
+
+### Rolling Update
+
+**How it works:** Kubernetes replaces pods one at a time (or in small batches). For each step, new pods are started and old pods are terminated only after new ones are Ready. `maxSurge` controls how many extra pods can exist during the rollout; `maxUnavailable` controls how many pods can be offline simultaneously.
+
+**Zero-downtime requirement:** The readinessProbe is **essential**. Without it, Kubernetes sends traffic to new pods before they are ready to serve requests, causing errors. The readinessProbe gates when a pod is added to the Service endpoint list.
+
+**Downtime:** None, if readinessProbe is correctly configured and `maxUnavailable: 0`.
+
+**When to use:**
+- The default choice for most stateless applications.
+- When you have 2+ replicas and a working readinessProbe.
+- When the new and old versions can run simultaneously (API-backward-compatible changes).
+
+**When NOT to use:**
+- Single-replica deployments (any `maxUnavailable > 0` causes downtime).
+- Schema changes incompatible with the running version.
+
+**Industry example:** Google uses rolling updates as the default for most services. Kubernetes itself uses rolling updates for its own control-plane components.
+
+---
+
+### Blue-Green
+
+**How it works:** Two complete, identical environments exist in parallel — "blue" (current production) and "green" (new version). Traffic is served entirely by blue. When green is tested and ready, a single change flips the Service selector from blue to green. Blue is kept as a hot standby for instant rollback.
+
+**Traffic switch:** Change the Service's label selector:
+```bash
+# Switch from v1 (blue) to v2 (green)
+kubectl patch service myapp -p '{"spec":{"selector":{"version":"v2"}}}'
+
+# Rollback — switch back to v1 (blue)
+kubectl patch service myapp -p '{"spec":{"selector":{"version":"v1"}}}'
+```
+
+**Downtime:** None — the selector change propagates in milliseconds via kube-proxy iptables updates.
+
+**Resource overhead:** 2x — you run a full duplicate of your application for the duration of the release window.
+
+**Rollback speed:** Instant — reverse the selector. No pod restarts required.
+
+**When to use:**
+- High-stakes releases where instant rollback is non-negotiable.
+- Applications with complex startup sequences that make rolling updates slow.
+- Schema migrations that need to be validated on green with production-like data before switching.
+- Compliance environments requiring zero-downtime with verifiable audit trails.
+
+**When NOT to use:**
+- Cost-sensitive environments (2x resource cost).
+- Stateful applications where two versions cannot share the same data layer.
+- Microservices with many dependencies (maintaining two complete environments is operationally complex).
+
+**Industry example:** Amazon uses blue-green for Route 53 weighted routing at the DNS level. Netflix uses it with Spinnaker for pipeline-controlled releases.
+
+---
+
+### Canary
+
+**How it works:** A small "canary" deployment runs alongside the stable deployment. Both are selected by the same Service, so traffic is split proportionally by replica count. With 4 stable replicas and 1 canary replica, ~20% of traffic hits the canary. After validating metrics (error rate, latency, business KPIs), the canary is promoted (scaled up) and the stable version is scaled down.
+
+**Traffic split approaches:**
+1. **Replica ratio (Kubernetes-native):** 4 stable + 1 canary = 20% canary. Simple but coarse-grained.
+2. **Ingress annotations (NGINX/Traefik):** Precise percentage control (e.g., 5%) regardless of replica count. See `canary/ingress.yml`.
+3. **Service Mesh (Istio/Linkerd):** Sub-1% routing, header-based routing, weighted virtual services. Most powerful.
+
+**Rollback:** Delete the canary Deployment. Traffic automatically returns 100% to stable.
+
+**Promote canary:**
+```bash
+# Promote: scale up canary to full capacity
+kubectl scale deployment myapp-canary --replicas=4 -n canary-demo
+# Then remove the stable deployment (or update it to v2 and retire canary)
+kubectl delete deployment myapp-stable -n canary-demo
+```
+
+**When to use:**
+- High-risk changes where you need real user validation before full rollout.
+- A/B testing (send specific user segments to canary).
+- Applications where you can define measurable success criteria (error rate < 0.1%, p99 latency < 200ms).
+
+**When NOT to use:**
+- Stateful operations where split-brain between v1 and v2 clients is dangerous.
+- Simple schema changes (all users should be on the same schema).
+- When you don't have metrics infrastructure to validate canary health.
+
+**Industry example:** Google's SRE book describes canary deployments as the standard for Search and Maps releases. Airbnb, LinkedIn, and Uber all use canary deployments with feature flags for risk-controlled rollouts.
+
+---
+
+## Choosing the Right Strategy for Your Situation
+
+| Situation | Recommended Strategy |
+|---|---|
+| Dev/staging, need fast iteration | Recreate |
+| Production, low-risk change, stateless app | Rolling Update |
+| Production, needs backward-compatible schema change | Rolling Update with carefully ordered migration |
+| Production, high-risk release, need instant rollback | Blue-Green |
+| Production, need user traffic validation | Canary |
+| Production, need to test with specific users (beta program) | Canary with header-based routing (Istio) |
+| High cost sensitivity | Rolling Update (minimal overhead) |
+| Regulatory/compliance requirement for zero-downtime | Blue-Green |
+| Breaking API change | Blue-Green (coordinate client migration) |
+
+## Resource Cost Summary
+
+```
+Recreate:       ████░░░░░░  1.0x (no extra pods)
+Rolling Update: █████░░░░░  1.1x (only 1-2 surge pods)
+Blue-Green:     ██████████  2.0x (full duplicate environment)
+Canary:         ██████░░░░  1.2x (a few extra canary pods)
+```

--- a/core/workloads/deployment-strategies/recreate/README.md
+++ b/core/workloads/deployment-strategies/recreate/README.md
@@ -1,0 +1,93 @@
+# Recreate Strategy
+
+## What Is It?
+
+The Recreate strategy is the simplest deployment strategy in Kubernetes. When you update a Deployment with `strategy.type: Recreate`, the controller:
+
+1. Scales the existing (old) ReplicaSet down to **0 replicas**.
+2. Waits for all old pods to terminate completely.
+3. Scales the new ReplicaSet up to the desired replica count.
+4. Waits for new pods to become Ready.
+
+There is a gap between steps 2 and 3 — during this time, **no pods are running** and the application is unavailable. This is the defining characteristic of the Recreate strategy: it always causes downtime.
+
+---
+
+## When Is Recreate Appropriate?
+
+**Development and staging environments** where:
+- Downtime is acceptable (no users are affected).
+- You want the simplest possible deployment mechanism.
+- You need to guarantee no two versions are running simultaneously (useful if your app crashes or misbehaves when two versions of the same process try to hold the same lock or port).
+
+**Applications with hard version exclusivity:**
+- Processes that acquire an exclusive lock that a new process cannot acquire until the old one releases it.
+- Applications where running v1 and v2 simultaneously causes data corruption.
+- Legacy applications that were never designed for concurrent multi-version operation.
+
+**Database schema changes that are NOT backward-compatible:**
+- If your migration drops a column that v1 reads from, you cannot run v1 and v2 simultaneously.
+- Recreate guarantees v1 is dead before v2 starts (which runs the migration).
+- In production, this scenario should be avoided by making schema changes backward-compatible (expand-contract pattern), but for dev/staging Recreate is fine.
+
+---
+
+## When Is Recreate NOT Appropriate?
+
+**Never use Recreate in production for user-facing services** unless:
+- You have a planned maintenance window in your SLA.
+- The service is internal with no external SLA.
+- You have verified the downtime window is acceptable to stakeholders.
+
+The downtime duration = time to terminate old pods + time for new pods to pass their startupProbe/readinessProbe. For applications with slow startup (JVM warmup, ML model loading), this can be several minutes.
+
+---
+
+## How to Apply
+
+```bash
+# Apply all resources in order (Namespace, Service, Deployment)
+kubectl apply -f recreate/
+
+# Verify the deployment
+kubectl rollout status deployment/nginx-recreate -n recreate-demo
+
+# Trigger a recreate by updating the image
+kubectl set image deployment/nginx-recreate nginx=nginx:1.25 -n recreate-demo
+
+# Watch pods — you will see all old pods Terminate before new pods start
+kubectl get pods -n recreate-demo -w
+```
+
+## Observing the Recreate Behavior
+
+```bash
+# In terminal 1: watch pods
+kubectl get pods -n recreate-demo -w
+
+# In terminal 2: trigger the update
+kubectl set image deployment/nginx-recreate nginx=nginx:1.25 -n recreate-demo
+
+# You will observe:
+# 1. Old pods enter Terminating state
+# 2. A period with 0 Running pods (the downtime window)
+# 3. New pods enter ContainerCreating, then Running state
+```
+
+## Comparison to Rolling Update
+
+```
+Recreate timeline:
+t=0   Old pods: [v1] [v1] [v1]
+t=5s  Old pods: [Term] [Term] [Term]
+t=10s No pods running ← DOWNTIME
+t=15s New pods: [Init] [Init] [Init]
+t=25s New pods: [v2] [v2] [v2]   ← Service restored
+
+Rolling Update timeline:
+t=0   Pods: [v1] [v1] [v1]
+t=5s  Pods: [v1] [v1] [v2-init]
+t=10s Pods: [v1] [v1-term] [v2]   ← Always serving
+t=15s Pods: [v1] [v2] [v2]
+t=20s Pods: [v2] [v2] [v2]
+```

--- a/core/workloads/deployment-strategies/recreate/deployment.yml
+++ b/core/workloads/deployment-strategies/recreate/deployment.yml
@@ -1,0 +1,143 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-recreate
+  namespace: recreate-demo
+  labels:
+    app.kubernetes.io/name: nginx-recreate
+    app.kubernetes.io/instance: nginx-recreate
+    app.kubernetes.io/version: "1.24"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "NGINX webserver using Recreate strategy — demonstrates downtime during version updates. Use nginx:1.25 to trigger recreation."
+spec:
+  # Only 2 replicas for the demo — enough to show the recreate pattern.
+  replicas: 2
+
+  # revisionHistoryLimit: how many old ReplicaSets to keep for rollback.
+  # 5 is a good production default — enough history to roll back through recent releases.
+  # Each old ReplicaSet takes minimal resources (just an object in etcd) but setting this
+  # too high clutters 'kubectl get replicasets'.
+  revisionHistoryLimit: 5
+
+  # minReadySeconds: a pod is considered 'available' only after being Ready for this long.
+  # Even with Recreate, this adds stability after the new pods start.
+  minReadySeconds: 10
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx-recreate
+      app.kubernetes.io/instance: nginx-recreate
+
+  strategy:
+    # Recreate: all old pods are terminated before new pods start.
+    # This guarantees no overlap between versions but causes downtime.
+    # To see the effect: change the image to nginx:1.25 and run 'kubectl apply'.
+    # Watch 'kubectl get pods -n recreate-demo -w' to observe the gap.
+    type: Recreate
+    # Note: rollingUpdate field is omitted — it only applies to type: RollingUpdate.
+    # Kubernetes will reject the manifest if rollingUpdate is specified with Recreate.
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nginx-recreate
+        app.kubernetes.io/instance: nginx-recreate
+        # version label tracks which image version this pod runs.
+        # Update to "1.25" when changing the image to nginx:1.25.
+        app.kubernetes.io/version: "1.24"
+        app.kubernetes.io/component: webserver
+        app.kubernetes.io/part-of: kube-platform
+        app.kubernetes.io/managed-by: kubectl
+      annotations:
+        kubernetes.io/description: "NGINX v1 pod (nginx:1.24) — to be recreated with v2 (nginx:1.25)"
+    spec:
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 60
+
+      securityContext:
+        runAsNonRoot: true
+        # NGINX official image: the master process runs as root to bind port 80,
+        # but worker processes run as 'nginx' user (UID 101) by default.
+        # For runAsNonRoot: true to work, we must use a non-privileged port (8080).
+        # The nginx:1.24 image's default config uses port 80 (requires root).
+        # In production, use a custom nginx.conf with 'listen 8080' and this security context.
+        # For simplicity in this demo, we document this but use UID 101 which still
+        # satisfies the PSA 'baseline' policy on the namespace.
+        runAsUser: 101    # nginx user in the official nginx image
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+
+      containers:
+      - name: nginx
+        # v1 image — change to nginx:1.25 to trigger the Recreate strategy.
+        image: nginx:1.24
+        imagePullPolicy: IfNotPresent
+
+        ports:
+        - name: http
+          containerPort: 8080   # Non-privileged port — required for runAsNonRoot
+          protocol: TCP
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+
+        lifecycle:
+          preStop:
+            exec:
+              # Give NGINX time to finish processing in-flight requests before shutdown.
+              # With Recreate, this is less critical (we want downtime to be brief),
+              # but it's still good practice to drain gracefully.
+              command: ["/bin/sh", "-c", "sleep 5"]
+
+        # readinessProbe determines when a pod is added to the Service endpoint list.
+        # With Recreate, readiness still matters — minReadySeconds requires the pod
+        # to be Ready for N seconds before the deployment is considered 'available'.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
+
+        volumeMounts:
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
+        - name: tmp
+          mountPath: /tmp
+
+      volumes:
+      # NGINX needs to write to /var/cache/nginx and /var/run when readOnlyRootFilesystem: true.
+      # We provide emptyDir volumes for these paths.
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}

--- a/core/workloads/deployment-strategies/recreate/namespace.yml
+++ b/core/workloads/deployment-strategies/recreate/namespace.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: recreate-demo
+  labels:
+    app.kubernetes.io/part-of: kube-platform
+    # Using 'baseline' PSS for demo namespaces — less restrictive than 'restricted'
+    # but still prevents privilege escalation and host namespace sharing.
+    # Production databases and services should use 'restricted'.
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+  annotations:
+    kubernetes.io/description: "Demo namespace for the Recreate deployment strategy — illustrates downtime during redeployment"

--- a/core/workloads/deployment-strategies/recreate/service.yml
+++ b/core/workloads/deployment-strategies/recreate/service.yml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-recreate
+  namespace: recreate-demo
+  labels:
+    app.kubernetes.io/name: nginx-recreate
+    app.kubernetes.io/instance: nginx-recreate
+    app.kubernetes.io/version: "1.24"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "ClusterIP service for nginx-recreate — during Recreate rollout, this service will return connection refused while pods are terminated"
+spec:
+  # ClusterIP is the default service type — a stable virtual IP within the cluster.
+  # During the Recreate rollout, the endpoint slice for this service will temporarily
+  # have zero endpoints (between old pod termination and new pod readiness).
+  # This is the observable "downtime window" of the Recreate strategy.
+  type: ClusterIP
+
+  selector:
+    app.kubernetes.io/name: nginx-recreate
+    app.kubernetes.io/instance: nginx-recreate
+
+  ports:
+  - name: http
+    port: 80          # External port that clients connect to
+    targetPort: 8080  # Must match the container's containerPort
+    protocol: TCP

--- a/core/workloads/deployment-strategies/rolling-update/README.md
+++ b/core/workloads/deployment-strategies/rolling-update/README.md
@@ -1,0 +1,112 @@
+# Rolling Update Strategy
+
+## What Is It?
+
+Rolling Update is the **default Kubernetes deployment strategy**. It replaces pods incrementally — a few old pods are taken down and new pods are brought up at a time, ensuring the application always has some pods running and serving traffic throughout the entire update process.
+
+When done correctly (with a readinessProbe and `maxUnavailable: 0`), Rolling Update achieves **true zero-downtime deployment**.
+
+---
+
+## Key Parameters
+
+```yaml
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1          # How many EXTRA pods above desired count can exist during rollout
+    maxUnavailable: 0    # How many pods can be UNAVAILABLE (below desired count) during rollout
+```
+
+### maxSurge
+
+The maximum number of pods that can be scheduled ABOVE the desired replica count during an update. With `replicas: 4` and `maxSurge: 1`, up to 5 pods can run simultaneously during the rollout.
+
+- `maxSurge: 0` — No extra pods. Old pods are killed before new ones start. Slower but uses fewer resources.
+- `maxSurge: 1` — One extra pod at a time. Balanced approach.
+- `maxSurge: 25%` — Percentage of desired replicas. `replicas: 4, maxSurge: 25%` = 1 extra pod.
+- `maxSurge: 100%` — All new pods start before any old ones are killed (surge-heavy rollout, fast but 2x resources temporarily).
+
+### maxUnavailable
+
+The maximum number of pods that can be UNAVAILABLE (not Ready) during an update.
+
+- `maxUnavailable: 0` — **Zero-downtime guarantee.** No pod is taken down until a replacement is Ready. This requires `maxSurge > 0` (otherwise the rollout would stall).
+- `maxUnavailable: 1` — One pod can be offline at a time. Slightly faster rollout, small risk of reduced capacity.
+- `maxUnavailable: 25%` — Up to 25% of pods can be offline simultaneously. Fast rollout, significant capacity reduction.
+
+**Production recommendation:** `maxSurge: 1, maxUnavailable: 0` — guarantees zero downtime while limiting resource overhead to one extra pod.
+
+---
+
+## Why readinessProbe Is Critical for Zero Downtime
+
+Without a readinessProbe, Kubernetes adds a new pod to the Service endpoint list the moment the pod's containers are **started** — not when they are **ready to serve traffic**. If your application takes 15 seconds to initialize (load config, warm up caches, establish DB connections), traffic sent to the pod during those 15 seconds will fail.
+
+With a readinessProbe:
+1. Kubernetes starts the new pod.
+2. The readinessProbe runs repeatedly. The pod is NOT added to Service endpoints yet.
+3. When the readinessProbe succeeds, the pod is marked Ready and added to Service endpoints.
+4. Only then does the controller start terminating an old pod.
+
+This is the mechanism that makes zero-downtime rolling updates possible. **If your readinessProbe is wrong (too lenient, wrong path, wrong port), you will have downtime during rolling updates.**
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /healthz   # Must return 2xx only when the app is truly ready to serve traffic
+    port: 8080
+  initialDelaySeconds: 5    # Wait this long before first check (let app start)
+  periodSeconds: 5          # Check every 5 seconds
+  failureThreshold: 3       # 3 consecutive failures = mark pod not ready
+  successThreshold: 1       # 1 success = mark pod ready
+```
+
+> **Interview Callout:** "How does Kubernetes achieve zero-downtime rolling updates?" — The readinessProbe gates when a new pod receives traffic. With `maxUnavailable: 0`, Kubernetes guarantees that at least N replicas are always Ready. The controller only terminates an old pod AFTER a new pod passes its readinessProbe and becomes Ready.
+
+---
+
+## Rollback
+
+```bash
+# View rollout history
+kubectl rollout history deployment/nginx-rolling -n rolling-demo
+
+# Roll back to the previous version
+kubectl rollout undo deployment/nginx-rolling -n rolling-demo
+
+# Roll back to a specific revision
+kubectl rollout undo deployment/nginx-rolling -n rolling-demo --to-revision=2
+```
+
+The rollback itself is a Rolling Update in reverse — it uses the same `maxSurge` and `maxUnavailable` parameters, so it is also zero-downtime (assuming the old version's pods pass their readinessProbe).
+
+---
+
+## How to Apply
+
+```bash
+kubectl apply -f rolling-update/
+
+# Watch the rollout
+kubectl rollout status deployment/nginx-rolling -n rolling-demo
+
+# Trigger an update (change image)
+kubectl set image deployment/nginx-rolling nginx=nginx:1.25 -n rolling-demo
+
+# Watch pods — you will see new pods start before old pods are terminated
+kubectl get pods -n rolling-demo -w
+```
+
+## Pause and Resume a Rollout
+
+```bash
+# Pause mid-rollout (e.g., to make additional changes before continuing)
+kubectl rollout pause deployment/nginx-rolling -n rolling-demo
+
+# Make additional changes while paused
+kubectl set env deployment/nginx-rolling APP_VERSION=v2 -n rolling-demo
+
+# Resume — all paused changes are applied together as one rollout
+kubectl rollout resume deployment/nginx-rolling -n rolling-demo
+```

--- a/core/workloads/deployment-strategies/rolling-update/deployment.yml
+++ b/core/workloads/deployment-strategies/rolling-update/deployment.yml
@@ -1,0 +1,163 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-rolling
+  namespace: rolling-demo
+  labels:
+    app.kubernetes.io/name: nginx-rolling
+    app.kubernetes.io/instance: nginx-rolling
+    app.kubernetes.io/version: "1.24"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "NGINX webserver using Rolling Update strategy — zero-downtime deployments with maxSurge:1 maxUnavailable:0"
+spec:
+  # 4 replicas provides enough capacity for the rolling update to be visible:
+  # With maxSurge:1, up to 5 pods run during rollout.
+  # With maxUnavailable:0, at least 4 pods are always Ready (no capacity loss).
+  replicas: 4
+
+  revisionHistoryLimit: 5
+
+  # minReadySeconds: a new pod must be continuously Ready for this many seconds before
+  # the controller considers it 'available'. This adds a stabilization buffer — if your
+  # app has a brief startup period where it is Ready but then crashes (init flip-flopping),
+  # minReadySeconds catches this and slows the rollout to avoid cascading failures.
+  minReadySeconds: 10
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx-rolling
+      app.kubernetes.io/instance: nginx-rolling
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # maxSurge: 1 — allow 1 extra pod above the desired 4 during rollout.
+      # This enables the "start new pod, then stop old pod" sequence that makes
+      # zero-downtime possible. Without surge, you would need maxUnavailable > 0.
+      maxSurge: 1
+
+      # maxUnavailable: 0 — ZERO-DOWNTIME GUARANTEE.
+      # No pod is terminated until a replacement is Ready.
+      # The readinessProbe below is what makes this guarantee meaningful —
+      # without it, "Ready" just means the container started, not that it serves traffic.
+      #
+      # CRITICAL: maxSurge and maxUnavailable cannot BOTH be 0 — the rollout would be
+      # unable to make progress (can't create new pods, can't delete old pods).
+      # Kubernetes validates this and rejects such configurations.
+      maxUnavailable: 0
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nginx-rolling
+        app.kubernetes.io/instance: nginx-rolling
+        app.kubernetes.io/version: "1.24"
+        app.kubernetes.io/component: webserver
+        app.kubernetes.io/part-of: kube-platform
+        app.kubernetes.io/managed-by: kubectl
+      annotations:
+        kubernetes.io/description: "NGINX v1 pod (nginx:1.24) — update image to nginx:1.25 to trigger rolling update"
+    spec:
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 60
+
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101    # nginx user
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+
+      containers:
+      - name: nginx
+        image: nginx:1.24
+        imagePullPolicy: IfNotPresent
+
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+
+        lifecycle:
+          preStop:
+            exec:
+              # WHY THIS MATTERS FOR ROLLING UPDATES:
+              # When Kubernetes decides to terminate a pod (during rollout), it:
+              # 1. Removes the pod from Service endpoints (stops new connections)
+              # 2. Runs the preStop hook
+              # 3. Sends SIGTERM to the container
+              # 4. Waits terminationGracePeriodSeconds for the process to exit
+              #
+              # The 'sleep 5' here creates a brief overlap where the pod is removed
+              # from endpoints BEFORE NGINX receives SIGTERM. This prevents the rare
+              # race condition where:
+              #   - kube-proxy removes the pod from iptables rules (async, takes 1-2s)
+              #   - New requests still arrive at the pod during that 1-2s window
+              #   - NGINX has already shut down and returns connection reset
+              # The sleep gives kube-proxy time to fully propagate the endpoint removal
+              # before NGINX starts refusing connections.
+              command: ["/bin/sh", "-c", "sleep 5"]
+
+        # THE MOST IMPORTANT PROBE FOR ZERO-DOWNTIME ROLLING UPDATES.
+        # This probe gates when a pod joins the Service endpoint list.
+        # Kubernetes will NOT terminate an old pod until this probe succeeds on the new pod.
+        # Make sure this probe accurately reflects when your app is ready to serve traffic:
+        #   - DB connections established
+        #   - Config loaded
+        #   - Caches warmed
+        #   - Health dependencies satisfied
+        # A probe that returns 200 too early (before the app is truly ready) breaks
+        # the zero-downtime guarantee.
+        readinessProbe:
+          httpGet:
+            path: /         # In production: use /readyz or /healthz/ready endpoint
+            port: 8080
+          initialDelaySeconds: 5    # Wait for NGINX to start before first check
+          periodSeconds: 5          # Check every 5 seconds
+          timeoutSeconds: 3         # Probe times out after 3 seconds (network latency buffer)
+          failureThreshold: 3       # 3 consecutive failures = remove from endpoints (not a restart)
+          successThreshold: 1       # 1 success = add to endpoints
+
+        # livenessProbe triggers a restart if the container is alive but not functioning.
+        # This is SEPARATE from readiness — a pod can be live but not ready (under load,
+        # waiting for dependencies) and should stay running but not receive traffic.
+        livenessProbe:
+          httpGet:
+            path: /         # In production: use /livez or /healthz/live endpoint
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3   # 3 consecutive failures = restart the container
+
+        volumeMounts:
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
+        - name: tmp
+          mountPath: /tmp
+
+      volumes:
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}

--- a/core/workloads/deployment-strategies/rolling-update/namespace.yml
+++ b/core/workloads/deployment-strategies/rolling-update/namespace.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rolling-demo
+  labels:
+    app.kubernetes.io/part-of: kube-platform
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+  annotations:
+    kubernetes.io/description: "Demo namespace for the Rolling Update deployment strategy — zero-downtime incremental pod replacement"

--- a/core/workloads/deployment-strategies/rolling-update/service.yml
+++ b/core/workloads/deployment-strategies/rolling-update/service.yml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-rolling
+  namespace: rolling-demo
+  labels:
+    app.kubernetes.io/name: nginx-rolling
+    app.kubernetes.io/instance: nginx-rolling
+    app.kubernetes.io/version: "1.24"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "ClusterIP service for nginx-rolling — during Rolling Update, this service always has healthy endpoints (zero-downtime guarantee with readinessProbe + maxUnavailable:0)"
+spec:
+  type: ClusterIP
+
+  selector:
+    # IMPORTANT: The selector does NOT include a 'version' label.
+    # This means the service selects pods from ALL versions simultaneously during the rollout.
+    # During a rolling update, some pods run nginx:1.24 and some run nginx:1.25,
+    # and the service routes traffic to all of them (all that are Ready).
+    # This is intentional — it means clients seamlessly hit either version during the rollout.
+    # Your application must be able to handle serving from mixed versions gracefully
+    # (i.e., v1 and v2 APIs must be compatible — no breaking changes in a rolling update).
+    app.kubernetes.io/name: nginx-rolling
+    app.kubernetes.io/instance: nginx-rolling
+
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+    protocol: TCP


### PR DESCRIPTION
## Summary
- Add `comparison.md` — strategy selection table: downtime, capacity cost, rollback speed, implementation complexity
- Add **Recreate** — complete namespace + deployment + service with `strategy.type: Recreate`
- Add **RollingUpdate** — `maxSurge:1 maxUnavailable:0` with PDB and anti-affinity
- Add **Blue-Green** — parallel blue/green Deployments; service selector patch for instant traffic switch
- Add **Canary** — stable (9 replicas) + canary (1 replica) with nginx `canary-weight` Ingress annotation for 10% traffic split; README covers promotion and weight adjustment

Each strategy has an isolated namespace, service, and dedicated README with operational commands.

## Issues referenced
Closes #98, relates to #89

## Test plan
- [ ] `kubectl apply -f blue-green/` then `kubectl patch svc` switches traffic to green version
- [ ] Canary ingress routes ~10% of requests to canary pod (`kubectl rollout status` + curl loop test)
- [ ] `kubectl rollout undo` on rolling-update reverts to previous ReplicaSet