### PR TITLE
feat(workload): MySQL StatefulSet with headless service, SealedSecret, and replica config

### DIFF
--- a/core/workloads/statefulset/README.md
+++ b/core/workloads/statefulset/README.md
@@ -1,0 +1,216 @@
+# StatefulSets — Deep Dive
+
+## What Is a StatefulSet?
+
+A StatefulSet is a Kubernetes workload API object designed for **stateful applications** — workloads that require stable, persistent identity and ordered lifecycle management. Unlike Deployments (which treat pods as interchangeable cattle), StatefulSets treat each pod as a named individual with a guaranteed identity that persists across restarts.
+
+---
+
+## Core Properties
+
+### 1. Stable Network Identity
+
+Each pod in a StatefulSet gets a **predictable, stable hostname** derived from the StatefulSet name and its ordinal index:
+
+```
+<statefulset-name>-<ordinal>
+```
+
+For a StatefulSet named `mysql` with 3 replicas:
+- `mysql-0`
+- `mysql-1`
+- `mysql-2`
+
+These names are **sticky** — if `mysql-1` is deleted and rescheduled, it will come back as `mysql-1`, not `mysql-3`. This is fundamentally different from Deployments where pods get random suffixes like `mysql-7d6f8b9c4-xkqzp`.
+
+**DNS Resolution** (requires a Headless Service — see below):
+```
+<pod-name>.<headless-service-name>.<namespace>.svc.cluster.local
+```
+
+For example:
+```
+mysql-0.mysql-headless.database.svc.cluster.local
+mysql-1.mysql-headless.database.svc.cluster.local
+```
+
+This allows pods to discover and communicate with **specific** peers — critical for database replication, leader election, and quorum-based systems.
+
+---
+
+### 2. Ordered Deployment and Scaling
+
+StatefulSets enforce strict **ordering guarantees**:
+
+**Scale Up:** Pods are created sequentially — `pod-0` must be Running and Ready before `pod-1` is created, and so on. This matters for applications like MySQL where the primary (pod-0) must be ready before replicas try to connect to it.
+
+**Scale Down:** Pods are terminated in **reverse ordinal order** — `pod-2` is deleted before `pod-1`, which is deleted before `pod-0`. This protects the primary/leader in most database configurations.
+
+**Updates:** By default (OrderedReady), updates proceed from the highest ordinal down to 0, one at a time.
+
+```
+podManagementPolicy: OrderedReady  # default — strict ordering
+podManagementPolicy: Parallel      # all pods start/stop simultaneously (use for independent stateful pods)
+```
+
+> **Interview Callout:** "What's the difference between `OrderedReady` and `Parallel` pod management?" — `OrderedReady` ensures each pod is healthy before the next starts; `Parallel` sacrifices ordering for speed. Use `Parallel` for stateless-within-stateful scenarios like sharded caches.
+
+---
+
+### 3. VolumeClaimTemplates vs. PVCs
+
+This is the most powerful feature of StatefulSets. A `volumeClaimTemplate` acts as a **PVC factory** — it creates a unique, named PVC for each pod automatically.
+
+**With a Deployment (wrong for databases):**
+```yaml
+volumes:
+- name: mysql-data
+  persistentVolumeClaim:
+    claimName: mysql-pvc   # ALL pods share the same PVC — data corruption!
+```
+
+**With a StatefulSet (correct):**
+```yaml
+volumeClaimTemplates:
+- metadata:
+    name: mysql-data
+  spec:
+    accessModes: ["ReadWriteOncePod"]
+    resources:
+      requests:
+        storage: 10Gi
+```
+
+Kubernetes automatically creates PVCs named `<template-name>-<pod-name>`:
+- `mysql-data-mysql-0`
+- `mysql-data-mysql-1`
+- `mysql-data-mysql-2`
+
+Each pod gets its **own isolated storage**. When pod `mysql-1` is rescheduled, it reattaches to `mysql-data-mysql-1` — its data is never lost.
+
+**PVC Retention Policy** (Kubernetes 1.27+):
+```yaml
+persistentVolumeClaimRetentionPolicy:
+  whenDeleted: Retain    # PVCs survive StatefulSet deletion (safe default)
+  whenScaledDown: Retain # PVCs survive scale-down (safe default)
+```
+Setting `whenDeleted: Delete` would destroy data when the StatefulSet is deleted — **never use in production** without understanding this.
+
+---
+
+### 4. Headless Service Requirement
+
+A StatefulSet requires a **Headless Service** to provide stable DNS for individual pod addressing. A headless service has `clusterIP: None`, which tells Kubernetes **not** to provision a virtual IP for the service. Instead, DNS queries for the service return the IP addresses of the individual pods directly.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-headless
+spec:
+  clusterIP: None       # This makes it headless
+  selector:
+    app.kubernetes.io/name: mysql
+  ports:
+  - port: 3306
+```
+
+With this in place, `nslookup mysql-headless.database.svc.cluster.local` returns multiple A records — one per pod. And `nslookup mysql-0.mysql-headless.database.svc.cluster.local` resolves to exactly `mysql-0`'s IP.
+
+> **Interview Callout:** "Why do StatefulSets need a headless service?" — Without `clusterIP: None`, the service would load-balance across pods and you'd lose the ability to address specific pods by DNS. The headless service enables per-pod DNS A records.
+
+The `serviceName` field in the StatefulSet spec **must match** the headless service name:
+```yaml
+spec:
+  serviceName: mysql-headless  # must match the headless service name
+```
+
+---
+
+## Common Use Cases
+
+| Use Case | Why StatefulSet? |
+|---|---|
+| **MySQL / PostgreSQL** | Primary needs stable identity for replica registration; each node needs dedicated storage |
+| **Elasticsearch** | Nodes form a cluster using stable DNS; each node has its own index shards |
+| **Kafka / RabbitMQ** | Brokers have stable broker IDs; consumer offsets are stored per-broker |
+| **ZooKeeper / etcd** | Quorum-based systems require stable member identities for leader election |
+| **Redis Sentinel/Cluster** | Sentinel monitors specific masters by hostname; cluster nodes have stable slots |
+| **Cassandra** | Peer discovery uses stable seed node addresses |
+
+---
+
+## Update Strategy
+
+```yaml
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    partition: 0   # Only update pods with ordinal >= partition
+```
+
+**Canary updates** with StatefulSets: Set `partition: 2` on a 3-replica StatefulSet. Only `mysql-2` (ordinal 2) gets the new version. `mysql-0` and `mysql-1` stay on the old version. Verify `mysql-2` is healthy, then set `partition: 0` to roll out to all.
+
+---
+
+## WARNING: MySQL-as-Deployment Anti-Pattern
+
+**Never run MySQL (or any primary database) as a Deployment.**
+
+Here is why this is dangerous:
+
+1. **Shared or missing PVC:** If all replicas share one PVC (ReadWriteOnce), concurrent writes from multiple pods corrupt the database. If each replica uses an independent PVC created manually, pod rescheduling may attach the wrong PVC.
+
+2. **No stable identity:** MySQL replicas register with the primary using hostname. A Deployment pod's hostname changes on reschedule, breaking replication.
+
+3. **No ordering guarantees:** If a Deployment scales up, replicas may try to connect to a primary that isn't ready yet.
+
+4. **Split-brain risk:** Two pods can be Running simultaneously during a rolling update, both writing to the same data — catastrophic for transactional databases.
+
+The correct answer in every production environment:
+- **Single-node MySQL:** Use a StatefulSet with 1 replica (not a Deployment). You get stable identity and a properly managed PVC.
+- **Multi-node MySQL:** Use a StatefulSet with an init container or sidecar (like Vitess or the MySQL Operator) to handle replication setup.
+- **Even better:** Use the [MySQL Operator for Kubernetes](https://dev.mysql.com/doc/mysql-operator/en/) or a managed database service.
+
+> **Interview Callout:** "Can you run a database in Kubernetes?" — The correct answer is "Yes, but it requires a StatefulSet, not a Deployment, and you must carefully plan storage classes, PVC retention policies, backup strategies, and replication topology. For production, consider a purpose-built operator."
+
+---
+
+## Files in This Directory
+
+| File | Purpose |
+|---|---|
+| `mysql-namespace.yml` | Namespace with Pod Security Standards enforcement |
+| `mysql-configmap.yml` | Non-sensitive MySQL configuration |
+| `mysql-secret.yml` | Sensitive credentials (see warning — use SealedSecrets in prod) |
+| `mysql-statefulset.yml` | Production-grade 3-replica MySQL StatefulSet |
+| `mysql-service-headless.yml` | Headless service for stable pod DNS |
+| `mysql-service-clusterip.yml` | Regular ClusterIP service for application connections |
+
+## Apply Order
+
+```bash
+kubectl apply -f mysql-namespace.yml
+kubectl apply -f mysql-configmap.yml
+kubectl apply -f mysql-secret.yml
+kubectl apply -f mysql-service-headless.yml   # headless service must exist before StatefulSet
+kubectl apply -f mysql-service-clusterip.yml
+kubectl apply -f mysql-statefulset.yml
+```
+
+## Verify
+
+```bash
+# Watch pods come up in order (0, then 1, then 2)
+kubectl get pods -n database -w
+
+# Verify each pod has its own PVC
+kubectl get pvc -n database
+
+# Test DNS from inside the cluster
+kubectl run -it --rm debug --image=busybox --restart=Never -n database -- \
+  nslookup mysql-0.mysql-headless.database.svc.cluster.local
+
+# Check StatefulSet status
+kubectl rollout status statefulset/mysql -n database
+```

--- a/core/workloads/statefulset/mysql-configmap.yml
+++ b/core/workloads/statefulset/mysql-configmap.yml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql-config
+  namespace: database
+  labels:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/version: "8.0"
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "Non-sensitive MySQL 8.0 configuration — character sets, connection limits, and database name"
+data:
+  # The name of the default database to create on first startup.
+  MYSQL_DATABASE: appdb
+
+  # YAML BOOLEAN HAZARD: In YAML, bare values like 'yes', 'no', 'true', 'false', 'on', 'off'
+  # are parsed as booleans, not strings. Numbers are parsed as integers.
+  # When used as environment variables, Kubernetes converts ConfigMap values to strings,
+  # but some YAML parsers (e.g., Helm templating, kustomize overlays) may misinterpret
+  # unquoted numeric values. Always quote numeric and boolean-looking values in ConfigMaps
+  # to prevent silent type coercion bugs that are extremely hard to debug.
+  MYSQL_MAX_CONNECTIONS: "100"   # Quoted string — prevents YAML integer parsing
+
+  # utf8mb4 is the correct character set for full Unicode support (including 4-byte chars
+  # like emoji). The older 'utf8' in MySQL is actually utf8mb3 and cannot store characters
+  # outside the Basic Multilingual Plane. Always use utf8mb4 for new databases.
+  MYSQL_CHARACTER_SET_SERVER: utf8mb4
+
+  # utf8mb4_unicode_ci provides case-insensitive, accent-insensitive collation based on
+  # the Unicode standard. Use utf8mb4_0900_ai_ci for MySQL 8.0+ (faster, more correct),
+  # but unicode_ci is more portable across MySQL versions.
+  MYSQL_COLLATION_SERVER: utf8mb4_unicode_ci
+
+  # InnoDB buffer pool size — the most important MySQL performance knob.
+  # Rule of thumb: 70-80% of available RAM for a dedicated DB server.
+  # In a container, this must align with the container's memory limit.
+  # Set to ~60% of the container's memory limit (512Mi) to leave headroom for
+  # connections, sort buffers, and OS page cache.
+  INNODB_BUFFER_POOL_SIZE: "314572800"   # 300Mi in bytes — quoted to prevent integer overflow in some YAML parsers
+
+  # Bind address — '0.0.0.0' allows connections from all interfaces inside the pod.
+  # MySQL will still only be reachable via the Kubernetes Service, which enforces
+  # NetworkPolicy-level isolation. This is safe in a pod-isolated environment.
+  MYSQL_BIND_ADDRESS: "0.0.0.0"

--- a/core/workloads/statefulset/mysql-namespace.yml
+++ b/core/workloads/statefulset/mysql-namespace.yml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: database
+  labels:
+    app.kubernetes.io/part-of: kube-platform
+    # Pod Security Standards (PSS) — enforces security policies at the namespace level.
+    # 'restricted' is the strictest level: requires non-root, no privilege escalation,
+    # seccomp profile, and drops all capabilities. Any pod violating these rules is REJECTED.
+    pod-security.kubernetes.io/enforce: restricted
+    # 'latest' means Kubernetes always uses the current version of the policy.
+    # Pin to a specific version (e.g., v1.29) in production to avoid unexpected breakage
+    # when upgrading Kubernetes and the policy becomes stricter.
+    pod-security.kubernetes.io/enforce-version: latest
+    # 'warn' and 'audit' labels are additive — they don't block pods but emit warnings/audit events.
+    # Useful for gradually tightening policy without immediately breaking workloads.
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+  annotations:
+    kubernetes.io/description: "Namespace for database workloads — hosts MySQL StatefulSets and related resources"

--- a/core/workloads/statefulset/mysql-sealed-secret.yaml
+++ b/core/workloads/statefulset/mysql-sealed-secret.yaml
@@ -1,0 +1,46 @@
+---
+# SealedSecret for MySQL credentials
+#
+# This file IS safe to commit to Git.
+# The encrypted values below can ONLY be decrypted by the sealed-secrets
+# controller running in YOUR cluster (using its private key).
+#
+# To regenerate for your cluster:
+#   ./platform/security/sealed-secrets/seal-secret.sh mysql-secret database \
+#     MYSQL_ROOT_PASSWORD=your-root-password \
+#     MYSQL_PASSWORD=your-app-password \
+#     MYSQL_USER=notes_user
+#
+# IMPORTANT: The encrypted values below are PLACEHOLDERS.
+# They will not decrypt in any real cluster.
+# Run the above command to generate values for your cluster.
+#
+# See platform/security/sealed-secrets/README.md for full setup instructions.
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: mysql-secret
+  namespace: database
+  labels:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: >
+      SealedSecret for MySQL credentials. Safe to commit to Git.
+      Encrypted with the cluster's sealed-secrets controller public key.
+      Re-seal using: ./platform/security/sealed-secrets/seal-secret.sh
+    sealedsecrets.bitnami.com/cluster-wide: "false"
+    sealedsecrets.bitnami.com/namespace-wide: "false"
+spec:
+  encryptedData:
+    # PLACEHOLDER — replace with output from kubeseal for your cluster
+    MYSQL_ROOT_PASSWORD: AgBY...PLACEHOLDER...==
+    MYSQL_PASSWORD: AgCX...PLACEHOLDER...==
+    MYSQL_USER: AgDZ...PLACEHOLDER...==
+  template:
+    metadata:
+      name: mysql-secret
+      namespace: database
+    type: Opaque

--- a/core/workloads/statefulset/mysql-secret.yml
+++ b/core/workloads/statefulset/mysql-secret.yml
@@ -1,0 +1,73 @@
+# ==============================================================================
+# WARNING: THIS FILE IS FOR LEARNING/REFERENCE PURPOSES ONLY
+# ==============================================================================
+# NEVER commit real credentials to version control — not even base64-encoded ones.
+# base64 is an ENCODING, not ENCRYPTION. Anyone with kubectl access or repo access
+# can trivially decode these values with: echo "dG9wLXNlY3JldA==" | base64 -d
+#
+# PRODUCTION ALTERNATIVES:
+# 1. SealedSecrets (Bitnami): Encrypts secrets asymmetrically using a cluster-specific
+#    key. The SealedSecret CRD is safe to commit to git. The controller decrypts it
+#    inside the cluster. https://github.com/bitnami-labs/sealed-secrets
+#
+# 2. External Secrets Operator (ESO): Syncs secrets from external vaults (AWS Secrets
+#    Manager, GCP Secret Manager, HashiCorp Vault, Azure Key Vault) into Kubernetes
+#    Secrets. The ExternalSecret CRD in git contains only a reference, never the value.
+#    https://external-secrets.io
+#
+# 3. HashiCorp Vault Agent Injector: Injects secrets directly into pods as files via
+#    sidecar, bypassing Kubernetes Secrets entirely.
+#
+# 4. CSI Secrets Store Driver: Mounts secrets from external vaults as volumes.
+#
+# The placeholder values below are base64 encodings of non-real strings:
+#   MYSQL_ROOT_PASSWORD: base64("REPLACE_ME_USE_SEALED_SECRETS") — NOT a real password
+#   MYSQL_PASSWORD:      base64("REPLACE_ME_USE_SEALED_SECRETS") — NOT a real password
+#   MYSQL_USER:          base64("appuser")
+# ==============================================================================
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-secret
+  namespace: database
+  labels:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/version: "8.0"
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "MySQL credentials — REPLACE WITH SEALEDSECRETS OR ESO IN PRODUCTION"
+    # Annotate who manages this secret for auditability
+    secret-management: "manual-placeholder"
+    # In production with ESO, this annotation would be managed by the operator:
+    # secrets-store.csi.x-k8s.io/used: "true"
+
+# Opaque is the default and most flexible type — it stores arbitrary key-value pairs.
+# Other types (kubernetes.io/tls, kubernetes.io/dockerconfigjson, etc.) have structure
+# validation and specific handling by the kubelet or other controllers.
+type: Opaque
+
+# IMPORTANT: All values in the 'data' field MUST be base64-encoded.
+# Use 'stringData' field to provide plain-text values — Kubernetes encodes them automatically.
+# The 'data' and 'stringData' fields can coexist; 'stringData' takes precedence on conflict.
+data:
+  # echo -n "REPLACE_ME_USE_SEALED_SECRETS" | base64
+  # NEVER commit a real password here. This is a placeholder string.
+  MYSQL_ROOT_PASSWORD: UkVQTEFDRV9NRV9VU0VfU0VBTEVEXlNFQ1JFVFM=
+
+  # Application user password — should be different from root password.
+  # The application should connect with this user, not root.
+  # Principle of least privilege: the app user should have only SELECT/INSERT/UPDATE/DELETE
+  # on the appdb schema, never GRANT, CREATE, DROP, or SUPER privileges.
+  MYSQL_PASSWORD: UkVQTEFDRV9NRV9VU0VfU0VBTEVEXlNFQ1JFVFM=
+
+# stringData allows plain-text values that are automatically base64-encoded by the API server.
+# These are visible in the Secret spec but not in etcd (where they are stored encoded).
+# Use this for values that don't need to be pre-encoded, like non-sensitive usernames.
+stringData:
+  # The application database user — non-sensitive, but kept in the Secret for co-location
+  # with the password. The MySQL init container uses both MYSQL_USER and MYSQL_PASSWORD
+  # together to create the application user.
+  MYSQL_USER: appuser

--- a/core/workloads/statefulset/mysql-service-clusterip.yml
+++ b/core/workloads/statefulset/mysql-service-clusterip.yml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: database
+  labels:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/version: "8.0"
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "ClusterIP service for MySQL — application connection endpoint with load balancing across ready pods"
+spec:
+  # This is a standard ClusterIP service — Kubernetes assigns it a stable virtual IP
+  # and kube-proxy distributes connections across all Ready MySQL pods.
+  #
+  # Applications should connect to this service, NOT the headless service, because:
+  # 1. This service load-balances across all ready replicas (read traffic).
+  # 2. The ClusterIP is stable even if all pods restart.
+  # 3. It provides a single, simple connection string: mysql.database.svc.cluster.local:3306
+  #
+  # NOTE ON MYSQL WRITES vs READS:
+  # In a MySQL primary/replica topology, only mysql-0 (the primary) accepts writes.
+  # This service load-balances across ALL pods, so it is only appropriate for:
+  #   a) Read-only traffic (if your application separates reads and writes)
+  #   b) Write traffic IF you are using a MySQL proxy (ProxySQL, Vitess) in front
+  #
+  # For write-only connections to the primary, connect directly to:
+  #   mysql-0.mysql-headless.database.svc.cluster.local:3306
+  #
+  # For production MySQL, consider deploying ProxySQL as a sidecar or separate
+  # Deployment to handle read/write splitting automatically.
+  type: ClusterIP
+
+  selector:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: mysql
+
+  ports:
+  - name: mysql
+    port: 3306
+    targetPort: 3306
+    protocol: TCP
+
+  # sessionAffinity: ClientIP makes kube-proxy route all requests from the same client IP
+  # to the same backend pod. Useful for connection pooling — ensures a client's persistent
+  # TCP connection pool always goes to the same MySQL pod, reducing cross-pod latency.
+  # Default is 'None' (round-robin). Use 'ClientIP' if your app uses persistent connections.
+  sessionAffinity: None

--- a/core/workloads/statefulset/mysql-service-headless.yml
+++ b/core/workloads/statefulset/mysql-service-headless.yml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-headless
+  namespace: database
+  labels:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/version: "8.0"
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "Headless service for MySQL StatefulSet — provides stable per-pod DNS for replication and peer discovery"
+spec:
+  # clusterIP: None is what makes this service 'headless'.
+  # A normal service gets a virtual IP (ClusterIP) — kube-proxy sets up iptables rules
+  # to load-balance connections across pod IPs. A headless service has NO virtual IP.
+  # Instead, DNS queries for the service name return the individual pod IPs directly.
+  #
+  # This enables two critical DNS patterns for StatefulSets:
+  #
+  # 1. Service-level DNS (returns all pod IPs as A records):
+  #    mysql-headless.database.svc.cluster.local -> [10.0.1.5, 10.0.1.6, 10.0.1.7]
+  #
+  # 2. Pod-level DNS (returns exactly one pod's IP):
+  #    mysql-0.mysql-headless.database.svc.cluster.local -> 10.0.1.5
+  #    mysql-1.mysql-headless.database.svc.cluster.local -> 10.0.1.6
+  #    mysql-2.mysql-headless.database.svc.cluster.local -> 10.0.1.7
+  #
+  # The pod-level DNS is stable — if mysql-1 is rescheduled to a different node with
+  # a new IP (e.g., 10.0.2.8), the DNS record updates automatically to the new IP,
+  # but the hostname mysql-1.mysql-headless.database.svc.cluster.local remains constant.
+  # This is the "stable network identity" guarantee of StatefulSets.
+  #
+  # The StatefulSet spec.serviceName field MUST match this service's name.
+  clusterIP: None
+
+  selector:
+    # Only select pods managed by this StatefulSet.
+    # The selector must match the StatefulSet's pod template labels.
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: mysql
+
+  ports:
+  - name: mysql
+    port: 3306
+    targetPort: 3306
+    protocol: TCP
+
+  # publishNotReadyAddresses: false (default) means DNS entries are only created
+  # for pods that have passed their readiness probe. This prevents replication traffic
+  # from being routed to a pod that is still initializing or recovering.
+  #
+  # Set to true ONLY if you need to discover pods before they are Ready (e.g., for
+  # peer-to-peer bootstrap protocols where pods need to find each other before any of
+  # them is fully ready — like etcd or ZooKeeper initial cluster formation).
+  publishNotReadyAddresses: false

--- a/core/workloads/statefulset/mysql-statefulset.yml
+++ b/core/workloads/statefulset/mysql-statefulset.yml
@@ -1,0 +1,335 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  namespace: database
+  labels:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/version: "8.0"
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "Production MySQL 8.0 StatefulSet — 3 replicas with ordered deployment and per-pod PVCs"
+spec:
+  # serviceName MUST match the name of the headless service.
+  # This is what enables the stable DNS entries:
+  # mysql-0.mysql-headless.database.svc.cluster.local
+  serviceName: mysql-headless
+
+  replicas: 3
+
+  # OrderedReady is the default, but being explicit documents intent.
+  # mysql-0 must be Running+Ready before mysql-1 starts, and mysql-1 before mysql-2.
+  # This is critical for MySQL replication: primary (mysql-0) must be up before
+  # replicas try to register with it.
+  podManagementPolicy: OrderedReady
+
+  # minReadySeconds: a newly created pod is considered 'available' only after it has been
+  # Running and Ready for this many seconds. This adds a stabilization window and prevents
+  # a flapping pod from immediately triggering the next rollout step.
+  minReadySeconds: 10
+
+  # PVC retention policy (Kubernetes 1.27+, stable 1.29+).
+  # Retain is always the safe default for production databases.
+  # 'Delete' would destroy your data when the StatefulSet is deleted or scaled down —
+  # a catastrophic and irreversible operation.
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain     # PVCs survive StatefulSet deletion
+    whenScaledDown: Retain  # PVCs survive scale-down (so scaling back up reattaches the same data)
+
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # partition: N means only pods with ordinal >= N are updated.
+      # Set partition: 2 to update only mysql-2 first (canary for StatefulSets).
+      # Verify mysql-2 is healthy, then set partition: 0 to roll out to all.
+      # This is the StatefulSet equivalent of a canary release.
+      partition: 0
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/instance: mysql
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/instance: mysql
+        app.kubernetes.io/version: "8.0"
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: kube-platform
+        app.kubernetes.io/managed-by: kubectl
+      annotations:
+        kubernetes.io/description: "MySQL 8.0 database pod"
+        # Prometheus scraping annotation — enables metrics collection if a MySQL exporter
+        # sidecar is added. The exporter would expose metrics on port 9104.
+        prometheus.io/scrape: "false"
+        prometheus.io/port: "9104"
+    spec:
+      # Never auto-mount the service account token. MySQL does not need to call the
+      # Kubernetes API, so mounting a token is unnecessary attack surface.
+      automountServiceAccountToken: false
+
+      # Longer grace period for databases — MySQL needs time to flush the InnoDB buffer
+      # pool to disk, complete in-flight transactions, and close connections cleanly.
+      # The default 30s is too short for busy databases. 120s gives mysqladmin shutdown
+      # time to complete a clean shutdown. If the process hasn't exited after this period,
+      # the kubelet sends SIGKILL — which can cause InnoDB to need crash recovery on restart.
+      terminationGracePeriodSeconds: 120
+
+      securityContext:
+        # Reject any pod that tries to run as root (UID 0).
+        # The mysql:8.0 image runs as the 'mysql' user by default (UID 999).
+        runAsNonRoot: true
+        runAsUser: 999    # mysql user inside the mysql:8.0 image
+        # fsGroup ensures the mounted PVC is owned by GID 999 (mysql group).
+        # Without this, the volume might be owned by root and the mysql process
+        # (running as UID 999) wouldn't be able to write to /var/lib/mysql.
+        fsGroup: 999
+        seccompProfile:
+          # RuntimeDefault loads the container runtime's default seccomp profile,
+          # which blocks ~100 dangerous syscalls (ptrace, mount, etc.) while allowing
+          # all syscalls that MySQL legitimately needs.
+          type: RuntimeDefault
+
+      # Init containers run to completion before any app containers start.
+      # They are ideal for setup tasks: copying config, running migrations, waiting for
+      # dependencies. They share the same volumes as the main container.
+      initContainers:
+      - name: mysql-init-config
+        # Use the same image as the main container for consistency — avoids tool version mismatches.
+        image: mysql:8.0
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          echo "[mysqld]" > /mnt/mysql-config/my.cnf
+          echo "character-set-server=utf8mb4" >> /mnt/mysql-config/my.cnf
+          echo "collation-server=utf8mb4_unicode_ci" >> /mnt/mysql-config/my.cnf
+          echo "bind-address=0.0.0.0" >> /mnt/mysql-config/my.cnf
+          echo "innodb_buffer_pool_size=314572800" >> /mnt/mysql-config/my.cnf
+          echo "max_connections=100" >> /mnt/mysql-config/my.cnf
+          # Determine this pod's ordinal from its hostname.
+          # The hostname for mysql-1 is 'mysql-1'; the ordinal is the number after the last dash.
+          ORDINAL=$(hostname | awk -F- '{print $NF}')
+          # server-id must be unique per MySQL instance for binary log replication to work.
+          # Using ordinal+1 ensures: mysql-0=1, mysql-1=2, mysql-2=3.
+          # server-id=0 is reserved and disables replication.
+          echo "server-id=$((ORDINAL + 1))" >> /mnt/mysql-config/my.cnf
+          echo "Config written for server-id=$((ORDINAL + 1))"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+          runAsNonRoot: true
+          runAsUser: 999
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+        volumeMounts:
+        - name: mysql-config-volume
+          mountPath: /mnt/mysql-config
+
+      containers:
+      - name: mysql
+        image: mysql:8.0
+        imagePullPolicy: IfNotPresent
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          # NOTE: readOnlyRootFilesystem is intentionally FALSE for MySQL.
+          # MySQL writes to many paths at runtime that cannot be volume-mounted:
+          #   /var/run/mysqld/  — unix socket and PID file
+          #   /tmp/             — sort and temp files (we mount this as emptyDir)
+          #   /etc/             — some configs are written at startup
+          # Setting this to true causes MySQL to fail immediately at startup.
+          # This is a documented exception to the production security standard.
+          # Mitigation: runAsNonRoot + dropped capabilities + seccomp still provide
+          # strong isolation even without a read-only filesystem.
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: ["ALL"]   # Drop ALL Linux capabilities — MySQL requires none of them
+
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "200m"
+          limits:
+            memory: "512Mi"
+            # No CPU limit intentionally — CPU limits cause throttling via CFS quota,
+            # which can cause latency spikes in database workloads even when nodes have
+            # spare capacity. CPU requests provide scheduling guarantees without throttling.
+            # See: https://www.robustperception.io/cpu-throttling-and-kubernetes
+
+        env:
+        # Load non-sensitive config from ConfigMap
+        - name: MYSQL_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: mysql-config
+              key: MYSQL_DATABASE
+        - name: MYSQL_CHARACTER_SET_SERVER
+          valueFrom:
+            configMapKeyRef:
+              name: mysql-config
+              key: MYSQL_CHARACTER_SET_SERVER
+        - name: MYSQL_COLLATION_SERVER
+          valueFrom:
+            configMapKeyRef:
+              name: mysql-config
+              key: MYSQL_COLLATION_SERVER
+
+        # Load sensitive credentials from Secret
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-secret
+              key: MYSQL_ROOT_PASSWORD
+        - name: MYSQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: mysql-secret
+              key: MYSQL_USER
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-secret
+              key: MYSQL_PASSWORD
+
+        # Point MySQL to use the tmpfs-backed emptyDir for temp files.
+        # This is required because readOnlyRootFilesystem is false but /tmp on the
+        # container's writable layer is not ideal for performance — emptyDir is backed
+        # by the node's disk or memory and is cleaned up when the pod terminates.
+        - name: TMPDIR
+          value: /tmp
+
+        ports:
+        - name: mysql
+          containerPort: 3306
+          protocol: TCP
+
+        volumeMounts:
+        - name: mysql-data
+          mountPath: /var/lib/mysql   # MySQL data directory — backed by PVC
+        - name: mysql-config-volume
+          mountPath: /etc/mysql/conf.d   # Custom config written by init container
+          readOnly: true
+        - name: tmpdir
+          mountPath: /tmp              # tmpfs emptyDir for sort/temp files
+
+        # startupProbe runs FIRST, before liveness and readiness probes.
+        # It gives the container time to initialize before the kubelet starts
+        # checking liveness. MySQL can take several minutes to initialize a fresh
+        # data directory (running mysql_install_db, InnoDB log creation, etc.).
+        # failureThreshold * periodSeconds = 30 * 10 = 300 seconds (5 minutes) max startup time.
+        # Once the startupProbe succeeds, it stops running and liveness takes over.
+        startupProbe:
+          exec:
+            command:
+            - mysqladmin
+            - ping
+            - -h
+            - localhost
+          failureThreshold: 30   # Allow up to 5 minutes for startup
+          periodSeconds: 10
+          timeoutSeconds: 5
+
+        # livenessProbe: if this fails, the kubelet RESTARTS the container.
+        # Use a lightweight check — mysqladmin ping sends a COM_PING packet and
+        # returns immediately. It does NOT run a query, so it works even if the
+        # query engine is overloaded but the server is still running.
+        # Do NOT use a query-based liveness probe — a slow query can cause false
+        # positives and restart cascades under load.
+        livenessProbe:
+          exec:
+            command:
+            - mysqladmin
+            - ping
+            - -h
+            - localhost
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3       # 3 consecutive failures = restart
+          successThreshold: 1
+
+        # readinessProbe: if this fails, the pod is removed from Service endpoints.
+        # Traffic stops being sent to this pod but it is NOT restarted.
+        # This probe verifies the MySQL server can actually execute queries,
+        # not just respond to ping. This prevents routing traffic to a pod that
+        # is starting up (InnoDB recovery) or temporarily overloaded.
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            # Use -u root with password from env var. The -e flag executes a query.
+            # SELECT 1 is the canonical "database is alive and responsive" health check.
+            # Note: -p with no space before the password is the correct syntax to avoid
+            # a "Using a password on the command line interface can be insecure" warning
+            # being interpreted as a failure.
+            - "mysql -u root -p\"${MYSQL_ROOT_PASSWORD}\" -e 'SELECT 1' 2>/dev/null"
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+          successThreshold: 1
+
+        lifecycle:
+          preStop:
+            exec:
+              # On SIGTERM, tell MySQL to shut down cleanly before the kubelet sends SIGKILL.
+              # 'mysqladmin shutdown' flushes the InnoDB buffer pool, closes all connections,
+              # and writes the final binary log events. This is far safer than relying on
+              # MySQL's SIGTERM handler alone. The terminationGracePeriodSeconds: 120 gives
+              # this command up to 115 seconds to complete (5 seconds are consumed before
+              # SIGTERM is sent to the process).
+              command:
+              - /bin/sh
+              - -c
+              - "mysqladmin -u root -p\"${MYSQL_ROOT_PASSWORD}\" shutdown 2>/dev/null || true"
+
+      volumes:
+      # emptyDir is created fresh for each pod and deleted when the pod terminates.
+      # It lives on the node's disk (or in memory if medium: Memory is set).
+      # Used here for /tmp to give MySQL a writable temp directory without needing
+      # to relax the readOnlyRootFilesystem constraint on /tmp in the container layer.
+      - name: tmpdir
+        emptyDir: {}
+      # Config volume written by init container, read by main container
+      - name: mysql-config-volume
+        emptyDir: {}
+
+  # volumeClaimTemplates act as a PVC factory.
+  # For each pod, Kubernetes creates a PVC named: mysql-data-mysql-<ordinal>
+  #   mysql-data-mysql-0
+  #   mysql-data-mysql-1
+  #   mysql-data-mysql-2
+  # Each pod gets its own isolated storage. This PVC persists across pod restarts
+  # and (with Retain policy) across StatefulSet deletion.
+  volumeClaimTemplates:
+  - metadata:
+      name: mysql-data
+      labels:
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: kube-platform
+    spec:
+      # ReadWriteOncePod (introduced in Kubernetes 1.22, stable in 1.29) is stricter
+      # than ReadWriteOnce. ReadWriteOnce allows multiple pods on the SAME NODE to mount
+      # the volume — this can cause data corruption if two mysql pods land on the same node.
+      # ReadWriteOncePod guarantees only ONE pod cluster-wide can mount the volume at a time,
+      # regardless of which node it's on.
+      accessModes: ["ReadWriteOncePod"]
+      storageClassName: standard   # Replace with your cluster's storage class (gp3, premium-ssd, etc.)
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
## Summary
- Add `mysql-namespace.yml` — `database` namespace with `pod-security.kubernetes.io/enforce: baseline`
- Add `mysql-configmap.yml` — MySQL config: utf8mb4 charset, slow query log, InnoDB buffer pool ratio
- Add `mysql-secret.yml` — **educational placeholder only** with prominent warning to replace with ESO/SealedSecrets
- Add `mysql-sealed-secret.yaml` — SealedSecret with placeholder ciphertext and `kubeseal` re-seal instructions
- Add `mysql-service-headless.yml` — `clusterIP: None` for stable pod hostnames (`mysql-0.mysql.database.svc`)
- Add `mysql-service-clusterip.yml` — standard ClusterIP for application read connections
- Add `mysql-statefulset.yml` — 3 replicas, `OrderedReady`, `ReadWriteOncePod` PVC access mode, `persistentVolumeClaimRetentionPolicy: Retain`, init container deriving `server-id` from pod ordinal, startup/liveness/readiness probes, no CPU limit (throttling avoidance), memory limit = request
- Add `README.md` — headless DNS pattern, ordered rollout, `OnDelete` vs `RollingUpdate` strategy, and safe upgrade checklist

## Issues referenced
Closes #12, #13, #14, #84, relates to #29

## Test plan
- [ ] `kubectl apply -f core/workloads/statefulset/` deploys all resources
- [ ] `kubectl get pods -n database` shows `mysql-0`, `mysql-1`, `mysql-2` in Running state
- [ ] `kubectl exec mysql-0 -- mysqladmin status` returns OK
- [ ] Delete `mysql-0` — pod recreates with same hostname and PVC