### PR TITLE
feat(config): ConfigMap, Secret, ResourceQuota — configuration and quota management

### DIFF
--- a/core/configuration/README.md
+++ b/core/configuration/README.md
@@ -1,0 +1,294 @@
+# Kubernetes Configuration: ConfigMaps and Secrets
+
+## ConfigMap
+
+A ConfigMap stores non-confidential configuration data as key-value pairs. The data can be consumed by pods as:
+- Environment variables
+- Command-line arguments
+- Files mounted in a volume
+
+ConfigMaps decouple configuration from container images, allowing the same image to run with different configurations across environments (dev, staging, production) by changing only the ConfigMap.
+
+### ConfigMap Use Cases
+
+**Application configuration:**
+```yaml
+data:
+  LOG_LEVEL: "info"
+  DATABASE_HOST: "mysql.database.svc.cluster.local"
+  FEATURE_FLAGS: "new-ui=true,dark-mode=false"
+```
+
+**Configuration files (nginx.conf, application.yaml, etc.):**
+```yaml
+data:
+  nginx.conf: |
+    server {
+      listen 8080;
+      location / {
+        root /usr/share/nginx/html;
+      }
+    }
+```
+
+**Scripts (entrypoint.sh, init.sh):**
+```yaml
+data:
+  entrypoint.sh: |
+    #!/bin/bash
+    set -euo pipefail
+    echo "Starting application..."
+    exec "$@"
+```
+
+### ConfigMap Size Limit
+
+ConfigMaps have a 1 MiB data size limit. For larger configurations (e.g., large CA bundles, model weights), use a volume mount from a PVC or an init container to fetch the data.
+
+---
+
+## Secret Types
+
+| Type | Description | Use Case |
+|---|---|---|
+| `Opaque` | Arbitrary key-value data | Passwords, API keys, tokens |
+| `kubernetes.io/tls` | TLS certificate and private key | TLS termination |
+| `kubernetes.io/dockerconfigjson` | Docker registry credentials | Pull images from private registries |
+| `kubernetes.io/service-account-token` | Service account token | Deprecated — use TokenRequest API |
+| `kubernetes.io/ssh-auth` | SSH private key | SSH authentication |
+| `kubernetes.io/basic-auth` | Username + password | HTTP basic auth |
+
+### Creating Secrets Imperatively (Preferred for Production)
+
+Never write real secret values in YAML files that end up in version control. Use `kubectl` directly or a secrets management tool:
+
+```bash
+# Create an Opaque secret from literal values:
+kubectl create secret generic app-secret \
+  --from-literal=DB_PASSWORD='my-secure-password' \
+  --from-literal=API_KEY='my-api-key' \
+  -n workloads
+
+# Create from a file (the filename becomes the key):
+kubectl create secret generic tls-certs \
+  --from-file=tls.crt \
+  --from-file=tls.key \
+  -n workloads
+
+# View the secret (values are base64-encoded):
+kubectl get secret app-secret -n workloads -o yaml
+
+# Decode a value:
+kubectl get secret app-secret -n workloads \
+  -o jsonpath='{.data.DB_PASSWORD}' | base64 -d
+```
+
+---
+
+## How to Reference ConfigMaps and Secrets in Pods
+
+### Method 1: Environment Variables (Simple, but Limited)
+
+```yaml
+containers:
+  - name: app
+    env:
+      # Individual key from a ConfigMap:
+      - name: LOG_LEVEL
+        valueFrom:
+          configMapKeyRef:
+            name: app-config
+            key: LOG_LEVEL
+
+      # Individual key from a Secret:
+      - name: DB_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: app-secret
+            key: DB_PASSWORD
+
+      # All keys from a ConfigMap as env vars (bulk import):
+    envFrom:
+      - configMapRef:
+          name: app-config
+      - secretRef:
+          name: app-secret
+```
+
+### Method 2: Volume Mounts (Recommended for Secrets and Config Files)
+
+```yaml
+volumes:
+  - name: config-volume
+    configMap:
+      name: app-config
+  - name: secret-volume
+    secret:
+      secretName: app-secret
+      defaultMode: 0400   # Read-only by owner. Do not use 0644 for secrets.
+
+containers:
+  - name: app
+    volumeMounts:
+      - name: config-volume
+        mountPath: /etc/config
+        readOnly: true
+      - name: secret-volume
+        mountPath: /etc/secrets
+        readOnly: true
+```
+
+**In the container:**
+- `/etc/config/LOG_LEVEL` — file containing the value `info`
+- `/etc/config/nginx.conf` — file containing the full nginx configuration
+- `/etc/secrets/DB_PASSWORD` — file containing the password
+
+---
+
+## WARNING: Mount Secrets as Volumes, NOT Environment Variables
+
+This is one of the most important security practices in Kubernetes.
+
+### Why Environment Variables Are Risky for Secrets
+
+**1. /proc/<pid>/environ leaks env vars:**
+Any process on the same node that can read `/proc/<pid>/environ` can see all environment variables of a running process. In a multi-tenant cluster, this is a serious risk.
+
+```bash
+# On the node, any user with root (or CAP_SYS_PTRACE) can read:
+cat /proc/<nginx-pid>/environ | tr '\0' '\n'
+# Output includes: DB_PASSWORD=supersecret
+```
+
+**2. Environment variables are logged:**
+Many applications (and frameworks) dump their environment to logs on startup for debugging. If `DB_PASSWORD` is an env var, it will appear in your log aggregation platform (Elasticsearch, Datadog, Splunk) in plain text.
+
+**3. Child process inheritance:**
+Environment variables are inherited by all child processes. If your app spawns a subprocess (a shell, a third-party tool, a forked worker), that child inherits all secrets.
+
+**4. Heap dumps and core dumps:**
+Environment variables are stored in the process's memory space. Core dumps and heap dumps contain the full memory image, including all environment variables.
+
+**Contrast with volume-mounted secrets:**
+- Files at `/etc/secrets/DB_PASSWORD` are not in the process environment.
+- They are not inherited by child processes.
+- They are not typically logged by frameworks.
+- They update automatically when the Secret is rotated (with a short kubelet sync delay, typically 60s), without requiring a pod restart.
+- Access can be restricted with file permissions (mode 0400).
+
+### Correct Pattern (Volume Mount)
+
+```yaml
+spec:
+  volumes:
+    - name: db-credentials
+      secret:
+        secretName: app-secret
+        items:
+          - key: DB_PASSWORD
+            path: db-password   # Mounted at /etc/secrets/db-password
+            mode: 0400          # Read-only by owner only
+  containers:
+    - name: app
+      volumeMounts:
+        - name: db-credentials
+          mountPath: /etc/secrets
+          readOnly: true
+```
+
+Your application reads the password from `/etc/secrets/db-password`:
+```python
+with open('/etc/secrets/db-password', 'r') as f:
+    password = f.read().strip()
+```
+
+---
+
+## base64 Encoding Is NOT Encryption
+
+This cannot be overstated: the `data` field in a Kubernetes Secret stores values as base64-encoded strings. **Base64 is an encoding, not encryption.** Anyone with read access to the Secret object can trivially decode the values.
+
+```bash
+echo "dGVzdC1wYXNzd29yZA==" | base64 -d
+# Output: test-password
+```
+
+**Secrets at rest are encrypted** only if you configured etcd encryption at rest (via the `EncryptionConfiguration` API resource) **AND** your etcd is encrypted. By default, Kubernetes clusters do NOT encrypt Secrets at rest in etcd.
+
+**Access control:** The primary protection for Secrets is RBAC. Use RBAC to restrict which ServiceAccounts and users can read Secrets, and limit access to named resources using `resourceNames`:
+
+```yaml
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+    resourceNames: ["app-secret"]   # Only this specific Secret, not all Secrets
+```
+
+---
+
+## Production Recommendations for Secret Management
+
+### Option 1: SealedSecrets (GitOps-Friendly)
+SealedSecrets encrypts Kubernetes Secrets using a public key. Only the SealedSecret controller (running in-cluster) can decrypt them using its private key. You can safely commit `SealedSecret` YAML files to git.
+
+```bash
+# Install kubeseal CLI and the controller:
+helm install sealed-secrets sealed-secrets/sealed-secrets -n kube-system
+
+# Seal a secret:
+kubectl create secret generic app-secret --dry-run=client \
+  --from-literal=DB_PASSWORD='secret' -o yaml | \
+  kubeseal --controller-name=sealed-secrets -o yaml > sealed-app-secret.yaml
+
+# Commit sealed-app-secret.yaml to git safely.
+```
+
+### Option 2: External Secrets Operator (ESO)
+ESO syncs secrets from external stores (AWS Secrets Manager, GCP Secret Manager, HashiCorp Vault, Azure Key Vault) into Kubernetes Secrets automatically. The secret values never live in git — only the reference to the external store does.
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: app-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: app-secret
+  data:
+    - secretKey: DB_PASSWORD
+      remoteRef:
+        key: production/app/db-password
+```
+
+### Option 3: HashiCorp Vault with the Vault Agent Injector
+The Vault Agent Injector mutates pod specs to inject a sidecar container that authenticates to Vault and writes secrets to a shared volume that the main container can read.
+
+### Option 4: etcd Encryption at Rest
+Configure Kubernetes to encrypt Secret objects in etcd using AES-CBC or AES-GCM. This protects against attackers who gain access to etcd backups or the etcd data directory.
+
+```yaml
+# /etc/kubernetes/encryption-config.yaml (on the control plane)
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources: ["secrets"]
+    providers:
+      - aescbc:
+          keys:
+            - name: key1
+              secret: <base64-encoded-32-byte-key>
+      - identity: {}   # Fallback for existing unencrypted secrets
+```
+
+---
+
+## Related Files
+
+- `configmap.yml` — Production ConfigMap example with multiple data formats
+- `secret.yml` — Educational Secret example (read all warnings before use)
+- `resource-quota.yml` — ResourceQuota enforcing aggregate namespace limits

--- a/core/configuration/configmap.yml
+++ b/core/configuration/configmap.yml
@@ -1,0 +1,187 @@
+# ==============================================================================
+# ConfigMap — Application Configuration
+# ==============================================================================
+# ConfigMaps store non-sensitive configuration data as key-value pairs.
+# This example demonstrates the three common data patterns:
+#   1. Simple string key-value pairs (used as environment variables)
+#   2. Numeric values stored as strings (important — see YAML type hazard note)
+#   3. Multi-line files (nginx.conf, properties files, scripts)
+#
+# HOW TO REFERENCE IN PODS:
+#
+# As environment variables (individual keys):
+#   env:
+#     - name: LOG_LEVEL
+#       valueFrom:
+#         configMapKeyRef:
+#           name: app-config
+#           key: LOG_LEVEL
+#
+# As environment variables (all keys at once):
+#   envFrom:
+#     - configMapRef:
+#         name: app-config
+#
+# As a volume mount (each key becomes a file):
+#   volumes:
+#     - name: config
+#       configMap:
+#         name: app-config
+#   containers:
+#     - volumeMounts:
+#         - name: config
+#           mountPath: /etc/config
+#           readOnly: true
+#   # Result: /etc/config/LOG_LEVEL, /etc/config/nginx.conf, etc.
+#
+# LIVE UPDATES:
+#   When a ConfigMap is updated (kubectl apply or kubectl edit), volume-mounted
+#   files are updated automatically by kubelet within ~60 seconds (the sync period).
+#   Environment variables injected at pod startup are NOT updated — the pod
+#   must be restarted to pick up changes.
+#
+# Apply:
+#   kubectl apply -f configmap.yml
+#   kubectl describe configmap app-config -n workloads
+# ==============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: workloads
+
+  labels:
+    app.kubernetes.io/name: app-config
+    app.kubernetes.io/instance: app-config
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: configuration
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      Application configuration ConfigMap for the workloads namespace.
+      Contains logging level, database connection settings, connection pool
+      size, and a full nginx.conf. Referenced by pods as environment variables
+      or volume-mounted files.
+
+data:
+  # ---------------------------------------------------------------------------
+  # Simple string values — used as environment variables or single-line files.
+  # ---------------------------------------------------------------------------
+
+  # Log verbosity level. Valid values: debug, info, warn, error.
+  LOG_LEVEL: "info"
+
+  # Internal cluster DNS name for the MySQL service.
+  # Format: <service-name>.<namespace>.svc.cluster.local
+  # Using the FQDN (not just "mysql") avoids DNS search path ambiguity
+  # and works correctly from any namespace in the cluster.
+  DATABASE_HOST: "mysql.database.svc.cluster.local"
+
+  # Database port as a string.
+  DATABASE_PORT: "3306"
+
+  # ---------------------------------------------------------------------------
+  # YAML TYPE HAZARD — Numbers Must Be Quoted
+  # ---------------------------------------------------------------------------
+  # YAML automatically parses unquoted values as their native types:
+  #   MAX_CONNECTIONS: 50    → parsed as integer 50 (not string "50")
+  #   ENABLED: true          → parsed as boolean true (not string "true")
+  #   VERSION: 1.0           → parsed as float 1.0 (not string "1.0")
+  #
+  # Kubernetes ConfigMap values MUST be strings. If YAML parses a value as
+  # an integer or boolean, the kubectl validation will reject it with:
+  #   "cannot unmarshal !!int into string"
+  #
+  # ALWAYS quote numeric values in ConfigMaps:
+  MAX_CONNECTIONS: "50"      # Correct: quoted string "50", not integer 50.
+  REQUEST_TIMEOUT_MS: "5000" # Correct: quoted string, not integer.
+  ENABLE_METRICS: "true"     # Correct: quoted string, not boolean true.
+  # ---------------------------------------------------------------------------
+
+  # Application environment tag (used for logging, tracing, etc.)
+  APP_ENV: "production"
+
+  # Feature flag configuration (simple string format)
+  FEATURE_FLAGS: "new-dashboard=true,beta-api=false,dark-mode=true"
+
+  # ---------------------------------------------------------------------------
+  # Multi-line file value — using the | literal block scalar.
+  # ---------------------------------------------------------------------------
+  # The | (pipe) character in YAML preserves newlines exactly as written.
+  # Each subsequent indented line becomes a line in the file.
+  # This creates a key "nginx.conf" whose value is the entire nginx config.
+  #
+  # When mounted as a volume:
+  #   mountPath: /etc/nginx/conf.d
+  # The file /etc/nginx/conf.d/nginx.conf will contain exactly this content.
+  #
+  # Using | instead of > (folded): | preserves newlines (correct for config files).
+  # > would collapse newlines into spaces, breaking multi-line configs.
+  nginx.conf: |
+    # nginx configuration managed by ConfigMap app-config.
+    # Do not edit this file directly on the container — changes will be overwritten.
+    # Update the ConfigMap and allow kubelet to sync the volume mount (~60s).
+
+    worker_processes auto;
+    error_log /var/log/nginx/error.log warn;
+
+    events {
+      worker_connections 1024;
+    }
+
+    http {
+      include       /etc/nginx/mime.types;
+      default_type  application/octet-stream;
+
+      # Log format includes request ID for distributed tracing.
+      log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for" '
+                      'req_id=$http_x_request_id';
+
+      access_log  /var/log/nginx/access.log  main;
+      sendfile        on;
+      tcp_nopush      on;
+      keepalive_timeout 65;
+      server_tokens   off;   # Do not expose nginx version in response headers.
+
+      # Gzip compression for text responses.
+      gzip on;
+      gzip_types text/plain application/json application/javascript text/css;
+
+      server {
+        listen 8080;           # Non-privileged port; no root required.
+        server_name _;
+
+        # Health check endpoint for readinessProbe / livenessProbe.
+        location /healthz {
+          access_log off;      # Don't flood access log with health checks.
+          return 200 "ok\n";
+          add_header Content-Type text/plain;
+        }
+
+        location / {
+          root   /usr/share/nginx/html;
+          index  index.html;
+          try_files $uri $uri/ =404;
+        }
+      }
+    }
+
+  # Application properties file (Java-style)
+  application.properties: |
+    # Database connection pool
+    spring.datasource.url=jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT}/appdb
+    spring.datasource.hikari.maximum-pool-size=${MAX_CONNECTIONS}
+    spring.datasource.hikari.connection-timeout=5000
+
+    # Logging
+    logging.level.root=${LOG_LEVEL}
+    logging.level.com.example=${LOG_LEVEL}
+
+    # Server
+    server.port=8080
+    server.shutdown=graceful
+    spring.lifecycle.timeout-per-shutdown-phase=50s

--- a/core/configuration/resource-quota.yml
+++ b/core/configuration/resource-quota.yml
@@ -1,0 +1,167 @@
+# ==============================================================================
+# ResourceQuota — Namespace Aggregate Resource Governance
+# ==============================================================================
+# ResourceQuota enforces aggregate resource limits across ALL pods, services,
+# configmaps, secrets, and PVCs in a namespace.
+#
+# DIFFERENCE FROM LIMITRANGE:
+#   LimitRange:    Governs individual container/pod resource declarations.
+#                  "No single container can request more than 2 CPU."
+#   ResourceQuota: Governs the TOTAL aggregate consumption of the namespace.
+#                  "All pods in this namespace combined cannot use more than 8 CPU."
+#
+# USE BOTH TOGETHER:
+#   Without LimitRange, pods with no resource declarations are admitted with
+#   unlimited resources, which causes ResourceQuota to reject new pods once
+#   the namespace quota is hit (because unlimitted pods count as 0 against quota).
+#   With LimitRange defaults, every container gets resource declarations auto-
+#   injected, so ResourceQuota correctly tracks namespace consumption.
+#
+# COUNT LIMITS — WHY THEY MATTER:
+# ┌───────────────────────────────────────────────────────────────────────────┐
+# │ count/* limits prevent etcd saturation from runaway controllers or       │
+# │ attackers. Kubernetes stores all object definitions in etcd. An          │
+# │ attacker (or a buggy controller) that creates tens of thousands of       │
+# │ pods, secrets, or configmaps can:                                        │
+# │   1. Saturate etcd storage (etcd has a default 8GiB storage limit)      │
+# │   2. Slow down the API server (etcd watches scale with object count)     │
+# │   3. Degrade the entire cluster for all tenants                         │
+# │                                                                           │
+# │ Count limits cap object creation BEFORE resources are exhausted.         │
+# └───────────────────────────────────────────────────────────────────────────┘
+#
+# Apply:
+#   kubectl apply -f resource-quota.yml
+#   kubectl describe resourcequota workloads-quota -n workloads
+#   # Shows current usage vs. limits for each quota item.
+#
+# Check current namespace usage:
+#   kubectl get resourcequota -n workloads
+# ==============================================================================
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: workloads-quota
+  namespace: workloads
+
+  labels:
+    app.kubernetes.io/name: workloads-quota
+    app.kubernetes.io/instance: workloads-quota
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: resource-governance
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      ResourceQuota for the workloads namespace. Enforces aggregate CPU and
+      memory limits across all pods, and count limits for pods, services,
+      configmaps, secrets, and PVCs. Prevents runaway controllers and etcd
+      saturation. Use together with LimitRange (limitrange.yml) to also enforce
+      per-container resource bounds.
+
+spec:
+  hard:
+    # -------------------------------------------------------------------------
+    # CPU Quota
+    # -------------------------------------------------------------------------
+
+    # requests.cpu: the total CPU requested by all containers across all pods
+    # in this namespace cannot exceed 4 cores. The scheduler uses requests for
+    # placement — if the aggregate requests exceed this, new pods are rejected.
+    requests.cpu: "4"
+
+    # limits.cpu: the total CPU limit across all containers cannot exceed 8 cores.
+    # CPU limits are enforced by the kernel's CFS scheduler (via cgroups).
+    # Setting limits.cpu to 2x requests.cpu allows controlled bursting.
+    limits.cpu: "8"
+
+    # -------------------------------------------------------------------------
+    # Memory Quota
+    # -------------------------------------------------------------------------
+
+    # requests.memory: total memory requested across all pods cannot exceed 8Gi.
+    requests.memory: "8Gi"
+
+    # limits.memory: total memory limits across all pods cannot exceed 16Gi.
+    # Memory over-limit results in OOMKill — set limits conservatively for
+    # memory-sensitive workloads. For latency-sensitive production workloads,
+    # consider setting requests == limits (Guaranteed QoS).
+    limits.memory: "16Gi"
+
+    # -------------------------------------------------------------------------
+    # Pod Count
+    # -------------------------------------------------------------------------
+
+    # count/pods: maximum number of pods in this namespace.
+    # This prevents:
+    # - Autoscalers from creating unbounded pod counts during traffic spikes.
+    # - Buggy controllers (e.g., CronJob with concurrencyPolicy: Allow)
+    #   from spawning thousands of pods.
+    # - Attackers who have gained pod-create permission from filling the cluster.
+    # 50 pods is a reasonable limit for most workload namespaces. Increase for
+    # large-scale microservices or autoscaled workloads.
+    count/pods: "50"
+
+    # -------------------------------------------------------------------------
+    # Service Count
+    # -------------------------------------------------------------------------
+
+    # count/services: maximum number of Services in this namespace.
+    # Prevents accidental or malicious creation of excessive NodePort or
+    # LoadBalancer services (each LoadBalancer costs money in cloud environments).
+    count/services: "20"
+
+    # count/services.loadbalancers: specifically limit the number of
+    # LoadBalancer-type Services, since each provisions a cloud load balancer.
+    # count/services.loadbalancers: "5"
+
+    # count/services.nodeports: limit NodePort services separately.
+    # count/services.nodeports: "10"
+
+    # -------------------------------------------------------------------------
+    # ConfigMap Count
+    # -------------------------------------------------------------------------
+
+    # count/configmaps: prevents runaway ConfigMap creation.
+    # Kubernetes stores all ConfigMaps in etcd. Thousands of ConfigMaps
+    # (e.g., from a Helm release that creates one per feature flag) can
+    # degrade etcd performance and API server response times.
+    count/configmaps: "50"
+
+    # -------------------------------------------------------------------------
+    # Secret Count
+    # -------------------------------------------------------------------------
+
+    # count/secrets: Secrets are stored in etcd and each is encrypted (if at-rest
+    # encryption is configured). Excessive secrets slow etcd and the encryption
+    # key rotation process. This limit also caps the blast radius of a compromised
+    # service account with 'create secrets' permission.
+    count/secrets: "30"
+
+    # -------------------------------------------------------------------------
+    # PersistentVolumeClaim Count
+    # -------------------------------------------------------------------------
+
+    # count/persistentvolumeclaims: prevents namespace from exhausting available
+    # PVs or triggering excessive cloud volume provisioning. Each PVC in a cloud
+    # environment may provision a separate block device (EBS, GCP PD, Azure Disk).
+    count/persistentvolumeclaims: "20"
+
+    # requests.storage: total storage requested by all PVCs in this namespace.
+    # Prevents a single namespace from monopolizing cluster storage capacity.
+    requests.storage: "100Gi"
+
+    # -------------------------------------------------------------------------
+    # Scoped Quotas (Advanced)
+    # -------------------------------------------------------------------------
+    # ResourceQuotas can be scoped to specific pod priority classes or
+    # termination states. This allows different quotas for different QoS classes.
+    #
+    # Example: quota only counts pods in the BestEffort QoS class:
+    # scopes:
+    #   - BestEffort
+    #
+    # Or quota only counts non-terminating pods (excludes completed/failed jobs):
+    # scopes:
+    #   - NotTerminating

--- a/core/configuration/secret.yml
+++ b/core/configuration/secret.yml
@@ -1,0 +1,168 @@
+# ==============================================================================
+# WARNING: THIS FILE IS FOR EDUCATIONAL PURPOSES ONLY
+# ==============================================================================
+# NEVER commit real secrets to a git repository.
+# base64 encoding is NOT encryption — it is trivially reversible:
+#
+#   echo "dGVzdC1wYXNzd29yZA==" | base64 -d
+#   # Output: test-password
+#
+# Anyone with read access to your git repository can decode these values.
+# Anyone with RBAC permission to 'get secrets' in this namespace can read them.
+# Anyone with access to the etcd data directory or backups can read them
+# (unless etcd encryption at rest is configured).
+#
+# For production, use one of:
+#   - SealedSecrets: encrypt secrets for safe git storage
+#       https://github.com/bitnami-labs/sealed-secrets
+#       See: platform/security/sealed-secrets/
+#
+#   - External Secrets Operator (ESO): sync from AWS Secrets Manager,
+#       GCP Secret Manager, Azure Key Vault, HashiCorp Vault, etc.
+#       https://external-secrets.io/
+#       See: platform/security/eso/
+#
+#   - HashiCorp Vault with the Agent Injector or Vault Secrets Operator
+#       https://developer.hashicorp.com/vault/docs/platform/k8s
+#
+# CREATE SECRETS IMPERATIVELY (preferred over this file):
+#   kubectl create secret generic app-secret \
+#     --from-literal=DB_PASSWORD='your-actual-password' \
+#     --from-literal=API_KEY='your-actual-api-key' \
+#     -n workloads
+#
+# TO ENCODE A VALUE FOR THIS FILE (educational only):
+#   echo -n 'change-me-in-production' | base64
+#   # -n is critical: omit it and you encode a trailing newline, breaking the value.
+#
+# TO DECODE A VALUE FROM THIS FILE:
+#   echo "Y2hhbmdlLW1lLWluLXByb2R1Y3Rpb24=" | base64 -d
+#   # Output: change-me-in-production
+#
+# MOUNT SECRETS AS VOLUMES, NOT ENVIRONMENT VARIABLES:
+#   See the README.md in this directory for a full explanation.
+#   Short version: env vars are visible in /proc/<pid>/environ, logged by
+#   many frameworks on startup, inherited by child processes, and present
+#   in core dumps and heap dumps.
+#
+#   Recommended volume mount pattern (see below in comments).
+# ==============================================================================
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secret
+  namespace: workloads
+
+  labels:
+    app.kubernetes.io/name: app-secret
+    app.kubernetes.io/instance: app-secret
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: configuration
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+  annotations:
+    kubernetes.io/description: >-
+      EDUCATIONAL EXAMPLE ONLY. Contains placeholder base64-encoded values.
+      Do not use in production. In production, create secrets imperatively
+      with kubectl create secret, or use SealedSecrets / External Secrets
+      Operator / HashiCorp Vault to manage secret lifecycle.
+
+# type: Opaque is the default for arbitrary key-value secrets.
+# Other types enforce specific key names and formats:
+#   kubernetes.io/tls       → requires tls.crt and tls.key
+#   kubernetes.io/dockerconfigjson → requires .dockerconfigjson
+#   kubernetes.io/basic-auth → requires username and password
+type: Opaque
+
+# data: values must be base64-encoded strings.
+# The Kubernetes API stores them as base64. When mounted as files or
+# injected as env vars, Kubernetes decodes them back to the original bytes.
+#
+# encode a value: echo -n 'plaintext' | base64
+# decode a value: echo 'encoded' | base64 -d
+data:
+  # DB_PASSWORD encodes "change-me-in-production"
+  # echo -n 'change-me-in-production' | base64
+  DB_PASSWORD: "Y2hhbmdlLW1lLWluLXByb2R1Y3Rpb24="
+
+  # API_KEY encodes "replace-with-real-api-key"
+  # echo -n 'replace-with-real-api-key' | base64
+  API_KEY: "cmVwbGFjZS13aXRoLXJlYWwtYXBpLWtleQ=="
+
+# stringData: an alternative to data that accepts plain (non-base64) strings.
+# kubectl encodes them to base64 automatically before storing.
+# stringData is write-only — it does not appear when you 'kubectl get secret -o yaml'.
+# Useful in dry-run or templated contexts where you don't want to manage base64.
+# NEVER use stringData with real secrets in files committed to git.
+#
+# stringData:
+#   DB_PASSWORD: "change-me-in-production"    # Plain text — DO NOT COMMIT REAL VALUES
+#   API_KEY: "replace-with-real-api-key"
+
+# ==============================================================================
+# HOW TO CONSUME THIS SECRET IN A POD (RECOMMENDED: Volume Mount)
+# ==============================================================================
+#
+# This is the recommended pattern. Do NOT use env vars for secrets.
+#
+# apiVersion: v1
+# kind: Pod
+# metadata:
+#   name: app
+#   namespace: workloads
+# spec:
+#   automountServiceAccountToken: false
+#   securityContext:
+#     runAsNonRoot: true
+#     runAsUser: 1000
+#     fsGroup: 2000
+#     seccompProfile:
+#       type: RuntimeDefault
+#   volumes:
+#     - name: db-credentials
+#       secret:
+#         secretName: app-secret
+#         # Mount only specific keys, not all keys in the secret.
+#         # This limits exposure: the pod can only see what it needs.
+#         items:
+#           - key: DB_PASSWORD
+#             path: db-password   # Mounted as /etc/secrets/db-password
+#             mode: 0400          # -r-------- owner read-only.
+#                                 # Do not use 0644 (world-readable) for secrets.
+#   containers:
+#     - name: app
+#       image: my-app:1.0.0
+#       securityContext:
+#         allowPrivilegeEscalation: false
+#         readOnlyRootFilesystem: true
+#         capabilities:
+#           drop: ["ALL"]
+#       resources:
+#         requests:
+#           memory: "128Mi"
+#           cpu: "100m"
+#         limits:
+#           memory: "128Mi"
+#       volumeMounts:
+#         - name: db-credentials
+#           mountPath: /etc/secrets    # Files appear here, e.g. /etc/secrets/db-password
+#           readOnly: true             # The container cannot modify secret files.
+#
+#       # In your application, read the secret from the file:
+#       #   Python:  open('/etc/secrets/db-password').read().strip()
+#       #   Node.js: fs.readFileSync('/etc/secrets/db-password', 'utf8').trim()
+#       #   Java:    new String(Files.readAllBytes(Path.of("/etc/secrets/db-password")))
+#       #   Go:      os.ReadFile("/etc/secrets/db-password")
+#       #   Shell:   DB_PASSWORD=$(cat /etc/secrets/db-password)
+#
+# WHY NOT ENV VARS? (summary — see README.md for full explanation)
+#   - /proc/<pid>/environ is readable by root on the node — any process with
+#     root or CAP_SYS_PTRACE can dump all env vars of running containers.
+#   - Many frameworks log their environment on startup (Spring Boot, Rails, etc.).
+#     DB_PASSWORD will appear in your centralized log system in plaintext.
+#   - Child processes (shells, worker forks) inherit env vars.
+#   - Core dumps contain the process memory, including env vars.
+#   - Volume-mounted secrets ARE updated automatically when the Secret changes
+#     (kubelet syncs within ~60s). Env-var secrets require a pod restart.
+# ==============================================================================


### PR DESCRIPTION
## Summary
- Add `configmap.yml` — ConfigMap with string `data` (env vars) and `nginx.conf` as a mounted file; shows both `envFrom` and `volumeMount` consumption patterns
- Add `secret.yml` — `Opaque` Secret with prominent base64-is-not-encryption warning; references ESO and SealedSecrets as production alternatives; shows `imagePullSecret` type
- Add `resource-quota.yml` — namespace quota for: CPU requests/limits, memory requests/limits, pod count, service count, PVC count, and `LoadBalancer` service count
- Add `README.md` — ConfigMap vs Secret decision guide, env var vs volume mount injection, `secretKeyRef` vs `configMapKeyRef`, quota scope selectors

## Issues referenced
Relates to #29, #30, #31, #32

## Test plan
- [ ] `kubectl apply -f core/configuration/` creates all resources
- [ ] `kubectl describe configmap nginx-config` shows `nginx.conf` key
- [ ] `kubectl describe resourcequota` shows used/hard for each resource