### PR TITLE
feat(networking): Ingress — path-based, host-based, and TLS with cert-manager

### DIFF
--- a/core/networking/ingress/README.md
+++ b/core/networking/ingress/README.md
@@ -1,0 +1,286 @@
+# Kubernetes Ingress: Complete Reference
+
+## What Is Ingress?
+
+An Ingress is an API object that manages **HTTP and HTTPS routing** from outside the cluster to Services inside the cluster. It provides:
+
+- **Host-based routing:** Route `api.example.com` to one Service and `web.example.com` to another.
+- **Path-based routing:** Route `/api/*` to one Service and `/web/*` to another, all on the same hostname.
+- **TLS termination:** Accept HTTPS connections, decrypt them at the edge, and forward plain HTTP to pods.
+- **Name-based virtual hosting:** Support multiple domains on a single external IP.
+
+### Why Not Just Use LoadBalancer Services?
+
+Each `type: LoadBalancer` Service provisions a separate cloud load balancer, which has real cost implications (hourly charges + data transfer fees). An Ingress Controller acts as a single, shared reverse proxy that fronts ALL your HTTP/HTTPS services through **one** external load balancer. This is dramatically more cost-efficient for clusters with many HTTP services.
+
+### Ingress vs. Gateway API
+
+The Gateway API (`gateway.networking.k8s.io`) is the successor to Ingress, offering more expressive routing, role separation (infrastructure vs. developer), and support for TCP/UDP/gRPC routes. It reached GA in Kubernetes 1.28. For new projects on modern clusters, consider the Gateway API. This directory covers the Ingress API, which remains widely used and production-supported.
+
+---
+
+## Ingress Architecture
+
+```
+Internet
+    │
+    ▼
+[ Cloud Load Balancer ]  ◄── One LB, provisioned by LoadBalancer Service
+    │                        for the Ingress Controller pods
+    ▼
+[ Ingress Controller ]   ◄── Deployment (e.g., nginx-ingress-controller)
+    │                        Watches Ingress objects; configures nginx/envoy
+    │
+    ├──► /api  ──► api-service:8080  ──► api pods
+    │
+    └──► /web  ──► web-service:80    ──► web pods
+```
+
+An **Ingress resource** is just a declarative routing rule. It does nothing without an **Ingress Controller** running in the cluster. The Ingress Controller is a pod that watches Ingress objects and configures the underlying proxy (nginx, Envoy, HAProxy, Traefik, etc.).
+
+---
+
+## IngressClass (Required Since Kubernetes 1.18)
+
+Before 1.18, you set the controller via a `kubernetes.io/ingress.class` annotation. Since 1.18, use the `spec.ingressClassName` field and an `IngressClass` resource. This allows multiple Ingress Controllers to coexist in the same cluster (e.g., an internal nginx and an external nginx, or nginx for HTTP and a separate controller for TCP).
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: nginx
+  annotations:
+    # Mark this IngressClass as the cluster-wide default.
+    # Ingress resources that omit spec.ingressClassName will use this class.
+    ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: k8s.io/ingress-nginx   # Matches the controller's --ingress-class flag
+```
+
+Always specify `spec.ingressClassName` in your Ingress resources — do not rely on the default to keep configurations explicit and portable.
+
+---
+
+## Path Types
+
+Every path rule requires a `pathType`:
+
+| pathType | Behaviour |
+|---|---|
+| `Exact` | Matches the URL path exactly. `/foo` does NOT match `/foo/` or `/foo/bar`. |
+| `Prefix` | Matches paths with the given prefix, split by `/`. `/foo` matches `/foo`, `/foo/`, `/foo/bar`. |
+| `ImplementationSpecific` | Matching is left to the IngressClass. Behaviour varies by controller. Avoid in portable configs. |
+
+For most API and web routing, use `Prefix`. For health check endpoints or specific static assets, use `Exact`.
+
+---
+
+## Path-Based vs. Host-Based Routing
+
+### Path-Based (Single Hostname, Multiple Services)
+
+```
+https://app.example.com/api   →   api-service:8080
+https://app.example.com/web   →   web-service:80
+```
+
+All traffic arrives on one hostname. The Ingress Controller routes based on the URL path. Simple to manage DNS (one record), but path conflicts must be managed carefully.
+
+### Host-Based (Multiple Hostnames, Multiple Services)
+
+```
+https://api.example.com   →   api-service:8080
+https://web.example.com   →   web-service:80
+```
+
+Each service gets its own subdomain. Cleaner separation. Each hostname needs a DNS record pointing to the Ingress Controller's external IP. In production, a wildcard DNS record (`*.example.com → <ingress-ip>`) covers all subdomains automatically.
+
+You can combine both in a single Ingress resource: multiple hosts, each with multiple paths.
+
+---
+
+## TLS Termination
+
+The Ingress Controller accepts TLS connections on port 443 and decrypts them using a certificate stored in a Kubernetes Secret of type `kubernetes.io/tls`. Traffic between the Ingress Controller pod and the backend Service is plain HTTP by default (encrypted within the cluster network). For end-to-end encryption, configure the backend pod to serve HTTPS and use the appropriate controller annotations.
+
+### Creating a TLS Secret
+
+**Option 1: Self-signed certificate (local dev only)**
+```bash
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout tls.key \
+  -out tls.crt \
+  -subj "/CN=secure.example.com/O=Dev"
+
+kubectl create secret tls tls-secret \
+  --cert=tls.crt \
+  --key=tls.key \
+  -n networking-demo
+```
+
+**Option 2: cert-manager (recommended for production)**
+cert-manager is a Kubernetes add-on that automates certificate issuance and renewal from Let's Encrypt, Vault, or a corporate PKI.
+
+```bash
+# Install cert-manager
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+
+# Create a ClusterIssuer for Let's Encrypt
+cat <<EOF | kubectl apply -f -
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: admin@example.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+EOF
+```
+
+Then add to your Ingress:
+```yaml
+annotations:
+  cert-manager.io/cluster-issuer: "letsencrypt-prod"
+```
+cert-manager watches the Ingress and automatically creates and renews the TLS secret.
+
+---
+
+## Installing the NGINX Ingress Controller
+
+### Via Helm (Recommended for Production)
+
+```bash
+# Add the ingress-nginx Helm repository
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
+
+# Install into the ingress-nginx namespace
+helm install ingress-nginx ingress-nginx/ingress-nginx \
+  --namespace ingress-nginx \
+  --create-namespace \
+  --set controller.replicaCount=2 \
+  --set controller.resources.requests.cpu=100m \
+  --set controller.resources.requests.memory=128Mi \
+  --set controller.metrics.enabled=true \
+  --set controller.podAnnotations."prometheus\.io/scrape"=true
+
+# Watch for the LoadBalancer external IP to be assigned
+kubectl get svc -n ingress-nginx -w
+```
+
+### Via kubectl (Quick Install / Dev)
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/cloud/deploy.yaml
+
+# For minikube:
+minikube addons enable ingress
+```
+
+---
+
+## Common NGINX Ingress Annotations
+
+```yaml
+annotations:
+  # Rewrite the path before forwarding to the backend.
+  # e.g., /api/users becomes /users on the backend.
+  nginx.ingress.kubernetes.io/rewrite-target: /$2
+
+  # Force redirect HTTP → HTTPS (301)
+  nginx.ingress.kubernetes.io/ssl-redirect: "true"
+
+  # Force HTTPS even for non-TLS Ingresses (redirect all HTTP globally)
+  nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+
+  # Configure a rate limit: 10 requests per second per IP
+  nginx.ingress.kubernetes.io/limit-rps: "10"
+
+  # Set the client request body size limit (default: 1m)
+  nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+
+  # Set custom proxy timeouts
+  nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
+  nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+  nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+
+  # Enable CORS
+  nginx.ingress.kubernetes.io/enable-cors: "true"
+  nginx.ingress.kubernetes.io/cors-allow-origin: "https://app.example.com"
+
+  # Whitelist specific IPs
+  nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/8,203.0.113.5/32"
+
+  # Configure backend protocol (for HTTPS backends)
+  nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+
+  # Use sticky sessions (consistent hashing on cookie)
+  nginx.ingress.kubernetes.io/affinity: "cookie"
+  nginx.ingress.kubernetes.io/session-cookie-name: "route"
+  nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
+
+  # Configure custom snippet (raw nginx config injection — use with caution)
+  nginx.ingress.kubernetes.io/configuration-snippet: |
+    more_set_headers "X-Frame-Options: DENY";
+    more_set_headers "X-Content-Type-Options: nosniff";
+```
+
+---
+
+## Debugging Ingress Issues
+
+```bash
+# 1. Verify the Ingress resource was created and has an Address
+kubectl get ingress -n networking-demo
+# If ADDRESS is empty, the Ingress Controller may not be running or
+# ingressClassName does not match.
+
+# 2. Describe the Ingress for events and rule details
+kubectl describe ingress path-based -n networking-demo
+
+# 3. Check that the backend Services and their Endpoints exist
+kubectl get svc,endpoints -n networking-demo
+
+# 4. Check the Ingress Controller pods are running
+kubectl get pods -n ingress-nginx
+
+# 5. View the Ingress Controller logs for 404/502 errors
+kubectl logs -n ingress-nginx -l app.kubernetes.io/name=ingress-nginx --tail=100
+
+# 6. View the generated nginx.conf (inside the controller pod)
+kubectl exec -n ingress-nginx deploy/ingress-nginx-controller -- \
+  cat /etc/nginx/nginx.conf | grep -A 5 "server_name"
+
+# 7. Test from inside the cluster (bypassing the LB)
+kubectl run debug --image=curlimages/curl --rm -it --restart=Never -- \
+  curl -H "Host: api.example.com" http://<ingress-controller-clusterip>/api/health
+
+# 8. Common causes of 502 Bad Gateway:
+#    - Backend pod not ready (check readinessProbe)
+#    - targetPort mismatch in Service
+#    - NetworkPolicy blocking Ingress Controller → pod traffic
+#    - Pod is listening on 0.0.0.0 but NetworkPolicy only allows from certain namespaces
+
+# 9. Common causes of 404 from the Ingress Controller (not the backend):
+#    - ingressClassName doesn't match the controller
+#    - Path type mismatch (Exact vs Prefix)
+#    - rewrite-target annotation removing required path prefix
+```
+
+---
+
+## Related Files
+
+- `path-based.yml` — Single-host Ingress routing by URL path
+- `host-based.yml` — Multi-host Ingress routing by hostname
+- `tls.yml` — TLS termination with a certificate Secret
+- `../services/` — ClusterIP Services that Ingress backends point to
+- `../network-policy/` — NetworkPolicy allowing the Ingress Controller to reach pods

--- a/core/networking/ingress/host-based.yml
+++ b/core/networking/ingress/host-based.yml
@@ -1,0 +1,123 @@
+# ==============================================================================
+# Host-Based Ingress — Multiple Hostnames, Multiple Backend Services
+# ==============================================================================
+# Routes HTTP traffic to different Services based on the HTTP Host header.
+# Each service gets its own subdomain. The Ingress Controller performs
+# name-based virtual hosting (the same mechanism Apache/nginx use for vhosts).
+#
+# Traffic flow:
+#   api.example.com  →  api-service:8080
+#   web.example.com  →  web-service:80
+#
+# DNS requirements:
+#   Both hostnames must resolve to the Ingress Controller's external IP.
+#   In production, use a wildcard A record:
+#     *.example.com  IN  A  <ingress-controller-external-ip>
+#
+# Local testing with minikube or kind:
+#   1. Get the Ingress Controller external IP:
+#        kubectl get svc -n ingress-nginx ingress-nginx-controller
+#   2. Add entries to /etc/hosts (Linux/macOS) or C:\Windows\System32\drivers\etc\hosts:
+#        192.168.49.2  api.example.com web.example.com
+#      Replace 192.168.49.2 with your actual Ingress IP (minikube ip).
+#   3. Test:
+#        curl http://api.example.com/health
+#        curl http://web.example.com/
+#
+# Apply:
+#   kubectl apply -f host-based.yml
+# ==============================================================================
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: host-based-ingress
+  namespace: networking-demo
+
+  labels:
+    app.kubernetes.io/name: host-based-ingress
+    app.kubernetes.io/instance: host-based-ingress
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      Host-based Ingress routing api.example.com to api-service and
+      web.example.com to web-service. Both hostnames must resolve to the
+      Ingress Controller's external IP. For local testing, add entries
+      to /etc/hosts pointing these names to the Ingress Controller IP.
+
+    # proxy-body-size: default 1m; increase for services that accept file uploads.
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+
+    # proxy-connect-timeout: time to wait for a connection to the backend.
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+
+    # proxy-read-timeout: time to wait for the backend to return a response.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+
+spec:
+  # ingressClassName is required since Kubernetes 1.18.
+  # Do not rely on the cluster-default IngressClass — always be explicit.
+  ingressClassName: nginx
+
+  rules:
+    # -------------------------------------------------------------------------
+    # Rule 1: api.example.com → api-service
+    # -------------------------------------------------------------------------
+    - host: api.example.com   # Matches the HTTP Host header exactly.
+                               # Wildcards like *.example.com are NOT supported
+                               # in the host field here — wildcard hosts require
+                               # implementation-specific annotations or the
+                               # Gateway API.
+      http:
+        paths:
+          - path: /            # Match ALL paths under this host.
+            pathType: Prefix   # Prefix on "/" matches every path.
+            backend:
+              service:
+                name: api-service
+                port:
+                  number: 8080 # The Service port (not the pod/container port).
+
+    # -------------------------------------------------------------------------
+    # Rule 2: web.example.com → web-service
+    # -------------------------------------------------------------------------
+    - host: web.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web-service
+                port:
+                  number: 80
+
+    # -------------------------------------------------------------------------
+    # Example: Path-based sub-routing on a host (combining both strategies)
+    # You can add multiple paths per host for finer-grained routing.
+    # -------------------------------------------------------------------------
+    # - host: api.example.com
+    #   http:
+    #     paths:
+    #       - path: /v1
+    #         pathType: Prefix
+    #         backend:
+    #           service:
+    #             name: api-v1-service
+    #             port:
+    #               number: 8080
+    #       - path: /v2
+    #         pathType: Prefix
+    #         backend:
+    #           service:
+    #             name: api-v2-service
+    #             port:
+    #               number: 8080
+
+  # TLS is NOT configured in this file (use tls.yml for TLS).
+  # Without TLS, all traffic is plain HTTP. In production, always use TLS.
+  # Without ssl-redirect, an attacker can downgrade HTTPS to HTTP via a
+  # redirect strip attack. See tls.yml for the recommended TLS configuration.

--- a/core/networking/ingress/path-based.yml
+++ b/core/networking/ingress/path-based.yml
@@ -1,0 +1,122 @@
+# ==============================================================================
+# Path-Based Ingress — Single Host, Multiple Backend Services
+# ==============================================================================
+# Routes HTTP traffic to different Services based on the URL path.
+# All paths share a single hostname (or no hostname, matching all hosts).
+#
+# Traffic flow:
+#   <external-ip>/api/* → api-service:8080 (path is rewritten: /api/foo → /foo)
+#   <external-ip>/web/* → web-service:80   (path is rewritten: /web/foo → /foo)
+#
+# Prerequisites:
+#   1. An Ingress Controller must be installed (e.g., ingress-nginx).
+#      kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/
+#        main/deploy/static/provider/cloud/deploy.yaml
+#   2. The Services api-service and web-service must exist in networking-demo.
+#
+# Apply:
+#   kubectl apply -f path-based.yml
+#
+# Verify:
+#   kubectl get ingress path-based-ingress -n networking-demo
+#   # Wait for the ADDRESS column to be populated with the external IP.
+# ==============================================================================
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: path-based-ingress
+  namespace: networking-demo
+
+  labels:
+    app.kubernetes.io/name: path-based-ingress
+    app.kubernetes.io/instance: path-based-ingress
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      Path-based Ingress routing /api traffic to api-service and /web traffic
+      to web-service. Uses nginx rewrite-target to strip the path prefix before
+      forwarding to backends.
+
+    # --------------------------------------------------------------------------
+    # rewrite-target: strips the captured group from the path before forwarding.
+    #
+    # How it works together with the path regex below:
+    #   Path regex: /api(/|$)(.*)
+    #   Capture group $2 captures everything after /api/
+    #   rewrite-target: /$2 forwards only the captured suffix.
+    #
+    #   Request:  GET /api/users/42
+    #   Backend sees: GET /users/42
+    #
+    # Without this annotation, the backend would receive GET /api/users/42
+    # which may not match any routes in your API service.
+    # --------------------------------------------------------------------------
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+
+    # use-regex: true enables regular expressions in path definitions.
+    # Required when using capture groups in rewrite-target.
+    nginx.ingress.kubernetes.io/use-regex: "true"
+
+    # proxy-body-size: maximum allowed size of the client request body.
+    # Default is 1m. Increase for file upload endpoints.
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+
+    # proxy-read-timeout: seconds nginx waits for a response from the backend.
+    # Increase for slow backend operations (large queries, heavy computation).
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+
+spec:
+  # ingressClassName is REQUIRED since Kubernetes 1.18.
+  # It references an IngressClass resource that identifies which controller
+  # should handle this Ingress. Using "nginx" corresponds to the ingress-nginx
+  # controller. If you have multiple controllers (e.g., internal-nginx and
+  # external-nginx), you can target the correct one here.
+  ingressClassName: nginx
+
+  rules:
+    # Omitting 'host' means this rule matches ALL hostnames.
+    # This is fine for path-based routing in development.
+    # In production, always specify a host to prevent unexpected routing.
+    - http:
+        paths:
+          # --- /api route ---
+          - path: /api(/|$)(.*)
+            # Prefix: the path is treated as a prefix match (split by /).
+            #   /api matches: /api, /api/, /api/users, /api/users/42
+            #   /api does NOT match: /apiv2, /api-docs (would need /api or exact)
+            #
+            # ImplementationSpecific: enables regex when use-regex: "true" is set.
+            # We use ImplementationSpecific here because Prefix does not support
+            # capture groups. The regex behaviour is nginx-specific.
+            pathType: ImplementationSpecific
+
+            backend:
+              service:
+                name: api-service     # Must exist in the same namespace.
+                port:
+                  number: 8080        # ClusterIP port on api-service.
+
+          # --- /web route ---
+          - path: /web(/|$)(.*)
+            pathType: ImplementationSpecific
+
+            backend:
+              service:
+                name: web-service     # Must exist in the same namespace.
+                port:
+                  number: 80
+
+          # --- Default catch-all (optional) ---
+          # Requests that don't match /api or /web are sent to web-service.
+          # Without this, nginx returns 404 for unmatched paths.
+          # - path: /
+          #   pathType: Prefix
+          #   backend:
+          #     service:
+          #       name: web-service
+          #       port:
+          #         number: 80

--- a/core/networking/ingress/tls.yml
+++ b/core/networking/ingress/tls.yml
@@ -1,0 +1,190 @@
+# ==============================================================================
+# TLS Ingress — HTTPS with Certificate Termination
+# ==============================================================================
+# Configures the Ingress Controller to terminate TLS for secure.example.com.
+# The certificate and private key are stored in a Kubernetes Secret of type
+# kubernetes.io/tls. The Ingress Controller mounts this Secret and configures
+# its proxy (nginx) with it.
+#
+# TLS TERMINATION MODEL:
+#   Client ──(HTTPS)──► Ingress Controller ──(HTTP)──► Backend Pod
+#   The segment from the Ingress Controller to the pod is plain HTTP.
+#   This is acceptable when the cluster network is trusted (mTLS via a
+#   service mesh handles pod-to-pod encryption in higher-security environments).
+#   For end-to-end TLS, configure the backend to serve HTTPS and annotate:
+#     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+#
+# HOW TO CREATE THE TLS SECRET:
+# ──────────────────────────────
+# Option 1: Self-signed certificate (LOCAL DEV ONLY — browsers will warn)
+#
+#   openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+#     -keyout tls.key \
+#     -out tls.crt \
+#     -subj "/CN=secure.example.com/O=Dev" \
+#     -addext "subjectAltName=DNS:secure.example.com"
+#
+#   kubectl create secret tls tls-secret \
+#     --cert=tls.crt \
+#     --key=tls.key \
+#     -n networking-demo
+#
+# Option 2: cert-manager with Let's Encrypt (PRODUCTION RECOMMENDED)
+#   Install cert-manager, create a ClusterIssuer, then add to this Ingress:
+#     annotations:
+#       cert-manager.io/cluster-issuer: "letsencrypt-prod"
+#   cert-manager will automatically create and rotate the tls-secret Secret.
+#   See the ingress README.md for the full ClusterIssuer configuration.
+#
+# Option 3: Import an existing certificate from a CA
+#   kubectl create secret tls tls-secret \
+#     --cert=/path/to/fullchain.pem \
+#     --key=/path/to/privkey.pem \
+#     -n networking-demo
+#
+# Verify the secret was created correctly:
+#   kubectl get secret tls-secret -n networking-demo
+#   kubectl describe secret tls-secret -n networking-demo
+#   # Should show: tls.crt and tls.key fields
+# ==============================================================================
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tls-ingress
+  namespace: networking-demo
+
+  labels:
+    app.kubernetes.io/name: tls-ingress
+    app.kubernetes.io/instance: tls-ingress
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      TLS-terminating Ingress for secure.example.com. Terminates HTTPS at the
+      nginx Ingress Controller using the certificate stored in tls-secret.
+      All HTTP requests are permanently redirected to HTTPS (301).
+
+    # ssl-redirect: Redirects all HTTP requests to HTTPS with a 308 redirect
+    # (permanent, method-preserving). This means http://secure.example.com
+    # automatically redirects to https://secure.example.com.
+    # Set to "false" only if you explicitly need to serve both HTTP and HTTPS.
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+
+    # force-ssl-redirect: Even if the request arrives over HTTP at the Ingress
+    # Controller (e.g., because the LB terminates TLS and forwards HTTP),
+    # force a redirect to HTTPS. Prevents HTTPS → HTTP downgrade via the LB.
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+
+    # hsts: Add Strict-Transport-Security header to instruct browsers to always
+    # use HTTPS for this domain for the next year (31536000 seconds).
+    # Do NOT enable HSTS until you are confident your TLS setup is stable —
+    # if you disable HTTPS later, browsers that cached the HSTS header will
+    # refuse to connect over HTTP for up to a year.
+    nginx.ingress.kubernetes.io/hsts: "true"
+    nginx.ingress.kubernetes.io/hsts-max-age: "31536000"
+    nginx.ingress.kubernetes.io/hsts-include-subdomains: "true"
+    nginx.ingress.kubernetes.io/hsts-preload: "true"
+
+    # If using cert-manager for automatic certificate management, add:
+    # cert-manager.io/cluster-issuer: "letsencrypt-prod"
+
+spec:
+  ingressClassName: nginx
+
+  # tls block: associates a hostname with a TLS certificate Secret.
+  # The Ingress Controller watches this Secret and configures its TLS listener.
+  # If the Secret is rotated (e.g., by cert-manager), the controller hot-reloads
+  # the certificate without downtime.
+  tls:
+    - hosts:
+        - secure.example.com  # Must match the CN or SAN in the certificate.
+                               # If they don't match, clients get a cert warning.
+      secretName: tls-secret  # Name of the kubernetes.io/tls Secret in the
+                               # SAME namespace as this Ingress resource.
+                               # The Secret must contain:
+                               #   tls.crt: the full certificate chain (PEM)
+                               #   tls.key: the private key (PEM)
+
+  rules:
+    - host: secure.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web-service     # Backend Service in the same namespace.
+                port:
+                  number: 80
+
+          # Add additional paths for sub-routing on this host:
+          # - path: /api
+          #   pathType: Prefix
+          #   backend:
+          #     service:
+          #       name: api-service
+          #       port:
+          #         number: 8080
+
+---
+# ==============================================================================
+# TLS Secret — Local Development (Self-Signed)
+# ==============================================================================
+# IMPORTANT: This Secret contains a PLACEHOLDER certificate. Replace tls.crt
+# and tls.key with real base64-encoded values before applying.
+#
+# In production, do NOT commit TLS private keys to git. Use cert-manager
+# (which auto-creates the Secret) or store the key in a secrets manager
+# (Vault, AWS Secrets Manager) and sync it with External Secrets Operator.
+#
+# To generate real base64 values:
+#   cat tls.crt | base64 -w 0   → paste as tls.crt value
+#   cat tls.key | base64 -w 0   → paste as tls.key value
+#
+# Or use kubectl imperative command (does not require base64 encoding):
+#   kubectl create secret tls tls-secret --cert=tls.crt --key=tls.key \
+#     -n networking-demo --dry-run=client -o yaml | kubectl apply -f -
+# ==============================================================================
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tls-secret
+  namespace: networking-demo
+
+  labels:
+    app.kubernetes.io/name: tls-secret
+    app.kubernetes.io/instance: tls-secret
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      TLS certificate and private key for secure.example.com. In production,
+      this Secret should be managed by cert-manager or External Secrets
+      Operator — never committed to git with real key material.
+
+# type must be kubernetes.io/tls for TLS Secrets.
+# This type enforces the presence of tls.crt and tls.key fields.
+type: kubernetes.io/tls
+
+data:
+  # Replace these placeholder values with real base64-encoded certificate data.
+  # The values below are NOT a valid certificate — they are placeholders only.
+  #
+  # tls.crt must be the full certificate chain: leaf cert + intermediate CA(s).
+  # The order matters: leaf first, then intermediates. Do NOT include the root CA.
+  tls.crt: |
+    # PLACEHOLDER — replace with: cat tls.crt | base64 -w 0
+    LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi4uLgotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t
+
+  # tls.key must be the unencrypted private key in PEM format.
+  # If your key is passphrase-protected, decrypt it first:
+  #   openssl rsa -in encrypted.key -out tls.key
+  tls.key: |
+    # PLACEHOLDER — replace with: cat tls.key | base64 -w 0
+    LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCi4uLgotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t


### PR DESCRIPTION
## Summary
- Add `path-based.yml` — single host, multiple path prefixes routing to different backends with `pathType: Prefix`
- Add `host-based.yml` — virtual hosting: separate hostnames routing to independent services
- Add `tls.yml` — TLS termination with `cert-manager.io/cluster-issuer` annotation, HTTPS redirect, and HSTS header annotation; both Let's Encrypt staging and production issuer references
- Add `README.md` — nginx Ingress controller architecture, `pathType` (Exact/Prefix/ImplementationSpecific), TLS provisioning flow with cert-manager

## Issues referenced
Closes #24, relates to #20, #88

## Test plan
- [ ] `kubectl apply -f core/networking/ingress/path-based.yml` and `curl -H "Host: app.local" http://localhost:8080/api` routes correctly
- [ ] TLS Ingress shows `SECRET` column populated after cert-manager issues certificate