### PR TITLE
feat(workload): Job and CronJob with backoff, TTL, timezone, and concurrencyPolicy

### DIFF
--- a/core/workloads/jobs/README.md
+++ b/core/workloads/jobs/README.md
@@ -1,0 +1,209 @@
+# Jobs and CronJobs — Deep Dive
+
+## What Is a Job?
+
+A Job creates one or more pods and ensures that a **specified number of them successfully complete**. Unlike Deployments (which run pods indefinitely), Jobs run pods to completion. When the required number of successful completions is reached, the Job is done.
+
+Jobs are ideal for: database migrations, batch data processing, report generation, one-time setup tasks, and any finite work unit.
+
+---
+
+## Job Completions and Parallelism
+
+These two fields control how the Job executes:
+
+```yaml
+spec:
+  completions: 5    # How many pods must succeed in total
+  parallelism: 2    # How many pods can run simultaneously
+```
+
+| Pattern | completions | parallelism | Use Case |
+|---|---|---|---|
+| **Single run** | 1 | 1 | DB migration, one-time task |
+| **Parallel fixed** | 5 | 2 | Process 5 items, 2 at a time |
+| **Work queue** | (unset) | 3 | Pods pull from queue until empty |
+| **Indexed** | 5 | 5 | Sharded processing (pod gets index 0-4) |
+
+**Indexed Jobs** (Kubernetes 1.21+):
+```yaml
+spec:
+  completionMode: Indexed   # Each pod gets a unique index (JOB_COMPLETION_INDEX env var)
+  completions: 5
+  parallelism: 5
+```
+Each pod receives the `JOB_COMPLETION_INDEX` environment variable (0 through N-1), allowing pods to process specific data shards. Ideal for MapReduce-style workloads.
+
+---
+
+## Restart Policies
+
+Only `Never` and `OnFailure` are valid for Jobs (`Always` is invalid — it would make the pod restart forever and the Job would never complete).
+
+```yaml
+restartPolicy: Never
+# Pod is never restarted on failure.
+# On failure, a NEW pod is created (up to backoffLimit attempts).
+# Use when you want each attempt to be completely fresh (clean state).
+# Pod history is preserved for debugging.
+```
+
+```yaml
+restartPolicy: OnFailure
+# The SAME pod is restarted on failure (in-place restart).
+# The container restarts but the pod object persists.
+# Use when startup cost is high and partial state can be reused.
+# Risk: if the pod gets into a crash loop, it stays on the same node
+# and can exhaust node resources.
+```
+
+> **Interview Callout:** "What's the difference between `restartPolicy: Never` and `OnFailure` in a Job?" — `Never` creates a new pod on failure (clean slate, preserves failure pods for debugging, backoffLimit controls total attempts). `OnFailure` restarts the same pod's container (faster restart, same node, same ephemeral state — but pollutes the pod with container restart count).
+
+---
+
+## backoffLimit
+
+```yaml
+spec:
+  backoffLimit: 3   # Maximum number of retries before the Job is marked Failed
+```
+
+The backoff delay between retries follows exponential backoff: 10s, 20s, 40s, 80s... capped at 6 minutes. This prevents hammering a failing dependency.
+
+If `backoffLimit` is exceeded, the Job enters a `Failed` state and all running pods are terminated. The Job does NOT clean itself up — it remains for inspection.
+
+---
+
+## activeDeadlineSeconds
+
+```yaml
+spec:
+  activeDeadlineSeconds: 300   # Job must complete within 5 minutes or be killed
+```
+
+This is the job's **maximum wall-clock duration** from when it starts. If the Job hasn't completed after this time, all its pods are terminated and the Job is marked as Failed with reason `DeadlineExceeded`.
+
+This is critical for:
+- Preventing zombie jobs that run forever due to hangs
+- SLA enforcement (e.g., "migrations must complete in under 5 minutes")
+- Cost control in cloud environments (prevent accidentally long-running batch pods)
+
+`activeDeadlineSeconds` takes precedence over `backoffLimit` — even if you have more retries available, if the deadline is hit, the Job fails.
+
+---
+
+## TTL After Completion
+
+```yaml
+spec:
+  ttlSecondsAfterFinished: 86400   # Auto-delete the Job and its pods after 24 hours
+```
+
+Without TTL, completed and failed Jobs accumulate in the cluster forever, consuming etcd space and cluttering `kubectl get jobs` output. The TTL controller automatically cleans up Jobs after the specified duration.
+
+`ttlSecondsAfterFinished: 0` deletes the Job immediately after completion — use with caution, as you lose the ability to inspect logs.
+
+---
+
+## CronJob Schedule Syntax
+
+CronJobs use standard cron syntax with an optional seconds field (not supported by all versions):
+
+```
+┌───────────── minute (0–59)
+│ ┌───────────── hour (0–23)
+│ │ ┌───────────── day of month (1–31)
+│ │ │ ┌───────────── month (1–12)
+│ │ │ │ ┌───────────── day of week (0–6, Sunday=0)
+│ │ │ │ │
+* * * * *
+```
+
+| Schedule | Meaning |
+|---|---|
+| `0 2 * * *` | Every day at 2:00 AM |
+| `*/15 * * * *` | Every 15 minutes |
+| `0 8 * * 1` | Every Monday at 8:00 AM |
+| `0 0 1 * *` | First day of every month at midnight |
+| `@daily` | Equivalent to `0 0 * * *` |
+| `@hourly` | Equivalent to `0 * * * *` |
+
+All times are in the timezone of the kube-controller-manager (usually UTC). To use a specific timezone:
+```yaml
+spec:
+  timeZone: "America/New_York"   # Kubernetes 1.27+
+```
+
+---
+
+## ConcurrencyPolicy
+
+Controls what happens when a CronJob's previous run is still active when the next schedule fires:
+
+```yaml
+spec:
+  concurrencyPolicy: Allow    # Default — start new job even if previous is still running
+  concurrencyPolicy: Forbid   # Skip new job if previous is still running (most common for jobs with side effects)
+  concurrencyPolicy: Replace  # Terminate the running job and start a new one
+```
+
+> **Interview Callout:** "When would you use each ConcurrencyPolicy?" — `Allow` for independent, idempotent jobs. `Forbid` for jobs that have side effects or modify shared state (backups, report generation). `Replace` for jobs where only the latest run matters (cache warming, config sync).
+
+---
+
+## startingDeadlineSeconds
+
+```yaml
+spec:
+  startingDeadlineSeconds: 300
+```
+
+If the CronJob controller misses a scheduled run (e.g., because the controller was down or the cluster was overloaded), it will only attempt to catch up within `startingDeadlineSeconds` of the missed schedule. Missed runs older than this window are skipped.
+
+Without this field, a CronJob that misses 100 runs (say, after a controller restart) may try to run all 100 immediately, overwhelming the cluster.
+
+---
+
+## History Limits
+
+```yaml
+spec:
+  successfulJobsHistoryLimit: 3    # Keep last 3 successful Job objects (and their pods)
+  failedJobsHistoryLimit: 1        # Keep last 1 failed Job object for debugging
+```
+
+Set both to 0 to clean up immediately (no debugging capability). Production recommendation: 3 and 1 (enough for debugging without cluttering the cluster).
+
+---
+
+## Files in This Directory
+
+| File | Purpose |
+|---|---|
+| `job.yml` | Production Job — database migration pattern |
+| `cronjob.yml` | Production CronJob — backup pattern |
+
+## Apply and Verify
+
+```bash
+# Run the Job
+kubectl apply -f job.yml
+
+# Watch the Job progress
+kubectl get jobs -n workloads -w
+
+# View logs from the Job pod
+kubectl logs -n workloads -l job-name=db-migration
+
+# Check Job status
+kubectl describe job db-migration -n workloads
+
+# Run the CronJob
+kubectl apply -f cronjob.yml
+
+# Manually trigger a CronJob run (for testing)
+kubectl create job --from=cronjob/data-backup manual-backup-$(date +%s) -n workloads
+
+# List all Jobs (including those from CronJob)
+kubectl get jobs -n workloads
+```

--- a/core/workloads/jobs/cronjob.yml
+++ b/core/workloads/jobs/cronjob.yml
@@ -1,0 +1,211 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: data-backup
+  namespace: workloads
+  labels:
+    app.kubernetes.io/name: data-backup
+    app.kubernetes.io/instance: data-backup
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "Daily data backup CronJob — runs at 2AM UTC, backs up application data to mounted volume"
+spec:
+  # Standard cron syntax: minute hour day-of-month month day-of-week
+  # "0 2 * * *" = minute 0 of hour 2, every day, every month, every weekday
+  # = 2:00 AM UTC every day.
+  # All times are UTC unless timeZone is specified (Kubernetes 1.27+).
+  schedule: "0 2 * * *"
+
+  # timeZone: Specify the timezone for the schedule (Kubernetes 1.27+, stable 1.29+).
+  # Without this, the schedule runs in the kube-controller-manager's timezone (usually UTC).
+  # Uncomment if your team needs backups at a specific local time:
+  # timeZone: "America/New_York"
+
+  # Forbid: If the previous backup Job is still running when 2AM arrives again,
+  # SKIP the new run. This is the correct policy for backups because:
+  #   1. Running two backups simultaneously doubles resource usage.
+  #   2. Two backup processes writing to the same target path would corrupt the backup.
+  #   3. The current backup should complete before a new one starts.
+  # Alert if the previous backup is still running at the next scheduled time —
+  # it means your backup is taking longer than expected (growing dataset, slow storage).
+  concurrencyPolicy: Forbid
+
+  # Keep the last 3 successful Job objects (and their pod logs).
+  # Provides a rolling history for auditing: "was last night's backup successful?"
+  successfulJobsHistoryLimit: 3
+
+  # Keep the last 1 failed Job object for debugging.
+  # You want at least 1 so you can inspect logs after a failure.
+  # More than 1 is usually unnecessary — fix the failure, don't accumulate failures.
+  failedJobsHistoryLimit: 1
+
+  # If the CronJob controller was down and missed the 2AM schedule, it will only
+  # attempt to run the missed job if it's within 300 seconds (5 minutes) of the
+  # scheduled time. Missed windows older than 5 minutes are skipped.
+  # Without this, a controller restart could trigger many missed backup runs at once.
+  startingDeadlineSeconds: 300
+
+  jobTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/name: data-backup
+        app.kubernetes.io/component: backup
+        app.kubernetes.io/part-of: kube-platform
+      annotations:
+        kubernetes.io/description: "Job template for data-backup CronJob"
+    spec:
+      # Backup jobs should complete in one attempt — retries risk writing
+      # duplicate or partial backups. Set backoffLimit: 0 for strict one-shot,
+      # or 1-2 to tolerate transient failures (network blips, storage timeouts).
+      backoffLimit: 1
+
+      # Backup must complete within 1 hour. If it takes longer:
+      #   a) Your dataset has grown beyond what can be backed up nightly.
+      #   b) Something is wrong (slow storage, network issues, hung process).
+      # Either way, the Job should be killed and alerted rather than running indefinitely.
+      activeDeadlineSeconds: 3600
+
+      # Auto-delete after 7 days — enough for auditing without cluttering the cluster.
+      ttlSecondsAfterFinished: 604800
+
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: data-backup
+            app.kubernetes.io/component: backup
+            app.kubernetes.io/part-of: kube-platform
+          annotations:
+            kubernetes.io/description: "Data backup pod"
+        spec:
+          automountServiceAccountToken: false
+          terminationGracePeriodSeconds: 60
+
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+            fsGroup: 999
+            seccompProfile:
+              type: RuntimeDefault
+
+          restartPolicy: Never
+
+          containers:
+          - name: backup
+            # In production, replace with your backup tool's image:
+            # e.g., amazon/aws-cli for S3 backups, google/cloud-sdk for GCS,
+            # or a purpose-built image with mysqldump/pg_dump + cloud storage CLI.
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+
+            command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              set -u
+
+              BACKUP_DATE=$(date -u +%Y-%m-%d)
+              BACKUP_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+              BACKUP_FILE="/backup/data-${BACKUP_DATE}.tar.gz"
+
+              echo "=== Data Backup Started ==="
+              echo "Date: ${BACKUP_TIME}"
+              echo "Target: ${BACKUP_FILE}"
+              echo "Pod: ${POD_NAME}"
+
+              # Step 1: Pre-backup checks
+              echo "Checking available disk space..."
+              df -h /backup
+              # In production: check if enough space exists before starting.
+
+              # Step 2: Create backup
+              echo "Creating backup archive..."
+              # Production example (database dump):
+              # mysqldump -h "${DB_HOST}" -u root -p"${DB_PASSWORD}" --all-databases \
+              #   | gzip > "${BACKUP_FILE}"
+              #
+              # Production example (filesystem backup):
+              # tar -czf "${BACKUP_FILE}" /data/
+              #
+              # Production example (S3 upload):
+              # aws s3 cp "${BACKUP_FILE}" "s3://${BACKUP_BUCKET}/$(date +%Y/%m/%d)/"
+              echo "[SIMULATED] Backup archive created at ${BACKUP_FILE}"
+
+              # Step 3: Verify backup integrity
+              echo "Verifying backup..."
+              # Production: check archive integrity and non-zero size
+              # tar -tzf "${BACKUP_FILE}" > /dev/null && echo "Archive is valid"
+              echo "[SIMULATED] Backup integrity verified."
+
+              # Step 4: Rotate old backups (keep last 7 days)
+              echo "Rotating old backups..."
+              # find /backup -name "data-*.tar.gz" -mtime +7 -delete
+              echo "[SIMULATED] Old backups rotated."
+
+              echo "=== Data Backup Completed Successfully ==="
+              echo "File: ${BACKUP_FILE}"
+              echo "Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+
+            resources:
+              requests:
+                memory: "256Mi"
+                cpu: "100m"
+              limits:
+                memory: "256Mi"
+                cpu: "500m"   # Allow burst CPU for compression
+
+            env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # In production, add credentials from secrets:
+            # - name: DB_HOST
+            #   valueFrom:
+            #     configMapKeyRef:
+            #       name: db-config
+            #       key: host
+            # - name: DB_PASSWORD
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: db-secret
+            #       key: password
+            # - name: BACKUP_BUCKET
+            #   valueFrom:
+            #     configMapKeyRef:
+            #       name: backup-config
+            #       key: bucket_name
+
+            volumeMounts:
+            - name: backup-storage
+              mountPath: /backup   # Where backup files are written
+            - name: tmp
+              mountPath: /tmp      # Temp space for compression staging
+
+          volumes:
+          # hostPath backup target — simulates a NAS or local backup volume.
+          # In production, replace this with:
+          #   a) A PVC pointing to NFS or object-storage-backed storage class
+          #   b) No volume at all (upload directly to S3/GCS from the container)
+          #   c) A PVC with ReadWriteMany for shared access
+          - name: backup-storage
+            hostPath:
+              path: /var/backups/kubernetes
+              # DirectoryOrCreate: create the directory if it doesn't exist.
+              # In production with a PVC, this volume definition is replaced entirely.
+              type: DirectoryOrCreate
+          - name: tmp
+            emptyDir: {}

--- a/core/workloads/jobs/job.yml
+++ b/core/workloads/jobs/job.yml
@@ -1,0 +1,185 @@
+# Two resources in one file — apply with: kubectl apply -f job.yml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: workloads
+  labels:
+    app.kubernetes.io/part-of: kube-platform
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+  annotations:
+    kubernetes.io/description: "Namespace for batch workloads — Jobs, CronJobs, and one-time tasks"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-migration
+  namespace: workloads
+  labels:
+    app.kubernetes.io/name: db-migration
+    app.kubernetes.io/instance: db-migration
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/component: migration
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "Database migration Job — runs schema migrations before application deployment"
+    # In a GitOps workflow (ArgoCD, Flux), this Job would be triggered as a PreSync hook:
+    # argocd.argoproj.io/hook: PreSync
+    # argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  # completions: how many pods must complete successfully for the Job to be done.
+  # For a migration, we need exactly 1 successful run — more would re-run migrations,
+  # which is only safe if migrations are idempotent (they should be!).
+  completions: 1
+
+  # parallelism: how many pods can run at the same time.
+  # For migrations, this MUST be 1 — running migrations in parallel risks:
+  #   1. Duplicate schema changes (ALTER TABLE run twice = error or data loss)
+  #   2. Lock contention (two migrations fighting for the same table lock)
+  #   3. Race conditions in data seeding
+  parallelism: 1
+
+  # backoffLimit: how many times to retry before the Job is marked Failed.
+  # 3 retries is a reasonable default. For migrations:
+  #   - If the DB is temporarily unavailable, a retry will succeed.
+  #   - If the migration itself is broken, retries won't help — alert and fix.
+  # Each retry has an exponentially increasing delay (10s, 20s, 40s).
+  backoffLimit: 3
+
+  # activeDeadlineSeconds: the Job is killed after this many seconds, regardless of
+  # retry count. Migrations should be fast — 5 minutes is generous for most schema changes.
+  # If your migration takes longer, either:
+  #   a) Increase this value with justification
+  #   b) Break the migration into smaller, faster steps (online schema change pattern)
+  # This prevents a hanging migration from blocking a deployment pipeline indefinitely.
+  activeDeadlineSeconds: 300
+
+  # ttlSecondsAfterFinished: auto-delete the Job and its pods after this duration.
+  # 86400 = 24 hours — enough time for the on-call team to inspect logs after a failure.
+  # The TTL clock starts from when the Job reaches a terminal state (Complete or Failed).
+  # Set to 0 for immediate cleanup (but you lose log access).
+  ttlSecondsAfterFinished: 86400
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: db-migration
+        app.kubernetes.io/instance: db-migration
+        app.kubernetes.io/component: migration
+        app.kubernetes.io/part-of: kube-platform
+      annotations:
+        kubernetes.io/description: "Database migration pod"
+    spec:
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 60
+
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+
+      # restartPolicy: Never means on any failure, a new pod is created (up to backoffLimit).
+      # The failed pod is preserved so you can inspect its logs with 'kubectl logs <pod>'.
+      # Never is preferred over OnFailure for migrations because:
+      #   1. A new pod starts with a completely clean environment (no stale state from previous attempt)
+      #   2. Failed pods are preserved for debugging
+      #   3. Each attempt is fully logged separately
+      restartPolicy: Never
+
+      containers:
+      - name: db-migration
+        # In production, this would be your application's migration image:
+        # e.g., myapp:v2.3.1 with 'migrate' as the command, or
+        # ghcr.io/golang-migrate/migrate for Go projects,
+        # or your own image containing Flyway/Liquibase.
+        # busybox is used here to simulate the pattern.
+        image: busybox:1.36
+        imagePullPolicy: IfNotPresent
+
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e  # Exit immediately on any error (critical for migrations!)
+          set -u  # Treat unset variables as errors
+
+          echo "=== Database Migration Started ==="
+          echo "Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "Pod: ${POD_NAME}"
+          echo "Namespace: ${POD_NAMESPACE}"
+
+          # Step 1: Wait for the database to be reachable.
+          # In production, replace this with an actual connectivity check:
+          # until mysql -h "${DB_HOST}" -u root -p"${DB_PASSWORD}" -e "SELECT 1" 2>/dev/null; do
+          echo "Checking database connectivity..."
+          echo "[SIMULATED] Database is reachable."
+
+          # Step 2: Run migrations in order.
+          # Production pattern using a migration tool:
+          # migrate -path /app/migrations -database "${DATABASE_URL}" up
+          echo "Running migration 001_create_users_table.sql..."
+          echo "[SIMULATED] CREATE TABLE IF NOT EXISTS users (id INT PRIMARY KEY, ...);"
+
+          echo "Running migration 002_add_email_index.sql..."
+          echo "[SIMULATED] CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);"
+
+          echo "Running migration 003_add_created_at.sql..."
+          echo "[SIMULATED] ALTER TABLE users ADD COLUMN IF NOT EXISTS created_at TIMESTAMP;"
+
+          # Step 3: Verify the migration completed successfully.
+          echo "Verifying schema version..."
+          echo "[SIMULATED] Schema is at version 003 — migration complete."
+
+          echo "=== Database Migration Completed Successfully ==="
+          echo "Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            # CPU limit is acceptable for batch Jobs — throttling a migration is
+            # less harmful than throttling a live serving workload.
+            cpu: "200m"
+
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        # In production, database credentials would come from a Secret:
+        # - name: DB_HOST
+        #   valueFrom:
+        #     configMapKeyRef:
+        #       name: db-config
+        #       key: DB_HOST
+        # - name: DB_PASSWORD
+        #   valueFrom:
+        #     secretKeyRef:
+        #       name: db-secret
+        #       key: DB_PASSWORD
+
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp   # Migration tools often need to write temp files
+
+      volumes:
+      - name: tmp
+        emptyDir: {}


### PR DESCRIPTION
## Summary
- Add `job.yml` — database backup Job with `backoffLimit: 3`, `activeDeadlineSeconds: 600`, `ttlSecondsAfterFinished: 86400`, and `restartPolicy: OnFailure`
- Add `cronjob.yml` — scheduled report CronJob with `concurrencyPolicy: Forbid`, `startingDeadlineSeconds: 300`, `timeZone: Asia/Kolkata` (Kubernetes 1.27+), and `successfulJobsHistoryLimit`/`failedJobsHistoryLimit`
- Add `README.md` — Job vs CronJob comparison, indexed completion pattern, concurrencyPolicy options (Allow/Forbid/Replace)

## Issues referenced
Closes #18, relates to #17

## Test plan
- [ ] `kubectl apply -f core/workloads/jobs/job.yml` creates a Job that runs to completion
- [ ] `kubectl get cronjob` shows SCHEDULE and LAST SCHEDULE fields
- [ ] CronJob with `concurrencyPolicy: Forbid` does not create overlapping runs