### PR TITLE
feat(workload): DaemonSet — log collector with node tolerations and rolling update strategy

### DIFF
--- a/core/workloads/daemonset/README.md
+++ b/core/workloads/daemonset/README.md
@@ -1,0 +1,143 @@
+# DaemonSets — Deep Dive
+
+## What Is a DaemonSet?
+
+A DaemonSet ensures that **exactly one copy of a pod runs on every node** in the cluster (or a subset of nodes matched by a nodeSelector/affinity). When a new node joins the cluster, the DaemonSet controller automatically schedules the pod on it. When a node is removed, the pod is garbage collected.
+
+This is fundamentally different from a Deployment, which schedules a fixed number of replicas across any available nodes without caring which nodes get pods.
+
+---
+
+## How It Works
+
+The DaemonSet controller watches the cluster for node additions and removals. For each node that matches the DaemonSet's `nodeSelector` (or all nodes if no selector is specified):
+1. The controller creates a pod bound to that specific node (`spec.nodeName` is set directly).
+2. The pod bypasses the normal scheduler priority queue — it is placed by the DaemonSet controller, not the kube-scheduler (though kube-scheduler is used in newer versions with ScheduleDaemonSetPods feature gate).
+
+---
+
+## Use Cases
+
+| Use Case | Example Tools | Why DaemonSet? |
+|---|---|---|
+| **Log Collection** | Fluentd, Fluent Bit, Filebeat | Must collect logs from every node's `/var/log` directory |
+| **Metrics Collection** | node-exporter, cAdvisor | Node-level CPU, memory, disk, network metrics require host access |
+| **Network Agents** | Calico, Weave Net, Cilium | CNI plugins must run on every node to manage pod networking |
+| **Storage Agents** | Ceph, Longhorn node agent | Distributed storage requires an agent on every storage node |
+| **Security Agents** | Falco, Sysdig, Tetragon | Host-level security monitoring needs to run on every node |
+| **Service Mesh** | Linkerd, Istio CNI | Proxy injection or CNI setup needed on every node |
+| **GPU Drivers** | NVIDIA device plugin | Hardware-specific plugin must run on nodes with GPUs |
+
+---
+
+## DaemonSet vs. Deployment — Decision Criteria
+
+| Criteria | DaemonSet | Deployment |
+|---|---|---|
+| **One pod per node?** | Yes — guaranteed | No — replicas spread across nodes arbitrarily |
+| **Host filesystem access?** | Ideal (`hostPath`) | Possible but discouraged |
+| **Scales with cluster?** | Automatically (new node = new pod) | Manual or HPA (CPU/memory metrics) |
+| **Fixed replica count?** | No — count = number of nodes | Yes |
+| **Node-specific configuration?** | Yes (downward API exposes node name) | No |
+| **Need to skip some nodes?** | Use `nodeSelector` or `nodeAffinity` | N/A |
+
+**Decision Rule:** If your workload needs to run on EVERY node (or every node of a specific type), use a DaemonSet. If you need N copies spread across the cluster, use a Deployment.
+
+---
+
+## Tolerations for Control-Plane Nodes
+
+By default, DaemonSet pods do NOT run on control-plane nodes because control-plane nodes have a taint:
+
+```
+node-role.kubernetes.io/control-plane:NoSchedule
+```
+
+In most clusters, this is correct — you don't want log collectors or network agents competing with etcd and kube-apiserver for resources.
+
+**When to add control-plane tolerations:**
+- Network plugins (CNI) — Calico/Cilium MUST run on control-plane nodes to enable pod networking
+- Security agents — You want full coverage including control plane
+- Node-exporter — For complete cluster metrics visibility
+
+```yaml
+tolerations:
+- key: node-role.kubernetes.io/control-plane
+  operator: Exists
+  effect: NoSchedule
+# Also needed for older cluster versions that use master instead of control-plane:
+- key: node-role.kubernetes.io/master
+  operator: Exists
+  effect: NoSchedule
+```
+
+> **Interview Callout:** "How do you run a DaemonSet on control-plane nodes?" — Add a toleration for the `node-role.kubernetes.io/control-plane:NoSchedule` taint. Without this toleration, the DaemonSet pod is not scheduled on tainted nodes.
+
+---
+
+## Update Strategies
+
+```yaml
+updateStrategy:
+  type: RollingUpdate       # Default — updates one node at a time
+  rollingUpdate:
+    maxUnavailable: 1       # How many pods can be unavailable during update
+    maxSurge: 0             # DaemonSets don't support surge (one pod per node)
+```
+
+```yaml
+updateStrategy:
+  type: OnDelete            # Manual control — new pod only created when old pod is deleted
+                            # Useful for testing updates on specific nodes before rolling out
+```
+
+**RollingUpdate** is the default and appropriate for most cases.
+**OnDelete** gives maximum control — you delete the pod on specific nodes manually to trigger the update. Useful during critical rollouts where you want to verify each node before proceeding.
+
+---
+
+## HostPath Security Considerations
+
+DaemonSets frequently need access to the host filesystem (log files, device files). This requires `hostPath` volumes, which are powerful but risky:
+
+- A misconfigured hostPath can give container access to sensitive host files.
+- Combined with `privileged: true`, a container can escape to the host.
+- Always use the most restrictive hostPath type:
+  - `File` — mounts a single file, not a directory
+  - `Directory` — mounts a specific directory
+  - `Socket` — mounts a Unix socket
+- Never use `hostPath: /` or mount sensitive host paths like `/etc`, `/proc`, `/sys` unless absolutely necessary (security agents may legitimately need these).
+
+For log collection (reading `/var/log`), the container needs read access but NOT write. Mount with `readOnly: true`:
+```yaml
+volumeMounts:
+- name: varlog
+  mountPath: /var/log/host
+  readOnly: true
+```
+
+> **Interview Callout:** "What's the security risk of hostPath volumes?" — A container with write access to a sensitive hostPath (like `/var/log`, `/etc`, or `/`) combined with elevated privileges can escape the container boundary and modify host files. Mitigate with `readOnly: true`, specific path types, and minimal Linux capabilities.
+
+---
+
+## Files in This Directory
+
+| File | Purpose |
+|---|---|
+| `daemonset.yml` | Production DaemonSet with Namespace — log collector example |
+
+## Apply and Verify
+
+```bash
+kubectl apply -f daemonset.yml
+
+# Verify one pod per node
+kubectl get pods -n logging -o wide
+
+# Should show one pod per node — count matches node count
+kubectl get nodes --no-headers | wc -l
+kubectl get pods -n logging --no-headers | wc -l
+
+# View logs from the log collector on a specific node
+kubectl logs -n logging -l app.kubernetes.io/name=log-collector --prefix
+```

--- a/core/workloads/daemonset/daemonset.yml
+++ b/core/workloads/daemonset/daemonset.yml
@@ -1,0 +1,215 @@
+# Two resources in one file separated by '---'.
+# Apply order within this file: Namespace first, then DaemonSet.
+# kubectl apply -f daemonset.yml applies both in document order.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logging
+  labels:
+    app.kubernetes.io/part-of: kube-platform
+    # Using 'privileged' PSS here because log collectors may need hostPath access.
+    # 'restricted' would block hostPath volumes and host-level access.
+    # In a real production environment, audit this carefully — only grant privileged
+    # PSS to namespaces that genuinely need it, and use NetworkPolicy to compensate.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+  annotations:
+    kubernetes.io/description: "Namespace for node-level log collection agents"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: log-collector
+  namespace: logging
+  labels:
+    app.kubernetes.io/name: log-collector
+    app.kubernetes.io/instance: log-collector
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/component: logging
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "Node-level log collector DaemonSet — runs one pod per node to collect /var/log from each node"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: log-collector
+      app.kubernetes.io/instance: log-collector
+
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # maxUnavailable: 1 means at most 1 node at a time has its log collector
+      # offline during an update. This limits the blast radius if the new version
+      # has a bug — only 1 node's logs are dropped at a time.
+      # For critical log collection (audit logs, security events), consider maxUnavailable: 0
+      # with OnDelete strategy to manually control rollout.
+      maxUnavailable: 1
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: log-collector
+        app.kubernetes.io/instance: log-collector
+        app.kubernetes.io/version: "1.0"
+        app.kubernetes.io/component: logging
+        app.kubernetes.io/part-of: kube-platform
+        app.kubernetes.io/managed-by: kubectl
+      annotations:
+        kubernetes.io/description: "Log collector pod — reads /var/log from the host node"
+    spec:
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 60
+
+      # hostPID: false (default) — don't share the host's PID namespace.
+      # A real log collector doesn't need to see host processes.
+      # hostPID: true is only needed for security tools that need to inspect host processes.
+      hostPID: false
+
+      # NOTE ON SECURITY CONTEXT FOR DAEMONSETS WITH hostPath:
+      # Reading /var/log from the host is straightforward if the log files are world-readable
+      # or owned by a known GID. In practice, many log files (e.g., syslog, kernel logs,
+      # container runtime logs) are only readable by root or a specific system group.
+      #
+      # TRADEOFF:
+      # Option A (this file): Run as a non-root user and rely on log files being readable
+      #   by the 'adm' group (GID 4) or configured to be group-readable.
+      #   Pro: Better security posture. Con: May miss some logs.
+      #
+      # Option B: Run as root (runAsUser: 0, runAsNonRoot: false).
+      #   Pro: Reads all log files. Con: Container runs as root — higher risk if compromised.
+      #   If you must run as root, compensate with: readOnlyRootFilesystem: true,
+      #   capabilities drop ALL, seccomp profile, and NetworkPolicy.
+      #
+      # In production, prefer a purpose-built log collector (Fluent Bit, Filebeat) that
+      # can be configured to run as non-root by adjusting host log file permissions via
+      # a node configuration tool (Ansible, cloud-init) or a privileged init container.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        fsGroup: 4            # 'adm' group on most Linux systems — can read /var/log files
+        seccompProfile:
+          type: RuntimeDefault
+
+      # Tolerations allow the DaemonSet to be scheduled on nodes that have matching taints.
+      # Without these tolerations, the pods would not be scheduled on control-plane nodes.
+      tolerations:
+      # Tolerate the control-plane taint so the log collector runs on control-plane nodes too.
+      # This is necessary for complete log coverage (e.g., kube-apiserver audit logs, etcd logs).
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      # Also tolerate the 'master' taint for compatibility with older Kubernetes versions
+      # that used 'master' instead of 'control-plane'.
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      # Tolerate nodes that are not yet ready — ensures the log collector starts collecting
+      # immediately when a node joins, before it is fully Ready. Useful for capturing
+      # startup logs and node initialization events.
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+        effect: NoSchedule
+      - key: node.kubernetes.io/unreachable
+        operator: Exists
+        effect: NoSchedule
+
+      containers:
+      - name: log-collector
+        # In production, replace busybox with Fluent Bit (fluent/fluent-bit),
+        # Filebeat (docker.elastic.co/beats/filebeat), or Fluentd (fluent/fluentd).
+        # busybox is used here to demonstrate the DaemonSet pattern without
+        # requiring external image pulls or complex configuration.
+        image: busybox:1.36
+        imagePullPolicy: IfNotPresent
+
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Log collector starting on node: ${NODE_NAME}"
+          echo "Watching /var/log/host for new log files..."
+          # In production, this would be replaced by the log collector's entrypoint.
+          # For demonstration: tail all log files and echo to stdout.
+          # The kubelet captures stdout and makes it available via 'kubectl logs'.
+          while true; do
+            echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [log-collector] Heartbeat — node=${NODE_NAME}"
+            # A real log collector (Fluent Bit) would:
+            # 1. Watch /var/log/host/containers/*.log for container logs
+            # 2. Parse, enrich (add node name, namespace, pod name labels)
+            # 3. Forward to Elasticsearch, Loki, CloudWatch, etc.
+            sleep 30
+          done
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          # readOnlyRootFilesystem: true is safe here because the log collector
+          # only reads from hostPath volumes, not the container's own filesystem.
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "100m"
+          limits:
+            memory: "128Mi"
+            # CPU limit is set here because log collectors should be 'best effort'
+            # for CPU — they should not starve application pods on busy nodes.
+            # If the log collector gets CPU-throttled under load, logs may be delayed
+            # but this is preferable to impacting application latency.
+            cpu: "200m"
+
+        env:
+        # Expose the node name to the container via the Downward API.
+        # This allows the log collector to label logs with the source node name —
+        # critical for log routing and filtering in multi-node clusters.
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        # Similarly expose pod name and namespace for self-identification in logs.
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log/host   # Mount host logs at a distinct path to avoid confusion
+          readOnly: true             # Log collectors need READ access only — never write to host logs
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true             # Container log files in JSON format (Docker/containerd runtime)
+        - name: tmp
+          mountPath: /tmp            # Writable temp space for the collector's own use
+
+      volumes:
+      # hostPath mounts a directory from the HOST NODE's filesystem into the pod.
+      # This is how the log collector accesses logs written by other pods and the OS.
+      # Security note: This gives the container visibility into host filesystem paths.
+      # Always use readOnly: true in the volumeMount when write access is not required.
+      - name: varlog
+        hostPath:
+          path: /var/log
+          # 'Directory' type ensures the path must already exist on the host.
+          # If the path doesn't exist, the pod will fail with a clear error.
+          # Other types: File, Socket, CharDevice, BlockDevice, DirectoryOrCreate, FileOrCreate
+          type: Directory
+
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+          type: DirectoryOrCreate    # Creates the directory if it doesn't exist (for non-Docker runtimes)
+
+      # emptyDir for the collector's own temporary buffer files.
+      - name: tmp
+        emptyDir: {}


### PR DESCRIPTION
## Summary
- Add `daemonset.yml` — Fluentd-style log collector DaemonSet with: `hostPath` mount for `/var/log`, control-plane toleration, `maxUnavailable: 1` rolling update, resource requests/limits, and `readOnlyRootFilesystem: true`
- Add `README.md` — DaemonSet use cases (monitoring, networking, storage), node targeting via `nodeSelector` vs `nodeAffinity`, update strategies

## Issues referenced
Relates to #15, #16

## Test plan
- [ ] `kubectl apply -f core/workloads/daemonset/` creates one pod per node
- [ ] `kubectl get pods -n kube-system -o wide` shows one log-collector pod per node