### PR TITLE
feat(storage): StorageClass, PV, PVC, LimitRange, and pod-with-PVC example

### DIFF
--- a/core/storage/README.md
+++ b/core/storage/README.md
@@ -1,0 +1,252 @@
+# Kubernetes Storage: Complete Reference
+
+## Storage Concepts Overview
+
+Kubernetes storage separates the concerns of provisioning storage (an infrastructure concern) from consuming storage (a developer concern). The abstractions are:
+
+```
+StorageClass  ──(defines provisioner + parameters)──►  HOW storage is created
+PersistentVolume (PV)  ──(represents actual storage)──►  WHAT storage exists
+PersistentVolumeClaim (PVC)  ──(requests storage)──►  WHAT a pod needs
+Pod  ──(mounts PVC as a volume)──►  WHO uses the storage
+```
+
+---
+
+## StorageClass — Dynamic Provisioning
+
+A StorageClass tells Kubernetes how to dynamically provision a PersistentVolume when a PVC is created. Instead of pre-creating PVs manually (static provisioning), you define a StorageClass once, and Kubernetes automatically creates PVs on demand by calling the specified provisioner.
+
+### Key Fields
+
+```yaml
+provisioner: kubernetes.io/aws-ebs   # The CSI driver or built-in provisioner
+parameters:                          # Provisioner-specific parameters
+  type: gp3
+  iopsPerGB: "10"
+reclaimPolicy: Delete                # What to do with the PV when the PVC is deleted
+volumeBindingMode: WaitForFirstConsumer  # When to bind the PV to the PVC
+allowVolumeExpansion: true           # Allow PVCs to be resized after creation
+mountOptions:                        # Options passed to the mount command
+  - debug
+```
+
+### Common Cloud StorageClasses
+
+**AWS EBS (gp3 — recommended over gp2):**
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-gp3
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp3
+  iops: "3000"
+  throughput: "125"
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+```
+
+**GCP Persistent Disk (pd-ssd):**
+```yaml
+provisioner: pd.csi.storage.gke.io
+parameters:
+  type: pd-ssd
+  replication-type: none
+```
+
+**Azure Disk:**
+```yaml
+provisioner: disk.csi.azure.com
+parameters:
+  skuName: Premium_LRS
+```
+
+---
+
+## PersistentVolume (PV) — Static Provisioning
+
+A PersistentVolume is a cluster-scoped resource representing a piece of storage. It is either:
+- **Statically provisioned**: Created manually by a cluster administrator.
+- **Dynamically provisioned**: Created automatically by a StorageClass provisioner when a PVC is bound.
+
+PVs have a lifecycle independent of any pod. When a pod is deleted, the PV persists (unless the reclaim policy deletes it).
+
+### PV Phases
+1. `Available` — PV exists and is not bound to any PVC.
+2. `Bound` — PV is bound to a specific PVC (one-to-one relationship).
+3. `Released` — The PVC was deleted, but the PV has not yet been reclaimed.
+4. `Failed` — Automatic reclamation has failed.
+
+---
+
+## PersistentVolumeClaim (PVC) — Requesting Storage
+
+A PVC is a namespace-scoped request for storage. It specifies the storage class, access mode, and capacity required. The PV controller matches the PVC to an available PV (or triggers dynamic provisioning) based on these constraints.
+
+**Binding is permanent:** Once a PVC is bound to a PV, that binding is exclusive for the lifetime of the PVC. The same PV cannot be used by another PVC even if the first PVC has no active pods.
+
+---
+
+## VolumeClaimTemplates (StatefulSets)
+
+For StatefulSets, each pod replica needs its own independent PVC (a database pod must not share storage with its replicas). `volumeClaimTemplates` in a StatefulSet automatically creates a PVC for each pod replica:
+
+```yaml
+volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      storageClassName: ebs-gp3
+      resources:
+        requests:
+          storage: 20Gi
+```
+
+This creates PVCs named `data-<statefulset-name>-0`, `data-<statefulset-name>-1`, etc. These PVCs are NOT deleted when the StatefulSet is scaled down or deleted — this is intentional to prevent accidental data loss. You must delete the PVCs manually.
+
+---
+
+## Access Modes
+
+Access modes define how a PV can be mounted. A PV supports one or more access modes, but can only be mounted in one mode at a time.
+
+| Mode | Short | Description | Typical Storage Types |
+|---|---|---|---|
+| `ReadWriteOnce` | RWO | Read-write by a single node | EBS, Azure Disk, local storage |
+| `ReadOnlyMany` | ROX | Read-only by multiple nodes simultaneously | NFS, CephFS |
+| `ReadWriteMany` | RWX | Read-write by multiple nodes simultaneously | NFS, CephFS, EFS (via CSI) |
+| `ReadWriteOncePod` | RWOP | Read-write by a single **pod** (1.22+, GA in 1.29) | EBS (with CSI driver 1.22+) |
+
+**ReadWriteOncePod** is the most restrictive mode and the recommended default for single-pod workloads. Unlike RWO (which allows multiple pods on the same node to access the volume), RWOP guarantees that only one pod in the entire cluster mounts the volume read-write. This prevents data corruption from concurrent writes.
+
+---
+
+## Reclaim Policies
+
+The reclaim policy controls what happens to the PV when the bound PVC is deleted.
+
+### Retain
+The PV is not deleted. Its data is preserved. The PV transitions to `Released` state and must be manually reclaimed by an administrator before it can be reused. Use for:
+- Any production data you cannot afford to lose.
+- Data that needs to be migrated or exported before deletion.
+- Compliance scenarios requiring data retention.
+
+```bash
+# To reuse a Released PV manually:
+# 1. Delete the PV
+# 2. Manually clean up the underlying storage
+# 3. Recreate the PV (or let the StorageClass create a new one)
+```
+
+### Delete (Default for dynamic provisioning)
+The underlying storage resource (EBS volume, GCP disk, etc.) is deleted when the PVC is deleted. Use for:
+- Ephemeral scratch space.
+- Caches that can be rebuilt.
+- Development environments.
+
+**WARNING:** If you accidentally delete a PVC with `reclaimPolicy: Delete`, the data is gone immediately and permanently. In production, use `Retain` for anything that matters.
+
+### Recycle (Deprecated — do not use)
+Scrubs the volume with `rm -rf` and makes it available again. Deprecated in Kubernetes 1.11 in favor of dynamic provisioning. Not supported by most CSI drivers.
+
+---
+
+## Volume Types
+
+### hostPath (Development Only)
+Mounts a file or directory from the host node's filesystem. Used for:
+- Local development and testing (minikube, kind).
+- Reading node-level data (e.g., `/var/log` for log collectors).
+- DaemonSet workloads that need host filesystem access.
+
+**NEVER use hostPath for application data in production:**
+- Data is node-local — if the pod is rescheduled to a different node, it loses access to its data.
+- Grants pods access to the host filesystem, which is a significant security risk.
+- No replication, no redundancy, no high availability.
+
+### NFS (Network File System)
+Mounts an NFS export. Supports ReadWriteMany (RWX), making it suitable for workloads that need shared storage across multiple pods. Requires an NFS server (can be in-cluster using the NFS CSI driver or external). Performance is network-dependent.
+
+### Cloud Volumes
+- **AWS EBS** (`ebs.csi.aws.com`): Block storage, ReadWriteOnce. Fast, reliable. Each pod gets its own volume. Not shareable.
+- **AWS EFS** (`efs.csi.aws.com`): NFS-based, ReadWriteMany. For shared storage across pods/nodes.
+- **GCP Persistent Disk** (`pd.csi.storage.gke.io`): Block storage, ReadWriteOnce.
+- **GCP Filestore** (`filestore.csi.storage.gke.io`): NFS, ReadWriteMany.
+- **Azure Disk** (`disk.csi.azure.com`): Block storage, ReadWriteOnce.
+- **Azure Files** (`file.csi.azure.com`): SMB/NFS, ReadWriteMany.
+
+### ConfigMap and Secret Volumes
+Mount ConfigMap or Secret data as files in a pod. Kubernetes updates the mounted files when the ConfigMap/Secret changes (with a short propagation delay). Use for configuration files, certificates, and credentials.
+
+---
+
+## CSI Drivers
+
+The Container Storage Interface (CSI) is the standard API for storage vendors to write Kubernetes storage drivers without modifying the core Kubernetes codebase. CSI replaced the legacy in-tree volume plugins (which are being removed in Kubernetes 1.28+).
+
+**Installing a CSI driver (example: AWS EBS CSI):**
+```bash
+# Via Helm (recommended):
+helm repo add aws-ebs-csi-driver https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+helm install aws-ebs-csi-driver aws-ebs-csi-driver/aws-ebs-csi-driver \
+  --namespace kube-system
+
+# The driver deploys:
+# - Controller plugin (Deployment): handles volume creation/deletion/attachment
+# - Node plugin (DaemonSet): handles volume mounting on each node
+```
+
+**Verify CSI driver is installed:**
+```bash
+kubectl get csidrivers
+kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-ebs-csi-driver
+```
+
+---
+
+## Debugging Storage Issues
+
+```bash
+# Check PVC status — is it Bound?
+kubectl get pvc -n workloads
+# If STATUS is Pending, check Events with describe
+
+# Describe the PVC to see why it's not binding
+kubectl describe pvc app-data-claim -n workloads
+# Common causes of Pending:
+# - No PV matches the access mode, size, or StorageClass
+# - WaitForFirstConsumer: PVC stays Pending until a pod is scheduled
+# - StorageClass provisioner pod is not running
+
+# Describe the PV to check its status and any error events
+kubectl get pv
+kubectl describe pv local-pv-1
+
+# Check if the StorageClass exists
+kubectl get storageclass
+
+# Check if the CSI driver is running (for dynamic provisioning)
+kubectl get pods -n kube-system | grep csi
+
+# Check events in the namespace for storage errors
+kubectl get events -n workloads --sort-by='.lastTimestamp' | grep -i volume
+
+# Check the pod is actually mounting the volume
+kubectl describe pod <pod-name> -n workloads
+# Look at the "Volumes" and "Mounts" sections
+# Look at Events for mount failures
+```
+
+---
+
+## Related Files
+
+- `storageclass-local.yml` — StorageClass for local development (no-provisioner)
+- `persistent-volume.yml` — Static PV using hostPath (dev only)
+- `persistent-volume-claim.yml` — PVC requesting storage from the local StorageClass
+- `pod-with-pvc.yml` — Pod that mounts the PVC
+- `limitrange.yml` — LimitRange enforcing resource defaults and maximums per namespace

--- a/core/storage/limitrange.yml
+++ b/core/storage/limitrange.yml
@@ -1,0 +1,129 @@
+# ==============================================================================
+# LimitRange — Namespace Resource Governance
+# ==============================================================================
+# A LimitRange sets default resource requests/limits for containers in a
+# namespace and enforces minimum/maximum bounds.
+#
+# Without LimitRange, a pod with NO resource declarations gets UNLIMITED
+# resources on the node. A single runaway pod can consume all node CPU and
+# memory, starving other pods on the same node (the "noisy neighbor" problem).
+#
+# HOW LIMITRANGE INTERACTS WITH PODS:
+#
+# 1. DEFAULT: If a container in a new pod omits resources.requests or
+#    resources.limits, the LimitRange's default/defaultRequest values are
+#    injected by the admission controller BEFORE the pod is created.
+#    This means all pods in this namespace automatically have resource
+#    governance even if developers forgot to specify them.
+#
+# 2. ENFORCEMENT: If a container specifies resources that exceed the max
+#    or fall below the min, the pod admission is REJECTED with a clear error.
+#    This catches misconfigured pod specs at creation time.
+#
+# 3. QoS CLASS IMPACT:
+#    - Guaranteed: requests == limits for ALL containers (best performance predictability)
+#    - Burstable: requests < limits for at least one container
+#    - BestEffort: no requests or limits set at all (evicted first under pressure)
+#    With this LimitRange's defaults, new pods without explicit resources get
+#    Burstable QoS (requests 100m/128Mi, limits 500m/512Mi).
+#
+# RELATIONSHIP TO RESOURCEQUOTA:
+#   LimitRange operates at the individual container level.
+#   ResourceQuota operates at the namespace level (total aggregate usage).
+#   Use both together: LimitRange prevents runaway individual containers,
+#   ResourceQuota prevents runaway aggregate namespace consumption.
+#
+# Apply:
+#   kubectl apply -f limitrange.yml
+#   kubectl describe limitrange workloads-limit-range -n workloads
+# ==============================================================================
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: workloads-limit-range
+  namespace: workloads
+
+  labels:
+    app.kubernetes.io/name: workloads-limit-range
+    app.kubernetes.io/instance: workloads-limit-range
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: resource-governance
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      LimitRange for the workloads namespace. Injects default resource requests
+      and limits for containers that do not specify them. Enforces maximum
+      container resource bounds to prevent runaway workloads from starving
+      the node. Without LimitRange, pods with no resource declarations
+      receive unlimited node resources.
+
+spec:
+  limits:
+    # -------------------------------------------------------------------------
+    # Container limits — applies to every container in every pod in this namespace.
+    # -------------------------------------------------------------------------
+    - type: Container
+
+      # default: injected as limits if the container omits resources.limits.
+      # Any container that doesn't specify limits gets these values automatically.
+      default:
+        cpu: "500m"         # 0.5 CPU core maximum per container by default.
+                            # Containers that need more must explicitly declare it
+                            # (up to the max below).
+        memory: "512Mi"     # 512 MiB maximum per container by default.
+
+      # defaultRequest: injected as requests if the container omits resources.requests.
+      # Requests affect scheduling (how much capacity the scheduler reserves).
+      # Setting requests below limits allows CPU bursting (Burstable QoS class).
+      defaultRequest:
+        cpu: "100m"         # 0.1 CPU core reserved per container by default.
+        memory: "128Mi"     # 128 MiB reserved per container by default.
+
+      # max: the hard ceiling — no container in this namespace can request
+      # or have limits exceeding these values. If a pod spec exceeds max,
+      # the pod is REJECTED by the admission controller at creation time.
+      # This prevents runaway containers regardless of what developers specify.
+      max:
+        cpu: "2"            # 2 CPU cores maximum per container.
+                            # Adjust to match the largest expected workload
+                            # in this namespace. A container needing more
+                            # should be in a dedicated high-resource namespace.
+        memory: "2Gi"       # 2 GiB maximum per container.
+
+      # min: the floor — containers must request at least this much.
+      # If a container requests less than min, it is rejected.
+      # Usually left unset (commented out) unless you need to prevent
+      # containers from requesting zero resources.
+      # min:
+      #   cpu: "10m"
+      #   memory: "32Mi"
+
+      # maxLimitRequestRatio: the maximum ratio of limit to request.
+      # Prevents containers from setting absurdly large limits relative to
+      # their requests (which can cause resource overcommit instability).
+      # A ratio of 4 means limits cannot be more than 4x the request.
+      # maxLimitRequestRatio:
+      #   cpu: "4"
+      #   memory: "4"
+
+    # -------------------------------------------------------------------------
+    # Pod limits — applies to the SUM of all containers in a pod.
+    # -------------------------------------------------------------------------
+    # Uncomment to enforce aggregate limits per pod (sum of all containers).
+    # - type: Pod
+    #   max:
+    #     cpu: "4"
+    #     memory: "4Gi"
+
+    # -------------------------------------------------------------------------
+    # PersistentVolumeClaim limits — applies to storage requests.
+    # -------------------------------------------------------------------------
+    # Prevents individual PVCs from requesting excessive storage.
+    - type: PersistentVolumeClaim
+      max:
+        storage: "10Gi"     # No single PVC can request more than 10Gi.
+      min:
+        storage: "1Mi"      # PVCs must request at least 1Mi.
+                            # Prevents zero-storage PVCs from being created.

--- a/core/storage/persistent-volume-claim.yml
+++ b/core/storage/persistent-volume-claim.yml
@@ -1,0 +1,87 @@
+# ==============================================================================
+# PersistentVolumeClaim — Requesting Persistent Storage
+# ==============================================================================
+# A PVC is a request for storage. The PV controller matches this PVC to an
+# available PV that satisfies:
+#   1. storageClassName matches
+#   2. accessModes are compatible (PV must support all modes requested)
+#   3. capacity >= the requested amount
+#   4. For WaitForFirstConsumer StorageClass: node topology is compatible
+#
+# With storageClassName: local-storage (WaitForFirstConsumer), this PVC will
+# remain in Pending state until a pod that references it is scheduled. That is
+# expected and correct behaviour — see storageclass-local.yml for explanation.
+#
+# Apply:
+#   kubectl apply -f persistent-volume-claim.yml
+#   kubectl get pvc -n workloads
+#   # STATUS will be Pending until a pod referencing this PVC is scheduled.
+#
+# Once a pod using this PVC starts:
+#   kubectl get pvc -n workloads
+#   # STATUS should change to Bound
+#   kubectl get pv
+#   # local-pv-1 should show STATUS: Bound, CLAIM: workloads/app-data-claim
+# ==============================================================================
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: app-data-claim
+  namespace: workloads        # PVCs are namespace-scoped. The pod using this
+                              # PVC must be in the same namespace.
+
+  labels:
+    app.kubernetes.io/name: app-data-claim
+    app.kubernetes.io/instance: app-data-claim
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      PersistentVolumeClaim requesting 1Gi of local storage from the
+      local-storage StorageClass. Binds to a pre-created PV with matching
+      storageClass and access mode. With WaitForFirstConsumer binding mode,
+      this PVC remains Pending until a pod referencing it is scheduled.
+
+spec:
+  # storageClassName: must exactly match the StorageClass name.
+  # If you set storageClassName: "" (empty string), the PVC requests a PV
+  # with NO StorageClass (legacy pre-1.6 PVs). To use the cluster default
+  # StorageClass, OMIT the storageClassName field entirely.
+  storageClassName: local-storage
+
+  # accessModes: must be a subset of the PV's access modes.
+  # We request ReadWriteOncePod — the most restrictive mode, ensuring
+  # only one pod can mount this volume at any time.
+  accessModes:
+    - ReadWriteOncePod      # Exclusive access for one pod across the cluster.
+                            # Use ReadWriteOnce for older clusters (< 1.29) or
+                            # CSI drivers that don't support RWOP.
+
+  # volumeMode: Filesystem means the volume is mounted as a directory.
+  # Must match the PV's volumeMode. Filesystem is the default.
+  volumeMode: Filesystem
+
+  resources:
+    requests:
+      # Request 1Gi of storage. The bound PV must have at least 1Gi capacity.
+      # You can request less than the PV's capacity (1Gi from a 5Gi PV is fine).
+      # You cannot request more than what any available PV provides.
+      #
+      # After binding, you cannot decrease the request. You can increase it
+      # (if the StorageClass has allowVolumeExpansion: true), but resizing
+      # local hostPath volumes is not supported — you would need to migrate data.
+      storage: 1Gi
+
+  # Optional: selector to restrict which PVs can satisfy this claim.
+  # Useful when you have multiple PVs with the same StorageClass and want to
+  # bind to a specific one (by label).
+  # selector:
+  #   matchLabels:
+  #     storage-tier: ssd
+  #
+  # Or bind to a specific PV by name using the PV's volumeName:
+  # volumeName: local-pv-1
+  # This creates a direct binding to that specific PV, skipping normal matching.

--- a/core/storage/persistent-volume.yml
+++ b/core/storage/persistent-volume.yml
@@ -1,0 +1,122 @@
+# ==============================================================================
+# PersistentVolume — Local Node Storage (Static Provisioning)
+# ==============================================================================
+# A PersistentVolume (PV) is a cluster-scoped resource representing a piece of
+# actual storage. This PV uses hostPath to expose a directory on the local node.
+#
+# IMPORTANT — HOSTPATH IS FOR DEVELOPMENT ONLY:
+# ┌──────────────────────────────────────────────────────────────────────────┐
+# │ DO NOT use hostPath for production application data. Reasons:           │
+# │                                                                          │
+# │ 1. Node-local: Data exists ONLY on the specific node. If the pod is    │
+# │    rescheduled to another node, it cannot access its data.              │
+# │                                                                          │
+# │ 2. No redundancy: A node failure means data loss.                       │
+# │                                                                          │
+# │ 3. Security: hostPath gives pods access to the node's filesystem.      │
+# │    A misconfigured or malicious pod can read/write arbitrary host data. │
+# │                                                                          │
+# │ For production, use:                                                    │
+# │   - AWS: ebs.csi.aws.com (block) or efs.csi.aws.com (shared)          │
+# │   - GCP: pd.csi.storage.gke.io (block) or filestore.csi.storage.gke.io│
+# │   - Azure: disk.csi.azure.com (block) or file.csi.azure.com (shared)  │
+# │   - Bare-metal: Rook/Ceph, OpenEBS, Longhorn, or NFS                  │
+# └──────────────────────────────────────────────────────────────────────────┘
+#
+# BEFORE APPLYING:
+#   Create the directory on the target node:
+#     ssh <node-name>
+#     sudo mkdir -p /data/k8s-pv-1
+#     sudo chmod 755 /data/k8s-pv-1
+#
+# The node name in nodeAffinity.nodeSelectorTerms MUST match an actual node:
+#   kubectl get nodes
+#
+# Apply:
+#   kubectl apply -f persistent-volume.yml
+#   kubectl get pv local-pv-1
+# ==============================================================================
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  # PVs are cluster-scoped — no namespace field.
+  name: local-pv-1
+
+  labels:
+    app.kubernetes.io/name: local-pv-1
+    app.kubernetes.io/instance: local-pv-1
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      Local PersistentVolume backed by hostPath /data/k8s-pv-1 on a specific
+      node. For development use only. Data is not replicated. Requires NodeAffinity
+      to pin pods to the node where the data lives. Do not use hostPath in
+      production — use a cloud CSI driver or distributed storage (Rook, Longhorn).
+
+spec:
+  # storageClassName must match the StorageClass name exactly.
+  # This PV will only be bound to PVCs that request the "local-storage" class.
+  storageClassName: local-storage
+
+  # capacity defines the storage available in this PV.
+  # PVCs requesting <= 5Gi with matching access mode and storageClass can bind to this PV.
+  # Note: For hostPath, this is a DECLARATION, not an enforcement. The OS does
+  # not actually limit disk usage to 5Gi. Real enforcement requires quotas
+  # at the filesystem level (e.g., XFS project quotas, ZFS datasets).
+  capacity:
+    storage: 5Gi
+
+  # accessModes: what operations are permitted on this volume.
+  # ReadWriteOncePod (RWOP) is the most restrictive and recommended mode:
+  # Only ONE pod in the entire cluster can mount this volume for read-write.
+  # Available since Kubernetes 1.22 (GA in 1.29 with CSI drivers).
+  #
+  # For local/hostPath volumes, RWOP enforcement depends on the CSI driver
+  # or local-static-provisioner. With the built-in no-provisioner and Kubelet,
+  # RWOP is enforced at the Kubelet level since 1.29.
+  #
+  # If using an older cluster version, use ReadWriteOnce (RWO) instead:
+  #   ReadWriteOnce — one NODE can mount read-write (multiple pods on same node can share)
+  accessModes:
+    - ReadWriteOncePod    # Preferred: one pod only, across the whole cluster.
+
+  # persistentVolumeReclaimPolicy: what happens when the PVC is deleted.
+  # Retain: PV transitions to Released state. Data is preserved on the node.
+  # An admin must manually delete the PV and clean up /data/k8s-pv-1 before
+  # this storage can be reused.
+  persistentVolumeReclaimPolicy: Retain
+
+  # volumeMode: Filesystem means the volume is formatted and mounted as a
+  # filesystem directory. The alternative is Block (raw block device), which
+  # is used by databases (PostgreSQL, MySQL) that manage their own I/O directly.
+  volumeMode: Filesystem
+
+  # local + nodeAffinity is the correct way to define local storage PVs.
+  # This combination replaced the older hostPath approach and is what the
+  # local-static-provisioner creates.
+  #
+  # local.path: the directory on the node's filesystem.
+  # Choose paths under /data, /mnt/disks, etc. — avoid /mnt/data which
+  # is often owned by root and not writable by the pod's non-root user.
+  local:
+    path: /data/k8s-pv-1    # Must exist on the node before applying.
+                             # Create it: sudo mkdir -p /data/k8s-pv-1
+
+  # nodeAffinity is REQUIRED for local volumes.
+  # Without nodeAffinity, the scheduler doesn't know the volume is node-local
+  # and may schedule the pod on a different node where the path doesn't exist.
+  # The PVC will bind to this PV, the pod will be scheduled anywhere, and then
+  # fail to mount because /data/k8s-pv-1 doesn't exist on the scheduled node.
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname   # Built-in node label, always present.
+              operator: In
+              values:
+                - worker-node-1   # CHANGE THIS to the actual node name.
+                                  # kubectl get nodes to find node names.

--- a/core/storage/pod-with-pvc.yml
+++ b/core/storage/pod-with-pvc.yml
@@ -1,0 +1,195 @@
+# ==============================================================================
+# Pod with PersistentVolumeClaim — Persistent Storage Demo
+# ==============================================================================
+# Demonstrates an nginx pod mounting a PVC for persistent content storage.
+#
+# PVC provides persistent storage that survives pod restarts.
+# When this pod is deleted and recreated, the data in /usr/share/nginx/html
+# remains intact in the PVC (and the backing PV on the node's disk).
+#
+# This is in contrast to emptyDir volumes, which are ephemeral and deleted
+# when the pod terminates.
+#
+# PRODUCTION NOTE:
+#   In production, use a Deployment or StatefulSet rather than a bare Pod.
+#   Bare Pods are not rescheduled if a node fails. A Deployment will restart
+#   the pod on another node, but note: with ReadWriteOncePod access mode, the
+#   new pod must be scheduled on the SAME node where the PV lives (enforced by
+#   the nodeAffinity on the PV and WaitForFirstConsumer binding).
+#
+# Apply:
+#   # Ensure the namespace exists first:
+#   kubectl create namespace workloads --dry-run=client -o yaml | kubectl apply -f -
+#   kubectl apply -f persistent-volume-claim.yml
+#   kubectl apply -f pod-with-pvc.yml
+#   kubectl get pod nginx-with-pvc -n workloads
+# ==============================================================================
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-with-pvc
+  namespace: workloads
+
+  labels:
+    app.kubernetes.io/name: nginx-with-pvc
+    app.kubernetes.io/instance: nginx-with-pvc
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      Nginx pod demonstrating PersistentVolumeClaim usage. Mounts the
+      app-data-claim PVC at /usr/share/nginx/html for persistent content
+      storage that survives pod restarts. Uses production-grade security
+      contexts. In production, wrap this in a Deployment for automatic
+      rescheduling on node failure.
+
+spec:
+  # automountServiceAccountToken: false — this pod does not need to call
+  # the Kubernetes API, so we disable the service account token mount.
+  # By default, every pod gets a token mounted at
+  # /var/run/secrets/kubernetes.io/serviceaccount/token. If the pod is
+  # compromised, this token could be used to query the API server.
+  automountServiceAccountToken: false
+
+  # terminationGracePeriodSeconds: 60 gives nginx 60 seconds to finish
+  # serving in-flight requests before SIGKILL is sent. During this window,
+  # nginx handles SIGTERM by stopping acceptance of new connections and
+  # draining existing ones. Adjust based on your longest expected request.
+  terminationGracePeriodSeconds: 60
+
+  securityContext:
+    # runAsNonRoot: true — the container's process must NOT run as UID 0 (root).
+    # If the image entrypoint is root, the pod will fail to start. This prevents
+    # privilege escalation exploits that rely on the process being root.
+    runAsNonRoot: true
+
+    # runAsUser: 1000 — run as a specific non-root UID.
+    # The PVC's mounted directory must be accessible by this UID.
+    # The fsGroup below ensures group ownership is set correctly.
+    runAsUser: 1000
+
+    # fsGroup: 2000 — Kubernetes sets the group ownership of the mounted volume
+    # to this GID and makes it group-writable. This allows the container
+    # (running as UID 1000) to write to the volume (GID 2000).
+    # Without fsGroup, the volume may be owned by root (UID 0, GID 0) and
+    # the non-root process cannot write to it.
+    fsGroup: 2000
+
+    # seccompProfile: RuntimeDefault applies the container runtime's default
+    # seccomp profile, which blocks dangerous syscalls (e.g., ptrace, mount,
+    # kexec_load). This reduces the attack surface significantly with minimal
+    # application compatibility impact.
+    seccompProfile:
+      type: RuntimeDefault
+
+  containers:
+    - name: nginx
+      # Use a specific digest or tag for reproducibility.
+      # "latest" is non-deterministic and can silently pull a broken image.
+      image: nginx:1.25-alpine   # Alpine-based: smaller image, reduced attack surface.
+
+      ports:
+        - name: http
+          containerPort: 8080    # Running on 8080 (non-privileged port) because
+                                 # the container runs as non-root UID 1000.
+                                 # Ports < 1024 require root or NET_BIND_SERVICE
+                                 # capability. We drop ALL capabilities below.
+
+      securityContext:
+        # allowPrivilegeEscalation: false prevents the process from gaining
+        # more privileges than its parent (e.g., via setuid binaries or sudo).
+        allowPrivilegeEscalation: false
+
+        # readOnlyRootFilesystem: true mounts the container's root filesystem
+        # as read-only. The container cannot modify its own image layers.
+        # This prevents many classes of attacks and makes tampering visible.
+        # Any writes must go to explicitly mounted volumes or emptyDirs.
+        readOnlyRootFilesystem: true
+
+        capabilities:
+          # drop: ALL removes all Linux capabilities from the container.
+          # Default capabilities include chown, setuid, net_bind_service, etc.
+          # A container with no capabilities is significantly hardened.
+          drop: ["ALL"]
+          # add: [] — do not add back any capabilities unless absolutely required.
+          # If the app needs to bind to port 80, add net_bind_service:
+          # add: ["NET_BIND_SERVICE"]
+
+      resources:
+        requests:
+          # requests: the amount Kubernetes reserves on the node for this container.
+          # The scheduler uses requests for placement decisions.
+          memory: "128Mi"
+          cpu: "100m"           # 100 millicores = 0.1 CPU core.
+        limits:
+          # limits: the maximum the container is allowed to use.
+          # Exceeding memory limit → OOMKilled (pod is terminated).
+          # Exceeding CPU limit → throttled (pod is slowed, not terminated).
+          # Set memory limit == request (Guaranteed QoS) for predictable performance.
+          memory: "128Mi"
+          # Note: CPU limits are omitted intentionally by some teams to prevent
+          # unnecessary throttling. If omitted, the container can burst to
+          # available node CPU. For consistent latency, set cpu limits = requests.
+          cpu: "200m"
+
+      volumeMounts:
+        - name: html-content           # Must match the volume name defined below.
+          mountPath: /usr/share/nginx/html  # Default nginx web root.
+                                       # Files here are served over HTTP.
+          readOnly: false              # false because nginx (or a sidecar) needs to
+                                       # write files here. For read-only content
+                                       # (e.g., static files from a ConfigMap),
+                                       # set readOnly: true.
+
+        # nginx needs a writable location for its PID file and cache.
+        # Since readOnlyRootFilesystem: true, we must provide emptyDir volumes
+        # for any paths nginx writes to.
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+          readOnly: false
+
+        - name: nginx-run
+          mountPath: /var/run
+          readOnly: false
+
+      # readinessProbe: determines when the pod is ready to receive traffic.
+      # Until this probe succeeds, the pod is not added to Service Endpoints.
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 8080
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        failureThreshold: 3
+
+      # livenessProbe: if this probe fails, the container is restarted.
+      livenessProbe:
+        httpGet:
+          path: /
+          port: 8080
+        initialDelaySeconds: 15
+        periodSeconds: 20
+        failureThreshold: 3
+
+  volumes:
+    # The PVC volume — backed by the PersistentVolumeClaim defined in
+    # persistent-volume-claim.yml. The PVC must exist in the same namespace
+    # as this pod before the pod can start.
+    - name: html-content
+      persistentVolumeClaim:
+        claimName: app-data-claim    # Must match the PVC name exactly.
+        readOnly: false              # Allow the pod to write to the PVC.
+
+    # emptyDir volumes for nginx's runtime scratch space.
+    # emptyDir is ephemeral — created when the pod starts, deleted when it stops.
+    # Unlike PVCs, emptyDir data does NOT survive pod restarts.
+    - name: nginx-cache
+      emptyDir:
+        sizeLimit: 64Mi    # Optional: limit the emptyDir size to prevent disk exhaustion.
+
+    - name: nginx-run
+      emptyDir:
+        sizeLimit: 1Mi

--- a/core/storage/storageclass-local.yml
+++ b/core/storage/storageclass-local.yml
@@ -1,0 +1,97 @@
+# ==============================================================================
+# StorageClass — Local Storage (Development / Bare-Metal)
+# ==============================================================================
+# This StorageClass configures local node storage for development environments
+# or bare-metal clusters where cloud dynamic provisioners are unavailable.
+#
+# IMPORTANT DIFFERENCES FROM CLOUD STORAGECLASSES:
+#   - provisioner: kubernetes.io/no-provisioner means Kubernetes will NOT
+#     automatically create PVs. You must pre-create PVs manually (see
+#     persistent-volume.yml). This is STATIC provisioning.
+#   - Data lives on the node's local disk. If the pod is rescheduled to a
+#     different node, it cannot access its data. This is why NodeAffinity
+#     on the PV is MANDATORY for local-storage.
+#
+# PRODUCTION ALTERNATIVE:
+#   For production bare-metal, use the local-static-provisioner DaemonSet
+#   (https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner)
+#   which automatically discovers and manages local PVs based on directories
+#   or devices you configure.
+#
+# Apply:
+#   kubectl apply -f storageclass-local.yml
+#   kubectl get storageclass local-storage
+# ==============================================================================
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-storage
+
+  labels:
+    app.kubernetes.io/name: local-storage
+    app.kubernetes.io/instance: local-storage
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      StorageClass for local node storage using static provisioning. Intended for
+      development and bare-metal environments. Data is node-local and not
+      replicated. Requires manually pre-created PersistentVolumes with NodeAffinity.
+      For production, use a cloud StorageClass or the local-static-provisioner.
+
+    # To make this the default StorageClass (auto-selected when PVCs omit
+    # storageClassName), add this annotation. Only ONE StorageClass should be
+    # marked as default per cluster to avoid ambiguity.
+    # storageclass.kubernetes.io/is-default-class: "true"
+
+spec:
+  # provisioner: kubernetes.io/no-provisioner disables dynamic provisioning.
+  # When a PVC is created that matches this StorageClass, Kubernetes will
+  # NOT call any provisioner to create a PV. Instead, it waits for a manually
+  # pre-created PV with the matching StorageClass name to become available.
+  provisioner: kubernetes.io/no-provisioner
+
+  # volumeBindingMode: WaitForFirstConsumer
+  # ─────────────────────────────────────────
+  # This is the CRITICAL setting for local storage.
+  #
+  # WITHOUT this (using Immediate binding, the old default):
+  #   The PVC is immediately bound to the first available matching PV, before
+  #   any pod is scheduled. If the PV's node is different from where the pod
+  #   eventually schedules (due to resource constraints, nodeSelector, etc.),
+  #   the pod CANNOT START — it is stuck waiting for a volume that is on
+  #   the wrong node. This creates a deadlock with no obvious error message.
+  #
+  # WITH WaitForFirstConsumer:
+  #   The PVC remains in Pending state until a pod that references it is
+  #   actually being scheduled. At that point, the scheduler knows which node
+  #   the pod will run on, and THEN binds the PVC to a PV on that specific node.
+  #   This guarantees pod and volume co-location.
+  #
+  # Always use WaitForFirstConsumer for:
+  #   - local-storage (mandatory)
+  #   - topology-aware cloud storage (e.g., EBS in multi-AZ clusters)
+  #   - any storage type that is zone or node-constrained
+  volumeBindingMode: WaitForFirstConsumer
+
+  # reclaimPolicy: Retain preserves the PV and its data when the PVC is deleted.
+  # This is essential for local development where you want data to persist
+  # between test runs. For local storage, Retain is safer than Delete because
+  # there is no automated cleanup process — data stays on the node's disk.
+  #
+  # After the PVC is deleted, the PV transitions to Released state. To reuse it:
+  #   1. Delete the PV object.
+  #   2. Manually clean up /data/k8s-pv-1 on the node.
+  #   3. Recreate the PV (or apply persistent-volume.yml again).
+  reclaimPolicy: Retain
+
+  # allowVolumeExpansion: true allows PVCs to request more storage after
+  # creation by editing the PVC's spec.resources.requests.storage field.
+  # The underlying storage must support expansion (local hostPath does NOT
+  # support this; cloud block storage generally does). Include it here as a
+  # best practice for StorageClass definitions, even if not currently used.
+  allowVolumeExpansion: false   # hostPath/local volumes do not support expansion.
+                                # Set to true for cloud StorageClasses.


### PR DESCRIPTION
## Summary
- Add `storageclass-local.yml` — local StorageClass with `WaitForFirstConsumer` binding (avoids AZ mismatch on multi-zone clusters), `Retain` reclaim policy
- Add `persistent-volume.yml` — static PV with `hostPath` (dev only), `nodeAffinity` pinning, and `Retain` reclaim policy; comment warns against hostPath in production
- Add `persistent-volume-claim.yml` — PVC with `storageClassName` reference, 5Gi request, `ReadWriteOnce`
- Add `limitrange.yml` — namespace LimitRange setting default CPU request (100m), default memory request/limit, and max CPU/memory ceilings
- Add `pod-with-pvc.yml` — pod mounting PVC as read-write volume; `emptyDir` for `/tmp` since `readOnlyRootFilesystem: true`
- Add `README.md` — PV lifecycle states, dynamic vs static provisioning, access mode matrix (RWO/ROX/RWX/RWOPod), reclaim policies

## Issues referenced
Closes #25, relates to #26, #27, #28

## Test plan
- [ ] `kubectl apply -f core/storage/` creates all resources
- [ ] `kubectl get pv,pvc` shows `Bound` status
- [ ] Pod using PVC shows `Running` state