### PR TITLE
feat(networking): NetworkPolicies — deny-all, namespace isolation, metadata API block, MySQL isolation

### DIFF
--- a/core/networking/network-policy/README.md
+++ b/core/networking/network-policy/README.md
@@ -1,0 +1,260 @@
+# Kubernetes NetworkPolicy: Complete Reference
+
+## What Is a NetworkPolicy?
+
+A NetworkPolicy is a Kubernetes API resource that specifies how pods are allowed to communicate with each other and with external endpoints. It is enforced by the cluster's CNI (Container Network Interface) plugin, not by kube-proxy or the API server. Without a supported CNI plugin, NetworkPolicy resources are created and stored in etcd but have **no effect**.
+
+**CNI plugins that support NetworkPolicy:**
+- Calico (most feature-rich)
+- Cilium (eBPF-based, also supports host-level and L7 policies)
+- Weave Net
+- Antrea
+- Canal (Calico policies + Flannel networking)
+
+**CNI plugins that do NOT support NetworkPolicy:**
+- Flannel (alone) — policies are stored but silently ignored
+- AWS VPC CNI (alone) — requires Calico for policy enforcement on EKS
+
+Verify your CNI supports NetworkPolicy:
+```bash
+kubectl get pods -n kube-system | grep -E "calico|cilium|weave|antrea"
+```
+
+---
+
+## Default Allow-All Behavior
+
+**CRITICAL:** By default, a namespace with no NetworkPolicy objects allows ALL traffic — pod to pod, namespace to namespace, and external to pod. Any pod can reach any other pod on any port.
+
+This is the biggest surprise for teams moving from traditional firewall models. In a default Kubernetes cluster:
+- A compromised pod in the `development` namespace can make TCP connections to MySQL in the `production` namespace on port 3306.
+- A compromised pod can reach the cloud metadata API at `169.254.169.254` and steal the node's IAM role credentials.
+- A compromised pod can port-scan the entire cluster network.
+
+**The solution:** Apply a default-deny NetworkPolicy to every namespace, then add specific allow rules. This is the network equivalent of "deny all, allow by exception."
+
+---
+
+## Policy Types
+
+A NetworkPolicy specifies `policyTypes` which determines what kind of traffic the policy applies to:
+
+### Ingress
+Controls traffic coming **into** pods that match `spec.podSelector`. If a pod has any NetworkPolicy with `Ingress` in `policyTypes`, only connections explicitly allowed by an ingress rule in any matching policy are permitted. All other inbound connections are dropped.
+
+### Egress
+Controls traffic going **out of** pods that match `spec.podSelector`. Same logic: once any policy with `Egress` is applied to a pod, only explicitly allowed outbound connections are permitted.
+
+### Specifying Both
+```yaml
+policyTypes:
+  - Ingress
+  - Egress
+```
+When both are specified, the pod is isolated in both directions unless explicit rules allow traffic.
+
+### What Counts as "Isolation"?
+A pod is considered **isolated for ingress** if there is at least one NetworkPolicy in its namespace whose `podSelector` matches it and whose `policyTypes` includes `Ingress`. Ditto for egress. Multiple policies are unioned — a connection is allowed if ANY matching policy permits it.
+
+---
+
+## Selector Types
+
+### podSelector
+Selects pods by label. Used in:
+- `spec.podSelector` — identifies which pods this policy applies TO (the "subject").
+- `spec.ingress[].from[].podSelector` — identifies which pods are ALLOWED to send traffic.
+- `spec.egress[].to[].podSelector` — identifies which pods are ALLOWED to receive traffic.
+
+An empty `podSelector: {}` matches ALL pods in the namespace.
+
+```yaml
+podSelector:
+  matchLabels:
+    app.kubernetes.io/name: mysql   # Only applies to mysql pods
+```
+
+### namespaceSelector
+Selects namespaces by label. Traffic from/to pods in matching namespaces is allowed.
+
+```yaml
+namespaceSelector:
+  matchLabels:
+    environment: production   # Namespace must have this label
+```
+
+Add a label to a namespace:
+```bash
+kubectl label namespace production environment=production
+```
+
+### Combining podSelector and namespaceSelector
+When both are specified in the same `from` or `to` entry (as a single list item), they are ANDed. Both conditions must be true:
+```yaml
+from:
+  - namespaceSelector:
+      matchLabels:
+        environment: production   # AND
+    podSelector:
+      matchLabels:
+        role: frontend            # Must be in a production namespace AND be a frontend pod
+```
+
+When they are in separate list items, they are ORed:
+```yaml
+from:
+  - namespaceSelector:
+      matchLabels:
+        environment: production   # OR
+  - podSelector:
+      matchLabels:
+        role: frontend            # ...be a frontend pod in the same namespace
+```
+
+This AND/OR distinction is a very common source of bugs. Check carefully.
+
+### ipBlock
+Selects traffic by IP CIDR range. Used for allowing/blocking external IPs.
+
+```yaml
+from:
+  - ipBlock:
+      cidr: 10.0.0.0/8        # Allow from the entire internal network
+      except:
+        - 10.1.0.0/16         # Except this subnet
+```
+
+---
+
+## The Deny-All + Allow-List Pattern (Production Standard)
+
+**Step 1:** Apply `default-deny-all` to the namespace (denies all ingress and egress).
+
+**Step 2:** Add specific allow policies for each communication path you need:
+- Allow ingress from the Ingress Controller namespace.
+- Allow ingress from monitoring (Prometheus scraping).
+- Allow egress to DNS (port 53, both UDP and TCP).
+- Allow egress to specific downstream services.
+
+This ensures that any newly deployed pod is automatically isolated until a policy explicitly permits its traffic. Forgetting to write a NetworkPolicy means the communication fails visibly, which is far preferable to silent over-permissiveness.
+
+---
+
+## Common Production Patterns
+
+### 1. Allow the Ingress Controller to reach pods
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-controller
+  namespace: workloads
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: web
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 8080
+          protocol: TCP
+```
+
+### 2. Allow Prometheus to scrape metrics
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-scrape
+  namespace: workloads
+spec:
+  podSelector: {}          # All pods in namespace
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9090
+          protocol: TCP
+```
+
+### 3. Allow egress to DNS (always required)
+
+When you deny all egress, DNS stops working immediately and pods cannot resolve any hostnames. Always include this in your egress policies:
+
+```yaml
+egress:
+  - to:
+      - namespaceSelector: {}  # Any namespace (kube-dns is in kube-system)
+    ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP  # DNS falls back to TCP for large responses (DNSSEC)
+```
+
+---
+
+## Blocking the Cloud Metadata API (169.254.169.254)
+
+This is a **critical security control** in cloud environments. The instance metadata API at `169.254.169.254` is a link-local IP accessible from every instance (pod). It provides:
+- IAM role credentials for the node (EC2 instance profile, GCP service account, Azure managed identity)
+- User data (often contains bootstrap secrets)
+- Instance identity documents
+
+A compromised pod can call `http://169.254.169.254/latest/meta-data/iam/security-credentials/<role-name>` and receive temporary AWS credentials with the full permissions of the node's IAM role. This is a well-known privilege escalation technique (e.g., the 2019 Capital One breach exploited SSRF to reach the EC2 metadata API).
+
+**Protection layers:**
+1. Use IMDSv2 (token-required) on EC2 — mitigates SSRF that cannot set custom HTTP headers.
+2. Apply `block-cloud-metadata` NetworkPolicy — blocks at the Kubernetes network layer regardless of IMDSv2 configuration.
+3. Apply least-privilege IAM roles to nodes — minimize blast radius if credentials are stolen.
+
+See `block-metadata-api.yml` for the NetworkPolicy implementation.
+
+---
+
+## Testing NetworkPolicies
+
+```bash
+# Test that a connection IS allowed (should succeed):
+kubectl exec -n workloads deploy/frontend -- \
+  curl -s --max-time 5 http://api-service.workloads.svc.cluster.local:8080/health
+
+# Test that a connection IS blocked (should time out or be refused):
+kubectl exec -n workloads deploy/frontend -- \
+  curl -s --max-time 5 http://mysql.database.svc.cluster.local:3306
+# Expected: connection refused or timeout (NOT a successful connection)
+
+# Test metadata API is blocked:
+kubectl exec -n workloads deploy/frontend -- \
+  curl -s --max-time 5 http://169.254.169.254/latest/meta-data/
+# Expected: timeout (connection blocked by NetworkPolicy)
+
+# Test DNS still works (after applying deny-all + allow-DNS egress):
+kubectl exec -n workloads deploy/frontend -- \
+  nslookup kubernetes.default.svc.cluster.local
+
+# Use netshoot for comprehensive network debugging:
+kubectl run netshoot --image=nicolaka/netshoot --rm -it -n workloads --restart=Never -- bash
+# Inside: curl, dig, nmap, tcpdump, ss, iperf3 all available
+```
+
+---
+
+## Related Files
+
+- `deny-all-ingress.yml` — Default deny-all NetworkPolicy (apply first in every namespace)
+- `allow-same-namespace.yml` — Allow intra-namespace pod communication
+- `mysql-isolation.yml` — Realistic production policy for MySQL (ingress from app, egress DNS only)
+- `block-metadata-api.yml` — Block the cloud metadata API (security critical)

--- a/core/networking/network-policy/allow-same-namespace.yml
+++ b/core/networking/network-policy/allow-same-namespace.yml
@@ -1,0 +1,86 @@
+# ==============================================================================
+# Allow Intra-Namespace Communication
+# ==============================================================================
+# Allows all pods within the same namespace to communicate with each other
+# on any port. This is the minimum required for microservice architectures
+# where services within a namespace need to call each other.
+#
+# Apply this AFTER deny-all to restore communication within the namespace:
+#   kubectl apply -f deny-all-ingress.yml      # Step 1: deny everything
+#   kubectl apply -f allow-same-namespace.yml  # Step 2: allow within namespace
+#
+# IMPORTANT: "Same namespace" is matched using the
+#   kubernetes.io/metadata.name label, which Kubernetes automatically adds
+#   to every namespace and which is immutable (cannot be forged by users
+#   who only have access to create pods, not to label namespaces).
+#
+# Do NOT use a custom label (e.g., name: workloads) for namespace matching
+# in security-critical policies, because users with permission to create
+# pods in their own namespace may also be able to add labels to objects
+# they control. The kubernetes.io/metadata.name label is set by the API
+# server itself and cannot be modified by normal users.
+#
+# NAMESPACE: Change "workloads" to the target namespace before applying.
+# ==============================================================================
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: workloads           # Target namespace — update as needed.
+
+  labels:
+    app.kubernetes.io/name: allow-same-namespace
+    app.kubernetes.io/instance: allow-same-namespace
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: network-policy
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      Allows all pods in the workloads namespace to communicate with each other
+      on any port. Apply after the default-deny-all policy to restore
+      intra-namespace communication while continuing to block cross-namespace
+      and external traffic.
+
+spec:
+  # podSelector: {} matches ALL pods in the namespace.
+  # This policy grants intra-namespace access to every pod.
+  # If you only want specific pods to receive intra-namespace traffic,
+  # use a label selector here instead of an empty selector.
+  podSelector: {}
+
+  policyTypes:
+    - Ingress
+    # Note: we only control Ingress here. Egress back to same-namespace pods
+    # is handled by the corresponding policy on the sending pod (or is allowed
+    # if no egress policy applies to the sender). If you have a deny-all
+    # egress policy in this namespace, add a matching Egress block below.
+
+  ingress:
+    - from:
+        # namespaceSelector with kubernetes.io/metadata.name matches only pods
+        # in THIS specific namespace. This is the standard recommended approach.
+        # kubernetes.io/metadata.name is an automatic, immutable label added by
+        # the Kubernetes API server — it cannot be spoofed by tenants.
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: workloads   # Must match this namespace's name.
+
+      # No ports restriction means ALL ports are allowed.
+      # To restrict to specific ports, add a ports block:
+      # ports:
+      #   - protocol: TCP
+      #     port: 8080
+      #   - protocol: TCP
+      #     port: 9090  # metrics
+
+  # If you also have a deny-all egress policy, add this block to allow
+  # same-namespace egress communication:
+  #
+  # egress:
+  #   - to:
+  #       - namespaceSelector:
+  #           matchLabels:
+  #             kubernetes.io/metadata.name: workloads
+  #     # No ports restriction = all ports allowed within namespace

--- a/core/networking/network-policy/block-metadata-api.yml
+++ b/core/networking/network-policy/block-metadata-api.yml
@@ -1,0 +1,136 @@
+# ==============================================================================
+# Block Cloud Metadata API Access
+# ==============================================================================
+# EC2 / GCP / Azure metadata APIs are accessible by default from every pod.
+# Pods can steal node IAM credentials through these APIs.
+# This policy blocks that critical attack vector.
+#
+# BACKGROUND — WHY THIS IS CRITICAL:
+# ───────────────────────────────────
+# Cloud providers expose instance metadata at the link-local IP 169.254.169.254.
+# This API is reachable from every VM (node) and from every pod running on that
+# node. It provides:
+#
+#   AWS:   http://169.254.169.254/latest/meta-data/iam/security-credentials/<role>
+#          Returns temporary AWS access keys for the node's IAM instance profile.
+#
+#   GCP:   http://169.254.169.254/computeMetadata/v1/instance/service-accounts/
+#          Returns OAuth tokens for the node's GCP service account.
+#
+#   Azure: http://169.254.169.254/metadata/identity/oauth2/token
+#          Returns tokens for the node's managed identity.
+#
+# ATTACK SCENARIO (Server-Side Request Forgery / SSRF):
+#   1. Attacker finds an SSRF vulnerability in your web application.
+#   2. Attacker crafts a request that causes the app pod to fetch:
+#        http://169.254.169.254/latest/meta-data/iam/security-credentials/my-node-role
+#   3. The app pod receives temporary AWS credentials for the node's IAM role.
+#   4. Attacker uses those credentials to access S3 buckets, RDS, Secrets Manager,
+#      or pivot to other AWS services — all with the node's permissions.
+#
+#   This is exactly how the 2019 Capital One breach occurred (via an SSRF in
+#   a WAF running on EC2). Credentials from the EC2 metadata API were used to
+#   exfiltrate over 100 million customer records from S3.
+#
+# MITIGATIONS (use all three for defense in depth):
+#   1. IMDSv2 (Token-required mode): Requires a PUT request to get a session
+#      token before metadata can be fetched. Mitigates simple SSRF (HTTP GET).
+#      Enable in Terraform: metadata_options { http_tokens = "required" }
+#      Does NOT protect if the SSRF can make arbitrary HTTP requests (PUT + GET).
+#
+#   2. This NetworkPolicy: Blocks TCP/UDP to 169.254.169.254 at the kernel
+#      network level regardless of IMDSv2. Even if IMDSv2 is misconfigured
+#      or disabled, pods cannot reach the metadata API.
+#
+#   3. Least-privilege node IAM roles: Minimise the blast radius if credentials
+#      are stolen. Node roles should NOT have S3 full access, Admin, or other
+#      broad permissions. Use pod-level IAM via IRSA (AWS), Workload Identity
+#      (GCP), or AAD Pod Identity (Azure) instead of node-level roles.
+#
+# APPLYING:
+#   Apply to every application namespace. Do NOT apply to kube-system or
+#   namespaces running the cloud controller manager — those system components
+#   legitimately need to reach the metadata API for cloud integration.
+#
+#   kubectl apply -f block-metadata-api.yml -n workloads
+#   kubectl apply -f block-metadata-api.yml -n application
+#   kubectl apply -f block-metadata-api.yml -n staging
+#   # etc. for every tenant/workload namespace.
+#
+# VERIFY IT WORKS:
+#   kubectl exec -n workloads deploy/any-app -- \
+#     curl -s --max-time 5 http://169.254.169.254/latest/meta-data/
+#   # Expected output: nothing (connection times out or is refused)
+# ==============================================================================
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: block-cloud-metadata
+  namespace: workloads         # Apply to every application/workload namespace.
+                               # Do NOT apply to kube-system.
+
+  labels:
+    app.kubernetes.io/name: block-cloud-metadata
+    app.kubernetes.io/instance: block-cloud-metadata
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: network-policy
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      Blocks all pod egress to 169.254.169.254/32 (the cloud instance metadata
+      API endpoint used by AWS, GCP, and Azure). Prevents compromised pods from
+      stealing node IAM credentials via SSRF or direct access. Apply to all
+      workload namespaces. Do not apply to kube-system.
+
+spec:
+  # podSelector: {} applies this policy to ALL pods in the namespace.
+  # If you only want to block specific pods (e.g., untrusted user workloads),
+  # use a label selector here. But in most cases, ALL pods should be blocked
+  # from the metadata API — legitimate metadata access should use pod-level
+  # identity (IRSA, Workload Identity) rather than the node metadata API.
+  podSelector: {}
+
+  policyTypes:
+    - Egress    # We are restricting outbound connections from pods.
+
+  egress:
+    # ALLOW: DNS egress — pods must still be able to resolve DNS.
+    # If you have a separate allow-dns policy in this namespace, you can
+    # omit this block here. Include it if this is the only egress policy.
+    - to:
+        - namespaceSelector: {}   # Any namespace (to reach kube-dns in kube-system)
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+
+    # ALLOW: All other egress EXCEPT to the metadata API.
+    # By allowing all non-metadata destinations and denying only the metadata
+    # IP, this policy is additive — it can coexist with other egress policies.
+    #
+    # Strategy: Allow traffic to all IPs EXCEPT 169.254.169.254/32.
+    # The ipBlock "except" field achieves this — allow 0.0.0.0/0, except the
+    # metadata API address.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0          # Allow all IPv4 destinations...
+            except:
+              - 169.254.169.254/32   # ...EXCEPT the cloud metadata API.
+                                     # This is a /32 (single host) because the
+                                     # metadata API is always exactly this one IP
+                                     # across AWS, GCP, and Azure.
+
+    # IPv6 metadata endpoint (if your cluster runs dual-stack)
+    # GCP uses fd00:ec2::254 for IPv6 metadata. AWS uses the same link-local.
+    # - to:
+    #     - ipBlock:
+    #         cidr: ::/0
+    #         except:
+    #           - fd00:ec2::254/128
+
+    # Note: This policy does NOT block access to the metadata API via the
+    # node's primary IP (some CNI plugins route link-local traffic differently).
+    # IMDSv2 enforcement at the cloud level is an additional required safeguard.

--- a/core/networking/network-policy/deny-all-ingress.yml
+++ b/core/networking/network-policy/deny-all-ingress.yml
@@ -1,0 +1,85 @@
+# ==============================================================================
+# Default Deny-All NetworkPolicy
+# ==============================================================================
+# IMPORTANT: Apply this first in every namespace, then add specific allow rules.
+# ┌──────────────────────────────────────────────────────────────────────────┐
+# │ This is the foundation of a zero-trust network posture. Without this   │
+# │ policy, ALL traffic is allowed by default. Any pod can reach any other  │
+# │ pod in any namespace on any port — including your databases.            │
+# │                                                                          │
+# │ Workflow:                                                                │
+# │   1. kubectl apply -f deny-all-ingress.yml                              │
+# │   2. Add allow policies for specific required communication paths.       │
+# │   3. Test that required paths work and disallowed paths are blocked.    │
+# └──────────────────────────────────────────────────────────────────────────┘
+#
+# WHAT THIS POLICY DOES:
+#   - podSelector: {} matches ALL pods in the namespace (the empty selector is
+#     a wildcard — it selects every pod regardless of labels).
+#   - policyTypes: [Ingress, Egress] — this policy governs both directions.
+#   - No ingress rules → all inbound traffic is dropped.
+#   - No egress rules → all outbound traffic is dropped.
+#
+# IMMEDIATE EFFECTS AFTER APPLYING:
+#   - Pods can no longer receive any inbound connections (from other pods,
+#     the Ingress Controller, or external traffic).
+#   - Pods can no longer make any outbound connections — including DNS queries.
+#     This means any pod that tries to resolve a hostname will fail with
+#     "Temporary failure in name resolution" until you add a DNS egress rule.
+#
+# WHAT TO ADD NEXT (in separate NetworkPolicy files):
+#   - DNS egress (port 53 UDP/TCP to kube-dns): required for all workloads
+#   - Ingress from Ingress Controller namespace: for HTTP/HTTPS services
+#   - Egress to specific downstream services: database, cache, external APIs
+#   - Ingress from monitoring namespace: for Prometheus scraping
+#
+# NAMESPACE: Change "database" to the target namespace before applying.
+# This file targets the "database" namespace as an example of the highest-
+# security namespace. Apply equivalents to all namespaces.
+#
+# Apply:
+#   kubectl apply -f deny-all-ingress.yml
+#   kubectl describe networkpolicy default-deny-all -n database
+# ==============================================================================
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: database          # Apply to the highest-risk namespaces first
+                               # (databases, secret stores, payment processing).
+                               # Replicate to every namespace in your cluster.
+
+  labels:
+    app.kubernetes.io/name: default-deny-all
+    app.kubernetes.io/instance: default-deny-all
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: network-policy
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      Default deny-all NetworkPolicy for the database namespace. Drops all
+      ingress and egress traffic for every pod in the namespace. Apply this
+      first, then add specific allow policies. This implements the zero-trust
+      network principle: deny by default, allow by explicit exception.
+
+spec:
+  # podSelector: {} — An empty label selector matches ALL pods in the namespace.
+  # This is the standard way to write a "catch-all" NetworkPolicy.
+  # It is NOT the same as omitting podSelector (which is invalid).
+  podSelector: {}
+
+  # policyTypes must list BOTH Ingress and Egress to deny traffic in
+  # both directions. Listing only Ingress would still allow all egress
+  # (pods could still exfiltrate data or reach the metadata API).
+  policyTypes:
+    - Ingress
+    - Egress
+
+  # No ingress rules → all inbound connections are DROPPED.
+  # (Omitting the ingress field entirely when Ingress is in policyTypes
+  # is equivalent to ingress: [] — the result is the same: deny all.)
+
+  # No egress rules → all outbound connections are DROPPED.
+  # (Same logic: omitting egress field when Egress is in policyTypes = deny all.)

--- a/core/networking/network-policy/mysql-isolation.yml
+++ b/core/networking/network-policy/mysql-isolation.yml
@@ -1,0 +1,138 @@
+# ==============================================================================
+# MySQL Isolation NetworkPolicy — Production Database Hardening
+# ==============================================================================
+# Restricts MySQL pods so that:
+#   INGRESS: Only pods in namespaces labeled "environment: production" can
+#            connect to MySQL on port 3306.
+#   EGRESS:  MySQL pods can only make DNS queries (required for hostname
+#            resolution). All other outbound traffic is blocked.
+#
+# WHY THIS MATTERS:
+#   Without this policy, any pod in the cluster — including pods in dev,
+#   staging, or a compromised workload namespace — can connect to MySQL
+#   on port 3306. This policy implements least-privilege network access.
+#
+# SETUP REQUIRED:
+#   Label the namespaces that should have MySQL access:
+#     kubectl label namespace production environment=production
+#     kubectl label namespace app-backend environment=production
+#
+#   Verify:
+#     kubectl get namespace --show-labels | grep environment
+#
+# APPLYING:
+#   kubectl apply -f mysql-isolation.yml -n database
+#
+# TESTING:
+#   # Should succeed (from a pod in a production-labeled namespace):
+#   kubectl exec -n production deploy/app -- \
+#     mysql -h mysql.database.svc.cluster.local -u appuser -p -e "SELECT 1"
+#
+#   # Should be BLOCKED (from a pod in an unlabeled namespace):
+#   kubectl exec -n staging deploy/app -- \
+#     curl -s --max-time 5 telnet://mysql.database.svc.cluster.local:3306
+#   # Expected: connection timeout
+# ==============================================================================
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mysql-allow-app-namespace
+  namespace: database            # This policy lives in the database namespace,
+                                 # protecting the MySQL pods that run there.
+
+  labels:
+    app.kubernetes.io/name: mysql-allow-app-namespace
+    app.kubernetes.io/instance: mysql-allow-app-namespace
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: network-policy
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      Restricts MySQL access to pods in namespaces labeled environment: production
+      only. MySQL pods can only receive connections on port 3306 from production
+      namespaces, and can only send outbound traffic to DNS. All other traffic
+      is blocked. Requires the database namespace to have a default-deny-all
+      NetworkPolicy applied first.
+
+spec:
+  # podSelector targets only the MySQL pods.
+  # Pods without this label are unaffected by this policy.
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: mysql   # Must match the label on MySQL pods.
+
+  policyTypes:
+    - Ingress    # Control who can connect TO MySQL.
+    - Egress     # Control where MySQL pods can connect TO.
+
+  # ---------------------------------------------------------------------------
+  # Ingress Rules — who can reach MySQL
+  # ---------------------------------------------------------------------------
+  ingress:
+    - from:
+        # Allow connections ONLY from pods in namespaces labeled:
+        #   environment: production
+        #
+        # This is an AND condition because namespaceSelector and podSelector
+        # are in the same list entry (not separate entries).
+        # It means: from pods in production namespaces (any pod in those namespaces).
+        #
+        # To restrict to specific pods within production namespaces, add:
+        #   podSelector:
+        #     matchLabels:
+        #       role: backend
+        - namespaceSelector:
+            matchLabels:
+              environment: production   # The namespace must have this label.
+                                        # Label namespaces with:
+                                        #   kubectl label namespace <ns> environment=production
+
+      ports:
+        - protocol: TCP
+          port: 3306        # MySQL default port.
+                            # If your MySQL uses a non-standard port, change this.
+                            # Named ports can also be used if the MySQL pod spec
+                            # defines a named containerPort.
+
+  # ---------------------------------------------------------------------------
+  # Egress Rules — where MySQL pods can connect
+  # ---------------------------------------------------------------------------
+  egress:
+    # Allow DNS resolution — MySQL needs to resolve hostnames (e.g., for
+    # replication, external auth plugins, or cloud RDS endpoints).
+    # Without this rule, DNS queries from MySQL pods will fail silently,
+    # which can cause cascading failures in replication or health checks.
+    - to:
+        # Allow DNS to any namespace — kube-dns runs in kube-system, but
+        # the namespace selector must be open to reach it because kube-system
+        # may not have a predictable label in all cluster configurations.
+        # For stricter control, label kube-system and restrict to that.
+        - namespaceSelector: {}   # All namespaces (permits reaching kube-system/kube-dns)
+      ports:
+        - protocol: UDP
+          port: 53          # DNS is primarily UDP. Must allow this.
+        - protocol: TCP
+          port: 53          # DNS falls back to TCP for responses >512 bytes
+                            # (e.g., DNSSEC-signed responses). Always allow both.
+
+    # If MySQL needs to replicate to a replica in another namespace:
+    # - to:
+    #     - namespaceSelector:
+    #         matchLabels:
+    #           environment: production
+    #       podSelector:
+    #         matchLabels:
+    #           app.kubernetes.io/name: mysql-replica
+    #   ports:
+    #     - protocol: TCP
+    #       port: 3306
+
+    # If MySQL needs to reach an external backup storage endpoint:
+    # - to:
+    #     - ipBlock:
+    #         cidr: 10.0.0.0/8    # Internal storage network
+    #   ports:
+    #     - protocol: TCP
+    #       port: 443


### PR DESCRIPTION
## Summary
- Add `deny-all-ingress.yml` — default deny-all NetworkPolicy; applied first, then layered with allow policies
- Add `allow-same-namespace.yml` — allow all pod-to-pod traffic within same namespace; paired with deny-all
- Add `block-metadata-api.yml` — block `169.254.169.254/32` (cloud IMDS endpoint) from all pods; prevents credential theft via SSRF (references Capital One breach pattern); three-layer defense commentary
- Add `mysql-isolation.yml` — ingress to MySQL pods restricted to `notes-app` namespace only via `namespaceSelector`; default-deny egress from MySQL except replication on port 3306
- Add `README.md` — NetworkPolicy enforcement model (CNI-dependent), additive policy composition, `policyTypes` field, and layering strategy

## Issues referenced
Closes #85, relates to #21, #22, #93

## Test plan
- [ ] Apply `deny-all-ingress.yml` — `curl` from another pod fails
- [ ] Apply `allow-same-namespace.yml` — same-namespace pods can communicate
- [ ] `kubectl exec` into a pod and `curl http://169.254.169.254` times out with metadata block applied