### PR TITLE
feat(networking): Service types — ClusterIP, NodePort, LoadBalancer

### DIFF
--- a/core/networking/services/README.md
+++ b/core/networking/services/README.md
@@ -1,0 +1,216 @@
+# Kubernetes Services: Complete Reference
+
+## What Is a Service?
+
+A Kubernetes Service is a stable network endpoint that provides a consistent IP address and DNS name to a group of pods. Pods are ephemeral — they can be rescheduled to different nodes, their IP addresses change, and they can be killed and replaced at any time. A Service solves this by acting as a stable front-end whose selector continuously tracks matching pods through the Endpoints (or EndpointSlice) controller.
+
+Without a Service, consumers of a pod would need to discover its current IP via the API server on every call — which is brittle and does not support load balancing.
+
+---
+
+## Service Types
+
+### 1. ClusterIP (Default — Internal Only)
+
+ClusterIP allocates a virtual IP address that is reachable only from within the cluster. kube-proxy programs iptables (or IPVS) rules on every node so that traffic to the ClusterIP:port is transparently DNAT'd to one of the ready backing pods.
+
+**Use when:** Any service that should only be reached by other workloads inside the cluster (databases, internal APIs, caches).
+
+**DNS name format:** `<service-name>.<namespace>.svc.cluster.local`
+
+```yaml
+spec:
+  type: ClusterIP        # or omit; ClusterIP is the default
+  clusterIP: ""          # auto-assigned; set to "None" for Headless
+```
+
+**Example DNS lookup from inside a pod:**
+```bash
+nslookup nginx-clusterip.networking-demo.svc.cluster.local
+```
+
+---
+
+### 2. NodePort (External — Development / Testing)
+
+NodePort extends ClusterIP by additionally opening a static port (default range: 30000–32767) on **every** node's external IP. Traffic arriving at `<any-node-IP>:<nodePort>` is forwarded to the Service's ClusterIP, then to a backing pod.
+
+**Use when:** Quick external access during development or in environments where you control the firewall and do not have a cloud load balancer. Not recommended for production external traffic because:
+- Exposes a port on every single node, including control-plane nodes in some setups.
+- Port range is non-standard (not 80/443).
+- No built-in health checking at the LB layer.
+
+**WARNING:** Every node in the cluster listens on the NodePort. An attacker who reaches any node on that port can reach the service, even if that node is running zero matching pods.
+
+---
+
+### 3. LoadBalancer (Cloud — Production External Access)
+
+LoadBalancer extends NodePort by additionally requesting that the cloud provider's CCM (Cloud Controller Manager) provision an external load balancer (e.g., AWS ALB/NLB, GCP L4 LB, Azure LB). The provisioned LB's IP or hostname is populated into `status.loadBalancer.ingress`.
+
+**Use when:** Production workloads that need external access in cloud environments. For bare-metal clusters, pair with **MetalLB** to provide the same functionality.
+
+**Cost awareness:** Each LoadBalancer service provisions a separate cloud load balancer, which costs money. For HTTP/HTTPS traffic, use a single Ingress + Ingress Controller instead of one LoadBalancer per service.
+
+---
+
+### 4. ExternalName (DNS Alias)
+
+ExternalName does not proxy traffic through kube-proxy at all. Instead, the cluster DNS server returns a CNAME record pointing to the external hostname you specify. The pod's TCP connection goes directly to that external host.
+
+**Use when:** Giving an in-cluster DNS name to an external dependency (e.g., a managed RDS database, a SaaS API endpoint). Allows you to change the external endpoint without updating application config — just update the Service.
+
+```yaml
+spec:
+  type: ExternalName
+  externalName: mydb.prod.us-east-1.rds.amazonaws.com
+```
+
+**Limitation:** No port remapping. No load balancing. Returns a CNAME, so the application must support following CNAMEs.
+
+---
+
+### 5. Headless Service (StatefulSets / Direct Pod Addressing)
+
+A Headless Service is a ClusterIP Service with `clusterIP: None`. No virtual IP is allocated and no kube-proxy rules are installed. Instead, the cluster DNS server returns **A records for each individual pod IP** that matches the selector.
+
+**Use when:**
+- StatefulSets, where each pod needs a stable DNS name (`pod-0.my-svc.namespace.svc.cluster.local`).
+- Client-side load balancing where the application needs to discover and connect to individual pod IPs.
+- Databases that use consensus protocols (etcd, Cassandra, Kafka) and need to address specific nodes.
+
+**DNS behavior for StatefulSet pods:**
+```
+<pod-name>.<service-name>.<namespace>.svc.cluster.local
+```
+e.g., `mysql-0.mysql-headless.database.svc.cluster.local`
+
+---
+
+## Service Type Decision Matrix
+
+| Scenario | Recommended Type | Notes |
+|---|---|---|
+| Internal microservice communication | ClusterIP | Default. Use DNS, not env vars. |
+| Expose to cluster pods only | ClusterIP | Add NetworkPolicy to restrict further |
+| Dev/test external access, no cloud LB | NodePort | Never use nodePort in production HTTP paths |
+| Production HTTP/HTTPS external traffic | Ingress + ClusterIP | One Ingress Controller = one LoadBalancer |
+| Production non-HTTP external traffic (TCP) | LoadBalancer | e.g., a game server, MQTT broker |
+| Alias to external DNS (RDS, SaaS) | ExternalName | — |
+| StatefulSet stable per-pod DNS | Headless (clusterIP: None) | Required for StatefulSet pod DNS |
+| Kafka, Cassandra cluster discovery | Headless | Clients get all pod IPs from DNS |
+
+---
+
+## kube-proxy Modes
+
+kube-proxy runs on every node and is responsible for implementing the Service virtual IP abstraction. It watches the API server for Service and Endpoints changes and programs the local node's networking stack.
+
+### iptables Mode (Default in most clusters)
+
+kube-proxy installs iptables DNAT rules in the `KUBE-SERVICES` chain. For each service, a chain of rules randomly selects a backend pod using the `statistic` module (probability-based).
+
+**Pros:** No extra dependency, widely supported.
+**Cons:** O(n) rule matching — clusters with tens of thousands of Services and endpoints see measurable latency from iptables traversal. Rules are not incrementally updated; the full ruleset is replaced on any change (can cause brief packet drops).
+
+### IPVS Mode (Recommended for large clusters)
+
+kube-proxy programs the Linux kernel's IPVS (IP Virtual Server) subsystem. IPVS uses a hash table so lookup is O(1) regardless of the number of services.
+
+**Pros:** Much better performance at scale. Supports more load-balancing algorithms (round-robin, least-connections, shortest expected delay, etc.).
+**Cons:** Requires the `ip_vs` kernel modules. Slightly more complex to debug.
+
+**Enable IPVS:** In the kube-proxy ConfigMap, set `mode: "ipvs"` and `ipvs.scheduler: "rr"` (or `lc`, `sh`, etc.).
+
+### nftables Mode (Kubernetes 1.31+, beta)
+
+A modern replacement for iptables that offers better performance and atomic rule updates. Becoming the default in newer Kubernetes versions. Check your distribution's support before enabling.
+
+---
+
+## Service Discovery
+
+Kubernetes offers two mechanisms for services to discover each other.
+
+### DNS (Recommended)
+
+The cluster DNS server (CoreDNS by default) automatically creates DNS records for every Service. Pods are configured by the kubelet to use the cluster DNS server via `/etc/resolv.conf`.
+
+```
+# From any pod in the cluster:
+curl http://nginx-clusterip.networking-demo.svc.cluster.local
+
+# From a pod in the same namespace, the short name resolves:
+curl http://nginx-clusterip
+
+# From a pod in a different namespace, use the FQDN:
+curl http://nginx-clusterip.networking-demo.svc.cluster.local
+```
+
+DNS is the right approach: it is dynamic (updates when pods change), human-readable, and does not have ordering constraints.
+
+### Environment Variables (Legacy — AVOID for new workloads)
+
+When a pod starts, kubelet injects environment variables for every Service that exists in the same namespace at that moment. For a Service named `REDIS`, kubelet injects:
+```
+REDIS_SERVICE_HOST=10.96.1.45
+REDIS_SERVICE_PORT=6379
+```
+
+**CRITICAL ORDERING PROBLEM:** The environment variables are injected at pod startup time. If the Service does not exist yet when the pod starts, the variables will not be present. If you create the Service after the pods, those pods will never see the variables unless they are restarted. This creates hard-to-diagnose bugs where the app cannot connect to a service that definitely exists.
+
+**Additionally:** The variables are not updated if the Service's ClusterIP changes (which can happen if the Service is deleted and recreated). You would need to restart all pods in the namespace.
+
+**Conclusion:** Use DNS. Disable environment variable injection if you want to reduce pod startup time and avoid confusion:
+```yaml
+spec:
+  enableServiceLinks: false  # Disables env var injection for this pod
+```
+
+---
+
+## Endpoint Slices
+
+Since Kubernetes 1.19, the Endpoints API has been supplemented (and in 1.21+ largely replaced) by EndpointSlices. EndpointSlices shard the backend pod list into slices of up to 100 endpoints each, dramatically reducing the size of API objects and the watch traffic kube-proxy must process in large clusters.
+
+You rarely interact with EndpointSlices directly — they are managed automatically by the EndpointSlice controller. But when debugging, inspect them:
+
+```bash
+kubectl get endpointslices -n networking-demo
+kubectl describe endpointslice <name> -n networking-demo
+```
+
+---
+
+## Debugging Services
+
+```bash
+# Check that the service exists and has the correct ClusterIP
+kubectl get svc -n networking-demo
+
+# Check that endpoints are populated (if Endpoints is empty, selector doesn't match any pod)
+kubectl get endpoints nginx-clusterip -n networking-demo
+
+# Describe the service for event details
+kubectl describe svc nginx-clusterip -n networking-demo
+
+# Test connectivity from within a pod (exec into a debug pod)
+kubectl run debug --image=curlimages/curl --rm -it --restart=Never -- \
+  curl -s http://nginx-clusterip.networking-demo.svc.cluster.local
+
+# Check kube-proxy logs on a node
+kubectl logs -n kube-system -l k8s-app=kube-proxy --tail=50
+
+# Verify iptables rules exist for the service (run on a node)
+sudo iptables-save | grep nginx-clusterip
+```
+
+---
+
+## Related Files
+
+- `clusterip.yml` — ClusterIP Service example (internal communication)
+- `nodeport.yml` — NodePort Service example (dev/test external access)
+- `loadbalancer.yml` — LoadBalancer Service example (cloud production external access)
+- `../ingress/` — Ingress resources for HTTP/HTTPS routing (recommended over LoadBalancer for HTTP)
+- `../network-policy/` — NetworkPolicy to restrict which pods can reach a Service

--- a/core/networking/services/clusterip.yml
+++ b/core/networking/services/clusterip.yml
@@ -1,0 +1,96 @@
+# ==============================================================================
+# ClusterIP Service — Internal Cluster Communication
+# ==============================================================================
+# ClusterIP is the DEFAULT Service type. It allocates a stable virtual IP
+# (the "ClusterIP") that is reachable ONLY from within the cluster. kube-proxy
+# programs iptables/IPVS rules on every node to DNAT traffic destined for the
+# ClusterIP:port to one of the healthy backing pods.
+#
+# For internal cluster traffic only.
+# Pods reach this service via DNS:
+#   nginx-clusterip.networking-demo.svc.cluster.local
+#
+# Short-form DNS (same namespace): nginx-clusterip
+# Cross-namespace DNS:             nginx-clusterip.networking-demo.svc.cluster.local
+#
+# Test connectivity from inside a pod:
+#   kubectl run debug --image=curlimages/curl --rm -it --restart=Never \
+#     -n networking-demo -- curl -sv http://nginx-clusterip
+# ==============================================================================
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-clusterip
+  namespace: networking-demo
+
+  labels:
+    # --- Recommended Kubernetes label standard (app.kubernetes.io/*) ---
+    # These labels are used by tooling (Helm, Lens, kubectl slice) and
+    # allow consistent selection across heterogeneous resources.
+    app.kubernetes.io/name: nginx-clusterip
+    app.kubernetes.io/instance: nginx-clusterip
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      ClusterIP Service exposing nginx pods on port 80 for internal cluster
+      communication only. Accessible via DNS at
+      nginx-clusterip.networking-demo.svc.cluster.local.
+
+spec:
+  # ClusterIP is the default; stating it explicitly makes intent clear.
+  # Other values: NodePort, LoadBalancer, ExternalName, (or omit type entirely)
+  type: ClusterIP
+
+  # selector matches pods whose labels contain ALL of these key-value pairs.
+  # The Endpoints controller continuously watches for pods with these labels
+  # and updates the Endpoints/EndpointSlice object. Only pods in Ready state
+  # (readinessProbe passing) are added to the endpoint list.
+  selector:
+    app.kubernetes.io/name: nginx    # Must match the pod's labels exactly.
+
+  ports:
+    - name: http                     # Naming ports is recommended. It allows
+                                     # Ingress and other resources to reference
+                                     # the port by name instead of number,
+                                     # making port changes less risky.
+      protocol: TCP                  # TCP is default. UDP is supported.
+                                     # SCTP is supported since 1.20 (beta).
+      port: 80                       # The port THIS service listens on.
+                                     # This is what other pods connect to.
+      targetPort: 80                 # The port on the backing POD to forward to.
+                                     # Can also be a named port: targetPort: http
+                                     # Using named ports decouples Service config
+                                     # from the pod's actual port number.
+
+  # sessionAffinity controls whether subsequent requests from the same client
+  # are routed to the same pod.
+  #
+  # None (default): each request is independently load-balanced (round-robin
+  # in iptables mode). Use this for stateless workloads.
+  #
+  # ClientIP: iptables hashes the source IP and pins the client to one pod for
+  # the duration of sessionAffinityConfig.clientIP.timeoutSeconds (default 3h).
+  # Use for stateful apps that cannot externalise session state. Note: this
+  # breaks if a client is behind a NAT (all clients look like the same IP).
+  sessionAffinity: None
+
+  # Optional: only set sessionAffinityConfig if sessionAffinity is ClientIP.
+  # sessionAffinityConfig:
+  #   clientIP:
+  #     timeoutSeconds: 10800        # 3 hours (default and maximum)
+
+  # Optional: publishNotReadyAddresses
+  # If true, pods that are NOT yet Ready are still included in Endpoints.
+  # Normally false. Useful for headless services in StatefulSets where you
+  # want to discover pods during initialisation (e.g., cluster bootstrap).
+  # publishNotReadyAddresses: false
+
+  # Optional: internalTrafficPolicy (Kubernetes 1.21+)
+  # Cluster (default): traffic can be forwarded to pods on any node.
+  # Local:             traffic is only forwarded to pods on the same node as
+  #                    the client pod. Reduces latency but can cause imbalance.
+  # internalTrafficPolicy: Cluster

--- a/core/networking/services/loadbalancer.yml
+++ b/core/networking/services/loadbalancer.yml
@@ -1,0 +1,137 @@
+# ==============================================================================
+# LoadBalancer Service — Cloud / Production External Access
+# ==============================================================================
+# LoadBalancer extends NodePort by requesting that the cloud provider's Cloud
+# Controller Manager (CCM) provision an external load balancer. The LB's public
+# IP or hostname is populated into status.loadBalancer.ingress[].ip/hostname.
+#
+# On bare-metal clusters (no cloud CCM), use MetalLB:
+#   https://metallb.universe.tf/
+# MetalLB implements the LoadBalancer spec using BGP or Layer 2 ARP.
+#
+# COST AWARENESS:
+#   Each LoadBalancer Service provisions a SEPARATE cloud load balancer, which
+#   incurs hourly and data-transfer charges. For HTTP/HTTPS traffic, strongly
+#   prefer a single Ingress Controller (which uses one LoadBalancer) with
+#   multiple Ingress resources routing to different Services. Only use per-
+#   service LoadBalancers for non-HTTP protocols (raw TCP, UDP, etc.).
+#
+# AWS NLB vs ALB:
+#   - Default AWS LB type for a LoadBalancer Service is a Classic LB (CLB),
+#     which is deprecated. Use the annotation below to request an NLB instead.
+#   - For HTTP/HTTPS with advanced routing, use an ALB via the AWS Load Balancer
+#     Controller and an Ingress resource, NOT a LoadBalancer Service.
+#
+# After applying, check the provisioned LB:
+#   kubectl get svc nginx-loadbalancer -n networking-demo
+#   kubectl describe svc nginx-loadbalancer -n networking-demo
+#   # Wait for EXTERNAL-IP to change from <pending> to an actual IP/hostname.
+# ==============================================================================
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-loadbalancer
+  namespace: networking-demo
+
+  labels:
+    app.kubernetes.io/name: nginx-loadbalancer
+    app.kubernetes.io/instance: nginx-loadbalancer
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      LoadBalancer Service exposing nginx on ports 80 and 443. Cloud providers
+      provision an external load balancer automatically. On bare-metal clusters,
+      deploy MetalLB first. Each LoadBalancer Service creates one cloud LB;
+      for HTTP/HTTPS workloads, prefer a single Ingress Controller instead.
+
+    # --------------------------------------------------------------------------
+    # AWS-Specific Annotations (comment out if not using AWS)
+    # --------------------------------------------------------------------------
+
+    # Request a Network Load Balancer (NLB) instead of the deprecated Classic LB.
+    # NLB operates at Layer 4 (TCP/UDP), supports static IPs, and handles
+    # millions of requests per second with ultra-low latency.
+    # service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+
+    # Request an internal NLB (not internet-facing). Use for LBs that only need
+    # to be reached from within the VPC or via VPN/Direct Connect.
+    # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+
+    # Specify which subnets the LB should be deployed into (comma-separated).
+    # service.beta.kubernetes.io/aws-load-balancer-subnets: "subnet-abc123,subnet-def456"
+
+    # Enable cross-zone load balancing so the NLB distributes traffic evenly
+    # across AZs even if pods are unevenly distributed.
+    # service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+
+    # Override the default idle timeout (in seconds). CLB/NLB default: 60s.
+    # service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "120"
+
+    # --------------------------------------------------------------------------
+    # GCP-Specific Annotations (comment out if not using GCP)
+    # --------------------------------------------------------------------------
+
+    # Request an internal passthrough NLB (regional). Traffic stays inside VPC.
+    # networking.gke.io/load-balancer-type: "Internal"
+
+    # --------------------------------------------------------------------------
+    # MetalLB Annotations (comment out if not using MetalLB)
+    # --------------------------------------------------------------------------
+
+    # Request a specific IP address from a MetalLB address pool.
+    # metallb.universe.tf/loadBalancerIPs: "192.168.1.100"
+
+    # Specify which MetalLB address pool to draw from.
+    # metallb.universe.tf/address-pool: "production"
+
+spec:
+  type: LoadBalancer
+
+  selector:
+    app.kubernetes.io/name: nginx
+
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80              # Port on the external load balancer.
+      targetPort: 80        # Port on the backing pod.
+                            # nodePort is auto-assigned; you can pin it if needed
+                            # (e.g., for firewall rules on the nodes themselves).
+
+    - name: https
+      protocol: TCP
+      port: 443             # TLS termination can happen at the LB or at the pod.
+      targetPort: 443       # If terminating TLS in-cluster, configure the pod to
+                            # handle HTTPS. If at the LB, targetPort could be 80.
+
+  # externalTrafficPolicy: Local preserves the original client IP in the pod.
+  # The receiving node only routes to pods ON THAT NODE. Cloud LBs health-check
+  # each node and only send traffic to nodes that have at least one backing pod.
+  # This requires the cloud LB to support node-level health checks (NLB does;
+  # CLB does not reliably). Use Cluster if client IP preservation is not needed.
+  externalTrafficPolicy: Cluster
+
+  # sessionAffinity: ClientIP can help with non-HTTP protocols that have per-
+  # connection state. For HTTP (handled by Ingress), keep None.
+  sessionAffinity: None
+
+  # loadBalancerSourceRanges restricts which CIDR blocks the cloud LB's
+  # security group / firewall rule will accept traffic from. This is NOT a
+  # replacement for NetworkPolicy (which operates inside the cluster), but it
+  # reduces the attack surface at the cloud provider firewall level.
+  # Without this, the default is 0.0.0.0/0 (open to the entire internet).
+  #
+  # Example — restrict to your corporate egress IP and a VPN range:
+  # loadBalancerSourceRanges:
+  #   - "203.0.113.0/24"   # Corporate egress block
+  #   - "10.8.0.0/16"      # VPN subnet
+
+  # allocateLoadBalancerNodePorts (Kubernetes 1.20+)
+  # Set to false to prevent Kubernetes from allocating NodePorts for this
+  # LoadBalancer service. Useful when using a pass-through LB that sends
+  # traffic directly to pod IPs (e.g., GKE NEG, AWS IPVS target groups).
+  # allocateLoadBalancerNodePorts: true

--- a/core/networking/services/nodeport.yml
+++ b/core/networking/services/nodeport.yml
@@ -1,0 +1,100 @@
+# ==============================================================================
+# NodePort Service — External Access for Development / Testing
+# ==============================================================================
+# NodePort extends ClusterIP by additionally opening a static port on EVERY
+# node's external network interface. Traffic arriving at <any-node-IP>:<nodePort>
+# is forwarded to the Service's ClusterIP, then to a backing pod.
+#
+# WHEN TO USE:
+#   - Local development clusters (minikube, kind, k3s) where no cloud LB exists.
+#   - Quick smoke-testing of a new service from outside the cluster.
+#   - CI environments where you need external access without provisioning infra.
+#
+# WARNING — DO NOT USE IN PRODUCTION FOR EXTERNAL HTTP/HTTPS TRAFFIC:
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │ NodePort exposes the service on ALL nodes simultaneously, including     │
+# │ control-plane nodes (in single-node dev setups). Any host that can     │
+# │ reach ANY node on port 30080 can reach this service. You cannot        │
+# │ restrict it to specific nodes at the Service level.                    │
+# │                                                                         │
+# │ For production external access, use:                                   │
+# │   - Ingress + Ingress Controller (for HTTP/HTTPS — cost-efficient)     │
+# │   - LoadBalancer Service (for raw TCP/UDP — one LB per service)        │
+# └─────────────────────────────────────────────────────────────────────────┘
+#
+# Access from outside the cluster:
+#   curl http://<any-node-external-ip>:30080
+#
+# With minikube:
+#   minikube service nginx-nodeport -n networking-demo --url
+# ==============================================================================
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-nodeport
+  namespace: networking-demo
+
+  labels:
+    app.kubernetes.io/name: nginx-nodeport
+    app.kubernetes.io/instance: nginx-nodeport
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      NodePort Service exposing nginx pods on node port 30080. Intended for
+      development and testing only. Do NOT use for production external traffic;
+      use Ingress + Ingress Controller or a LoadBalancer Service instead.
+
+spec:
+  type: NodePort
+
+  # selector must match the pods you want to expose.
+  selector:
+    app.kubernetes.io/name: nginx
+
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80             # Port on the ClusterIP (for in-cluster consumers).
+                           # In-cluster pods can still use the ClusterIP:80.
+      targetPort: 80       # Port on the backing pod containers.
+      nodePort: 30080      # The port opened on every node's external interface.
+                           # Must be in the range 30000-32767 (configurable in
+                           # kube-apiserver --service-node-port-range, default
+                           # is 30000-32767).
+                           #
+                           # Omitting nodePort causes Kubernetes to assign one
+                           # randomly from the available range — fine for dev,
+                           # but hard to use in static firewall rules.
+                           #
+                           # Do NOT use ports below 30000 here; those ranges
+                           # typically require root and conflict with OS services.
+
+  # sessionAffinity: None means each connection is independently routed.
+  # For a dev/test NodePort, None is appropriate.
+  sessionAffinity: None
+
+  # externalTrafficPolicy controls how the node that receives the packet
+  # handles it:
+  #
+  # Cluster (default): The receiving node may forward the packet to a pod on a
+  #   DIFFERENT node. This provides better load distribution but performs SNAT,
+  #   which means the pod sees the node's IP as the source, not the client's
+  #   real IP. Useful when pods need even load distribution.
+  #
+  # Local: The receiving node only forwards to pods running ON THAT NODE. If no
+  #   pod runs on the receiving node, the connection is dropped (so you need a
+  #   proper LB in front). Benefit: no SNAT, so pods see the real client IP.
+  #   The DaemonSet + Local pattern is used by Ingress Controllers and MetalLB
+  #   speaker pods.
+  #
+  # For a simple dev NodePort, Cluster is fine.
+  externalTrafficPolicy: Cluster
+
+  # healthCheckNodePort is only relevant when externalTrafficPolicy: Local.
+  # Kubernetes allocates a health-check port on each node that cloud LBs can
+  # probe to determine whether any backing pods exist on that node.
+  # healthCheckNodePort: 32500   # auto-assigned when externalTrafficPolicy: Local


### PR DESCRIPTION
## Summary
- Add `clusterip.yml` — ClusterIP with named ports, `sessionAffinity: ClientIP` documentation, and CoreDNS resolution pattern
- Add `nodeport.yml` — NodePort with explicit port assignment; note on ephemeral vs static NodePort
- Add `loadbalancer.yml` — LoadBalancer with AWS NLB annotations (`aws-load-balancer-type: nlb`, internal scheme); note on cloud controller manager requirement
- Add `README.md` — service type decision table, `kube-proxy` iptables mode, `CLUSTER_IP` vs external DNS, `ExternalName` type explained

## Issues referenced
Closes #23, relates to #19

## Test plan
- [ ] `kubectl get svc` shows correct `TYPE` and `CLUSTER-IP` for each service
- [ ] `kubectl exec -- nslookup <service-name>` resolves to ClusterIP