### PR TITLE
feat(platform): HPA and VPA — CPU/memory autoscaling with behavior control

### DIFF
--- a/platform/autoscaling/README.md
+++ b/platform/autoscaling/README.md
@@ -1,0 +1,168 @@
+# Autoscaling in Kubernetes: HPA vs VPA
+
+## Overview
+
+Kubernetes provides two primary autoscaling mechanisms for workloads:
+
+| Feature | HPA (Horizontal Pod Autoscaler) | VPA (Vertical Pod Autoscaler) |
+|---|---|---|
+| What it scales | Number of pod replicas | CPU/memory requests & limits per pod |
+| Best for | Stateless services with variable traffic | Right-sizing, resource tuning |
+| Metric sources | CPU, memory, custom metrics | Historical resource usage |
+| Disruption | None (adds/removes pods) | Pod restart required (in Auto mode) |
+| API built-in | Yes (`autoscaling/v2`) | No — separate CRD installation |
+
+---
+
+## When to Use HPA
+
+Use HPA when:
+
+- Your workload is **stateless** (web servers, API gateways, workers)
+- You can handle **variable traffic** by adding more pod replicas
+- You have **predictable scaling triggers** (CPU spikes, queue depth, RPS)
+- Your container images are fast to start (short startup time)
+
+HPA is the default recommendation for most production workloads. It scales out (more pods) rather than up (bigger pods), which is safer and more compatible with Kubernetes scheduling.
+
+**Metric sources HPA supports (v2 API):**
+- `Resource` — CPU and memory utilization against requests
+- `ContainerResource` — per-container metrics (multi-container pods)
+- `Pods` — custom metric averaged across all pods in the target
+- `Object` — custom metric from a specific Kubernetes object
+- `External` — metric from a system outside Kubernetes (e.g., SQS queue depth)
+
+---
+
+## When to Use VPA
+
+Use VPA when:
+
+- You don't know the right resource requests for a workload (use `updateMode: Off` first)
+- Your workload is **stateful or bursty** and can't easily scale horizontally
+- You want to **right-size** requests to reduce waste and improve scheduling
+- You're running **batch jobs** or workloads with inconsistent resource needs
+
+VPA continuously observes resource usage and recommends (or applies) new resource requests. In `Auto` mode, it evicts pods to apply updated resource values — plan for this disruption.
+
+**VPA modes:**
+| Mode | Behavior |
+|------|----------|
+| `Off` | Recommendations only — no changes applied |
+| `Initial` | Sets resources on pod creation only — never modifies running pods |
+| `Auto` | Evicts and recreates pods to apply updated resource values |
+
+---
+
+## Can HPA and VPA Work Together?
+
+**Yes — with important caveats.**
+
+You **must not** let HPA and VPA both control the same metric. The conflict scenario:
+
+1. VPA increases CPU requests → HPA sees lower utilization → HPA scales down
+2. Lower utilization triggers VPA to reduce requests → HPA scales up
+3. Loop repeats, thrashing replicas and evicting pods
+
+**Safe combinations:**
+- HPA on CPU/memory + VPA in `Off` or `Initial` mode only (VPA provides recommendations, HPA controls replicas)
+- HPA on **custom metrics** (e.g., RPS, queue depth) + VPA on **CPU/memory** (no overlap)
+- Use [KEDA](https://keda.sh) as an alternative to avoid this complexity entirely
+
+**Recommended pattern for most teams:** Start with VPA in `Off` mode to get right-sizing recommendations, apply them manually to your deployment, then enable HPA.
+
+---
+
+## Metrics Server Requirement
+
+Both HPA (for CPU/memory) and VPA require [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) to be installed in the cluster. Metrics Server collects resource usage data from the kubelet on each node.
+
+**Installation:**
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+```
+
+**Verify it's working:**
+```bash
+kubectl top nodes
+kubectl top pods -A
+```
+
+If `kubectl top` returns data, Metrics Server is healthy.
+
+> **Note:** In some environments (e.g., kubeadm clusters without TLS-verified kubelets), you may need to add `--kubelet-insecure-tls` to the Metrics Server deployment args. Do NOT do this in production without understanding the security implications.
+
+---
+
+## Custom Metrics via Prometheus Adapter
+
+For HPA to scale on application-specific metrics (e.g., HTTP requests per second, queue depth, active sessions), you need the [Prometheus Adapter](https://github.com/kubernetes-sigs/prometheus-adapter).
+
+**Architecture:**
+```
+Application → Prometheus (scrapes metrics) → Prometheus Adapter → custom.metrics.k8s.io API → HPA
+```
+
+**Installation:**
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+helm upgrade --install prometheus-adapter prometheus-community/prometheus-adapter \
+  --namespace monitoring \
+  --set prometheus.url=http://monitoring-prometheus.monitoring.svc.cluster.local \
+  --set prometheus.port=9090
+```
+
+**Verify custom metrics are available:**
+```bash
+kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1" | jq .
+```
+
+**Example HPA using a custom metric:**
+```yaml
+metrics:
+  - type: Pods
+    pods:
+      metric:
+        name: http_requests_per_second
+      target:
+        type: AverageValue
+        averageValue: "100"  # target 100 RPS per pod
+```
+
+---
+
+## External Metrics (e.g., SQS, Pub/Sub)
+
+For scaling on external queue depths or cloud metrics, consider [KEDA (Kubernetes Event-Driven Autoscaling)](https://keda.sh). KEDA provides 50+ built-in scalers (AWS SQS, Azure Service Bus, Kafka, Redis, etc.) and is significantly easier to configure than the raw External metrics API.
+
+---
+
+## Decision Tree
+
+```
+Is the workload stateless and can it run multiple replicas?
+├── YES → Use HPA
+│   ├── Traffic/CPU driven? → HPA on cpu/memory
+│   ├── Queue/event driven? → HPA + KEDA
+│   └── Don't know right resource sizes? → Add VPA in Off mode alongside
+└── NO (stateful, singleton)
+    └── Use VPA (Auto or Initial mode)
+        └── Consider StatefulSet + manual scaling for databases
+```
+
+---
+
+## Directory Structure
+
+```
+autoscaling/
+├── README.md                  ← This file
+├── hpa/
+│   ├── README.md              ← HPA deep dive
+│   ├── hpa-cpu-memory.yml     ← HPA with CPU + memory metrics
+│   └── hpa-with-behavior.yml  ← HPA with behavior block demo
+└── vpa/
+    ├── README.md              ← VPA guide
+    └── vpa-auto.yml           ← VPA in Auto mode
+```

--- a/platform/autoscaling/hpa/README.md
+++ b/platform/autoscaling/hpa/README.md
@@ -1,0 +1,211 @@
+# Horizontal Pod Autoscaler (HPA) — Deep Dive
+
+## v2 API vs v1 (Why v1 is Deprecated)
+
+The `autoscaling/v1` API only supported a single metric: **CPU utilization**. Every field beyond `targetCPUUtilizationPercentage` was either absent or stored in a JSON annotation hack. It offered no `behavior` block, no memory metrics, and no custom/external metrics.
+
+The `autoscaling/v2` API (stable since Kubernetes 1.23) is the current standard and supports:
+- Multiple simultaneous metrics (CPU + memory + custom)
+- The `behavior` block (scale-up/scale-down speed control)
+- `ContainerResource` metrics (per-container in multi-container pods)
+- `Object` and `External` metric types
+
+**Always use `autoscaling/v2`.** The v1 API is deprecated and removed in Kubernetes 1.26+. Any tooling or docs still referencing v1 are outdated.
+
+---
+
+## Metric Types
+
+### Resource Metrics (CPU and Memory)
+
+Resource metrics measure utilization relative to each pod's **requests** (not limits). This is why correct resource requests are critical — if requests are too low, the HPA will think pods are heavily loaded and scale out unnecessarily.
+
+```yaml
+metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: AverageUtilization  # percentage of requested CPU
+        averageUtilization: 70    # scale when average pod CPU > 70% of request
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: AverageUtilization
+        averageUtilization: 80
+```
+
+**Formula:** `desiredReplicas = ceil(currentReplicas * (currentMetricValue / desiredMetricValue))`
+
+### Custom Metrics
+
+Custom metrics require the [Prometheus Adapter](https://github.com/kubernetes-sigs/prometheus-adapter) or another custom metrics provider.
+
+```yaml
+metrics:
+  - type: Pods
+    pods:
+      metric:
+        name: http_requests_per_second
+      target:
+        type: AverageValue
+        averageValue: "100"
+```
+
+### External Metrics
+
+External metrics come from systems outside Kubernetes (cloud queues, etc.). Consider KEDA instead, which is purpose-built for this.
+
+---
+
+## Stabilization Window — Preventing Flapping
+
+The stabilization window prevents the HPA from making rapid back-and-forth decisions when a metric hovers near the threshold. Without it, a metric bouncing between 68% and 72% around a 70% target would cause constant scale-up/scale-down events.
+
+**How it works:**
+- The HPA keeps a sliding window of past metric values and recommendations
+- For scale-down: it uses the **highest** recommendation in the window (conservative — avoids premature scale-down)
+- For scale-up: it uses the **lowest** recommendation in the window (can be 0 for immediate response)
+
+**Default values (if behavior block is absent):**
+- Scale-down stabilization: 300 seconds (5 minutes)
+- Scale-up stabilization: 0 seconds (immediate)
+
+---
+
+## Scale-Down vs Scale-Up Speeds
+
+The `behavior` block gives fine-grained control over how fast the HPA can add or remove pods.
+
+### Why slow scale-down matters
+
+If your application takes 30 seconds to initialize and traffic spikes recur every few minutes, scaling down to minimum and then back up creates startup latency for users. A conservative scale-down window keeps a buffer of pods ready.
+
+### Why immediate scale-up matters
+
+Latency spikes during traffic surges are user-visible. Scale-up should be as fast as possible. The default `stabilizationWindowSeconds: 0` for scale-up is correct — don't add a window here unless you have a specific reason.
+
+### Policy types
+
+| Type | Meaning |
+|------|---------|
+| `Pods` | Add/remove at most N pods per `periodSeconds` |
+| `Percent` | Add/remove at most N% of current replicas per `periodSeconds` |
+
+Multiple policies can be combined; the `selectPolicy` field (`Max` or `Min`) determines which constraint wins:
+- `selectPolicy: Max` — allow the **largest** change (faster scaling)
+- `selectPolicy: Min` — allow the **smallest** change (more conservative, default)
+
+---
+
+## Behavior Block Reference
+
+```yaml
+behavior:
+  scaleDown:
+    stabilizationWindowSeconds: 300   # Wait 5 min before acting on scale-down
+    selectPolicy: Min                  # Use the most conservative policy
+    policies:
+      - type: Percent
+        value: 50
+        periodSeconds: 60             # Remove at most 50% of pods per minute
+      - type: Pods
+        value: 2
+        periodSeconds: 60             # OR at most 2 pods per minute
+  scaleUp:
+    stabilizationWindowSeconds: 0     # React immediately to scale-up signals
+    selectPolicy: Max                  # Use the most aggressive policy
+    policies:
+      - type: Pods
+        value: 4
+        periodSeconds: 60             # Add at most 4 pods per minute
+      - type: Percent
+        value: 100
+        periodSeconds: 60             # OR double the pod count per minute
+```
+
+---
+
+## Demo: Load Testing with Busybox to Trigger HPA
+
+This demo assumes you have a Deployment named `nginx-deployment` in the `workloads` namespace with the HPA from `hpa-cpu-memory.yml` applied.
+
+### Step 1: Apply the HPA
+
+```bash
+kubectl apply -f hpa-cpu-memory.yml
+kubectl get hpa -n workloads nginx-hpa --watch
+```
+
+### Step 2: Open a second terminal — watch the HPA
+
+```bash
+watch -n 2 "kubectl get hpa -n workloads nginx-hpa && echo && kubectl get pods -n workloads -l app.kubernetes.io/name=nginx"
+```
+
+### Step 3: Generate load from a busybox pod
+
+```bash
+# Run in a loop — sends continuous HTTP requests to the nginx service
+kubectl run load-generator \
+  --image=busybox:1.36 \
+  --restart=Never \
+  --rm -it \
+  -n workloads \
+  -- /bin/sh -c "while true; do wget -q -O- http://nginx-service.workloads.svc.cluster.local; done"
+```
+
+### Step 4: Observe scale-up
+
+Within ~60–90 seconds (one HPA sync cycle), you should see:
+```
+NAME        REFERENCE                     TARGETS         MINPODS   MAXPODS   REPLICAS   AGE
+nginx-hpa   Deployment/nginx-deployment   88%/70%, ...    2         10        4          3m
+```
+
+### Step 5: Stop load and observe scale-down
+
+Delete the load-generator pod (Ctrl+C if running interactively, or `kubectl delete pod load-generator -n workloads`).
+
+Due to the 300-second stabilization window for scale-down, replicas will remain elevated for ~5 minutes before reducing.
+
+### Step 6: Inspect HPA events
+
+```bash
+kubectl describe hpa -n workloads nginx-hpa
+# Look for Events section — shows each scale decision with reason
+```
+
+---
+
+## Useful Commands
+
+```bash
+# View current HPA status with metrics
+kubectl get hpa -n workloads -o wide
+
+# Watch HPA in real time
+kubectl get hpa -n workloads --watch
+
+# Full detail including events and conditions
+kubectl describe hpa -n workloads nginx-hpa
+
+# View raw metrics the HPA is reading
+kubectl get --raw "/apis/metrics.k8s.io/v1beta1/namespaces/workloads/pods" | jq .
+
+# Check HPA conditions (Useful for diagnosing "unable to get metrics" errors)
+kubectl get hpa -n workloads nginx-hpa -o jsonpath='{.status.conditions}' | jq .
+```
+
+---
+
+## Common Problems
+
+| Problem | Likely Cause | Fix |
+|---------|-------------|-----|
+| `unable to get metrics for resource cpu` | Metrics Server not installed | Install metrics-server |
+| HPA stuck at min replicas despite high load | Resource requests not set on pods | Set `resources.requests.cpu` |
+| HPA flapping (scaling up and down rapidly) | Missing stabilization window | Add `behavior.scaleDown.stabilizationWindowSeconds` |
+| `FailedGetScale` error | RBAC — HPA controller can't read the target | Check HPA controller ServiceAccount permissions |
+| Replicas don't go below `minReplicas` | This is correct behavior | HPA never goes below min |

--- a/platform/autoscaling/hpa/hpa-cpu-memory.yml
+++ b/platform/autoscaling/hpa/hpa-cpu-memory.yml
@@ -1,0 +1,129 @@
+# ==============================================================================
+# HPA — CPU AND MEMORY METRICS (autoscaling/v2)
+# ==============================================================================
+# Scales nginx-deployment in the workloads namespace based on both CPU and
+# memory utilization. Kubernetes picks whichever metric indicates MORE scaling
+# is needed (the HPA takes the maximum recommendation across all metrics).
+#
+# Prerequisites:
+#   - Metrics Server installed in the cluster
+#   - nginx-deployment exists in the workloads namespace
+#   - Pods in the deployment must have resources.requests.cpu and
+#     resources.requests.memory set — HPA utilization % is relative to requests
+#
+# Apply:
+#   kubectl apply -f hpa-cpu-memory.yml
+#
+# Verify:
+#   kubectl get hpa -n workloads nginx-hpa
+#   kubectl describe hpa -n workloads nginx-hpa
+# ==============================================================================
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: nginx-hpa
+  namespace: workloads
+  labels:
+    app.kubernetes.io/name: nginx-hpa
+    app.kubernetes.io/component: autoscaler
+    app.kubernetes.io/part-of: nginx
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: "1.0.0"
+    environment: production
+  annotations:
+    kubernetes.io/description: >
+      HPA for nginx-deployment. Scales on both CPU (target 70%) and memory
+      (target 80%). Scale-down is throttled to 50% of pods per minute after a
+      5-minute stabilization window. Scale-up is immediate with a burst of up
+      to 4 pods per minute.
+spec:
+  # ---------------------------------------------------------------------------
+  # Scale target — the Deployment this HPA controls
+  # ---------------------------------------------------------------------------
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx-deployment
+
+  # ---------------------------------------------------------------------------
+  # Replica bounds
+  # minReplicas: Keep at least 2 pods for basic HA even at zero load.
+  # maxReplicas: Hard ceiling — prevents runaway scaling from metric anomalies.
+  # ---------------------------------------------------------------------------
+  minReplicas: 2
+  maxReplicas: 10
+
+  # ---------------------------------------------------------------------------
+  # Metrics — HPA uses ALL metrics and scales to satisfy whichever requires
+  # the highest replica count. It does NOT average across metrics.
+  # ---------------------------------------------------------------------------
+  metrics:
+    # CPU utilization relative to each pod's resources.requests.cpu
+    # AverageUtilization: 70 means scale out when average pod CPU > 70% of request
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: AverageUtilization
+          averageUtilization: 70
+
+    # Memory utilization relative to each pod's resources.requests.memory
+    # Memory-based scaling is useful for workloads that cache data in memory
+    # and degrade before CPU becomes a bottleneck.
+    # AverageUtilization: 80 — memory is less elastic, so threshold is higher.
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: AverageUtilization
+          averageUtilization: 80
+
+  # ---------------------------------------------------------------------------
+  # Behavior — controls the speed of scale-up and scale-down decisions.
+  # Without this block, scale-down defaults to 300s stabilization (safe),
+  # but scale-down RATE is unlimited — a sudden drop could remove all extra
+  # pods at once, causing a latency spike if load returns quickly.
+  # ---------------------------------------------------------------------------
+  behavior:
+    scaleDown:
+      # stabilizationWindowSeconds: The HPA looks back 300 seconds (5 minutes)
+      # and uses the HIGHEST replica recommendation in that window before
+      # deciding to scale down. This prevents thrashing when load fluctuates
+      # near the threshold. 300s is the Kubernetes default and a good production value.
+      stabilizationWindowSeconds: 300
+
+      # selectPolicy: Min means use the policy that allows the SMALLEST reduction
+      # per period — the most conservative option. Combined with the stabilization
+      # window, this makes scale-down slow and deliberate.
+      selectPolicy: Min
+
+      policies:
+        # Limit scale-down to 50% of current pods per minute.
+        # Example: if running 8 pods, at most 4 can be removed per minute.
+        # This prevents sudden cliff-drops in capacity.
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+
+    scaleUp:
+      # stabilizationWindowSeconds: 0 means react immediately to scale-up signals.
+      # Do not add a delay here — slow scale-up means latency for users during spikes.
+      stabilizationWindowSeconds: 0
+
+      # selectPolicy: Max means use the policy that allows the LARGEST increase
+      # per period — the most aggressive option. We want fast scale-up.
+      selectPolicy: Max
+
+      policies:
+        # Add at most 4 pods per minute regardless of current replica count.
+        # Good for workloads that start quickly.
+        - type: Pods
+          value: 4
+          periodSeconds: 60
+
+        # Alternatively, allow doubling the pod count per minute for very low
+        # starting counts (e.g., 2 → 4 → 8). The Max selectPolicy above means
+        # whichever policy allows MORE pods wins.
+        - type: Percent
+          value: 100
+          periodSeconds: 60

--- a/platform/autoscaling/hpa/hpa-with-behavior.yml
+++ b/platform/autoscaling/hpa/hpa-with-behavior.yml
@@ -1,0 +1,157 @@
+# ==============================================================================
+# HPA — BEHAVIOR BLOCK DEMONSTRATION (Slow Scale-Down)
+# ==============================================================================
+# This HPA intentionally uses a LOW CPU threshold (20%) so that the HPA will
+# attempt to scale during a demo even without heavy load. The primary purpose
+# of this file is to demonstrate every field in the behavior block with
+# detailed comments explaining the intent behind each value.
+#
+# Target: apache-deployment in the workloads namespace
+#
+# Apply:
+#   kubectl apply -f hpa-with-behavior.yml
+#
+# Watch decisions in real time:
+#   kubectl describe hpa -n workloads apache-hpa | grep -A 20 "Events:"
+# ==============================================================================
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: apache-hpa
+  namespace: workloads
+  labels:
+    app.kubernetes.io/name: apache-hpa
+    app.kubernetes.io/component: autoscaler
+    app.kubernetes.io/part-of: apache
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: "1.0.0"
+    environment: production
+  annotations:
+    kubernetes.io/description: >
+      HPA for apache-deployment demonstrating the full behavior block.
+      CPU threshold is intentionally low (20%) for demo purposes.
+      In production, tune to 60–80% based on your observed utilization patterns.
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: apache-deployment  # Must exist in the workloads namespace
+
+  # min: 1 — allow scale-down to a single pod (acceptable for demo).
+  # In production HA workloads, use minReplicas: 2 or more.
+  minReplicas: 1
+  maxReplicas: 5
+
+  metrics:
+    # Intentionally low threshold for demo purposes.
+    # At 20%, most real pods will be "above" the threshold and HPA will scale up.
+    # Adjust to 60–80% for real workloads.
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: AverageUtilization
+          averageUtilization: 20   # LOW — for demo only, change in production
+
+  # ---------------------------------------------------------------------------
+  # BEHAVIOR BLOCK — Full explanation of every field
+  # ---------------------------------------------------------------------------
+  behavior:
+    # -------------------------------------------------------------------------
+    # SCALE DOWN — deliberately slow and conservative
+    # -------------------------------------------------------------------------
+    scaleDown:
+      # stabilizationWindowSeconds (default: 300)
+      # ─────────────────────────────────────────
+      # The HPA controller evaluates metrics on a regular sync loop (~15s).
+      # Each sync produces a "recommendation" (desired replica count).
+      # The stabilization window accumulates all recommendations for this many
+      # seconds. For scale-DOWN, the HPA picks the MAXIMUM (highest) replica
+      # count from the window — the most conservative option.
+      #
+      # Why 300 seconds (5 minutes)?
+      #   - Traffic often has short quiet periods that quickly reverse
+      #   - Applications with slow startup (JVM, large ML models) need time
+      #     to become ready before they're needed again
+      #   - 5 minutes is a good balance between responsiveness and stability
+      #
+      # For bursty workloads, consider 600s. For always-on low-latency services,
+      # consider 120s. Avoid 0s for scale-down — it causes replica thrashing.
+      stabilizationWindowSeconds: 300
+
+      # selectPolicy (default: Max for scaleDown — confusingly named)
+      # ──────────────────────────────────────────────────────────────
+      # When multiple policies are defined, selectPolicy determines which one wins:
+      #   - "Max"  → pick the policy that ALLOWS THE MOST change (fast scaling)
+      #   - "Min"  → pick the policy that ALLOWS THE LEAST change (conservative)
+      #   - "Disabled" → prevent scaling in this direction entirely
+      #
+      # For scale-down, "Min" is the safest choice: it means we always take the
+      # smallest allowed reduction, even if another policy would allow more.
+      selectPolicy: Min
+
+      policies:
+        # Policy 1: Percent-based — remove at most 25% of current replicas per period
+        # ─────────────────────────────────────────────────────────────────────────────
+        # type: Percent — value is a percentage of currentReplicas
+        # value: 25 — can remove at most 25% of pods per periodSeconds
+        # periodSeconds: 60 — evaluated once per minute
+        #
+        # Example: currently 4 replicas → at most 1 pod removed per minute
+        # Example: currently 8 replicas → at most 2 pods removed per minute
+        #
+        # This is proportional and gets slower as you scale down, preventing
+        # a death-spiral where removing pods increases load on the remaining ones.
+        - type: Percent
+          value: 25
+          periodSeconds: 60
+
+        # Policy 2: Absolute pod count — remove at most 1 pod per period
+        # ──────────────────────────────────────────────────────────────
+        # type: Pods — value is an absolute number of pods
+        # value: 1 — never remove more than 1 pod per minute
+        #
+        # This acts as a hard floor on scale-down speed regardless of replica count.
+        # For a deployment at maxReplicas (5), the Percent policy above would allow
+        # removing 1 pod (25% of 5 = 1.25 → floor 1). So both policies agree here.
+        # For larger fleets, this policy becomes the binding constraint.
+        #
+        # With selectPolicy: Min, if Percent allows 2 and Pods allows 1, we use 1.
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+
+    # -------------------------------------------------------------------------
+    # SCALE UP — fast and responsive
+    # -------------------------------------------------------------------------
+    scaleUp:
+      # stabilizationWindowSeconds: 0
+      # ─────────────────────────────
+      # For scale-UP, the stabilization window holds the MINIMUM recommendation.
+      # Setting it to 0 means: use only the current recommendation, don't look back.
+      # This allows immediate scale-up response when load spikes.
+      #
+      # Never set a large stabilization window for scale-up — users experience
+      # latency during the window while you wait to confirm the load is real.
+      # A spike lasting 30 seconds is very real to the users hitting it.
+      stabilizationWindowSeconds: 0
+
+      # selectPolicy: Max for scale-up — take the most aggressive policy.
+      # We want to add as many pods as possible per minute to absorb spikes fast.
+      selectPolicy: Max
+
+      policies:
+        # Scale up by at most 2 pods per minute (absolute)
+        # ─────────────────────────────────────────────────
+        # For small deployments (1–3 pods), this allows quick doubling.
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+
+        # Scale up by at most 100% (double) per minute (percentage-based)
+        # ─────────────────────────────────────────────────────────────────
+        # For larger deployments this kicks in: e.g., 4 pods → can add 4 more.
+        # With selectPolicy: Max, whichever allows MORE pods per minute wins.
+        - type: Percent
+          value: 100
+          periodSeconds: 60

--- a/platform/autoscaling/vpa/README.md
+++ b/platform/autoscaling/vpa/README.md
@@ -1,0 +1,186 @@
+# Vertical Pod Autoscaler (VPA) — Guide
+
+## Overview
+
+VPA automatically adjusts the CPU and memory **requests** (and optionally limits) for pods based on observed historical usage. Unlike HPA, which adds more replicas, VPA makes each individual pod more (or less) resource-efficient.
+
+VPA is a separate project from core Kubernetes and requires its own installation. It is not bundled with the Kubernetes control plane.
+
+---
+
+## Update Modes
+
+VPA operates in one of four modes controlled by `updatePolicy.updateMode`:
+
+### `Off` — Recommendations Only (Start Here)
+
+VPA observes resource usage and writes recommendations to the VPA object's `status.recommendation` field, but **makes no changes to running pods**.
+
+```bash
+kubectl describe vpa -n workloads nginx-vpa
+# Look for: Status > Recommendation > Container Recommendations
+```
+
+**Use `Off` mode to:**
+- Discover right-sized requests for a workload without risk
+- Build a baseline before enabling automatic updates
+- Use in CI/CD pipelines to validate resource requests in PRs
+
+### `Initial` — Set on Pod Creation Only
+
+VPA sets resource requests when pods are **first created** (or recreated after a deployment rollout), but never modifies running pods.
+
+**Use `Initial` mode for:**
+- Deployments that roll frequently (VPA gets to set values on each rollout)
+- Workloads where you can't tolerate pod disruption
+- Blue/green deployments where new pods always start fresh
+
+### `Auto` — Full Automation
+
+VPA monitors resource usage and when it detects that a pod's requests diverge significantly from the recommendation, it **evicts the pod** and lets the scheduler recreate it with updated resource requests.
+
+**Important caveats for `Auto` mode:**
+- Pod evictions cause brief disruption — ensure PodDisruptionBudgets (PDBs) are configured
+- VPA does not respect `minReplicas` on your Deployment directly — it evicts one pod at a time, but if your deployment has only 1 replica, that pod will be evicted (brief downtime)
+- VPA will not evict pods that would violate a PodDisruptionBudget, so PDBs are your safety net
+
+**Use `Auto` mode for:**
+- Batch jobs and non-user-facing workloads
+- Single-tenant workloads where brief restarts are acceptable
+- Stateless services with multiple replicas and PDBs configured
+
+### `Recreate` (Legacy alias for Auto behavior pre-1.0)
+
+Behaves like `Auto` but was the original name. Use `Auto` in modern VPA versions.
+
+---
+
+## How VPA Interacts with HPA
+
+**The golden rule: do not let VPA and HPA control the same resource dimension.**
+
+| Scenario | Safe? | Notes |
+|---------|-------|-------|
+| VPA `Off` + HPA on CPU | ✅ Yes | VPA advises, HPA controls replicas. Manually apply VPA recommendations. |
+| VPA `Initial` + HPA on CPU | ⚠️ Caution | VPA sets values at pod creation; HPA then controls replicas. Can work if VPA recommendations are stable. |
+| VPA `Auto` + HPA on CPU | ❌ No | VPA changes requests → HPA sees different utilization → replica thrashing |
+| VPA `Auto` + HPA on custom metrics (RPS, queue depth) | ✅ Yes | No overlap — VPA handles resource requests, HPA handles replica count on non-resource metric |
+
+**Recommended production pattern:**
+1. Run VPA in `Off` mode for 1–2 weeks to gather recommendations
+2. Apply the recommended values to your Deployment YAML manually
+3. Enable HPA on CPU/memory with the now-correct requests as baseline
+4. Keep VPA in `Off` mode for ongoing monitoring
+
+---
+
+## VPA Installation
+
+VPA is NOT installed by default. It requires separate installation from the [kubernetes/autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) repository.
+
+### Option 1: Helm (Recommended)
+
+```bash
+helm repo add fairwinds-stable https://charts.fairwinds.com/stable
+helm repo update
+helm upgrade --install vpa fairwinds-stable/vpa \
+  --namespace kube-system \
+  --set recommender.enabled=true \
+  --set updater.enabled=true \
+  --set admissionController.enabled=true
+```
+
+### Option 2: Official Scripts
+
+```bash
+git clone https://github.com/kubernetes/autoscaler.git
+cd autoscaler/vertical-pod-autoscaler
+./hack/vpa-up.sh
+```
+
+### Verify Installation
+
+```bash
+kubectl get pods -n kube-system | grep vpa
+# Expect three pods:
+#   vpa-recommender-xxx      - reads metrics, computes recommendations
+#   vpa-updater-xxx          - evicts pods that need resource updates (Auto mode)
+#   vpa-admission-controller-xxx - mutates pod specs on creation (Initial/Auto)
+```
+
+**Note:** VPA requires Metrics Server to be installed — same prerequisite as HPA.
+
+---
+
+## Reading VPA Recommendations
+
+After a VPA object exists in `Off` mode and the recommender has had time to observe the workload (minimum 15 minutes, ideally 24+ hours for meaningful data):
+
+```bash
+kubectl describe vpa nginx-vpa -n workloads
+```
+
+Look for the `Status > Recommendation` section:
+
+```
+Status:
+  Recommendation:
+    Container Recommendations:
+      Container Name: nginx
+      Lower Bound:
+        Cpu:     25m
+        Memory:  128Mi
+      Target:
+        Cpu:     50m        ← Set this as resources.requests.cpu
+        Memory:  256Mi      ← Set this as resources.requests.memory
+      Uncapped Target:
+        Cpu:     50m
+        Memory:  200Mi
+      Upper Bound:
+        Cpu:     200m
+        Memory:  512Mi
+```
+
+**Fields explained:**
+
+| Field | Meaning | Action |
+|-------|---------|--------|
+| `Target` | Optimal value based on observed usage | Apply this to your Deployment |
+| `Lower Bound` | 5th percentile — minimum safe value | Use as `resources.requests` floor |
+| `Upper Bound` | 95th percentile — maximum observed | Use to validate `resources.limits` |
+| `Uncapped Target` | Target ignoring `resourcePolicy` bounds | Diagnostics only |
+
+---
+
+## Resource Policy — Bounding VPA Recommendations
+
+Use `resourcePolicy.containerPolicies` to prevent VPA from recommending values outside safe ranges:
+
+```yaml
+resourcePolicy:
+  containerPolicies:
+    - containerName: nginx
+      minAllowed:
+        cpu: 50m
+        memory: 64Mi
+      maxAllowed:
+        cpu: 2
+        memory: 2Gi
+      controlledResources: ["cpu", "memory"]
+```
+
+**Why set bounds?**
+- `minAllowed`: Prevents VPA from setting requests so low that resource pressure causes OOMKills or CPU throttling
+- `maxAllowed`: Prevents VPA from requesting more resources than a single node can provide (making the pod unschedulable)
+
+---
+
+## VPA in Production: Checklist
+
+- [ ] VPA recommender, updater, and admission-controller are all running
+- [ ] Metrics Server is installed and `kubectl top pods` works
+- [ ] Start with `updateMode: Off` — observe recommendations for at least 24 hours
+- [ ] Set `minAllowed` and `maxAllowed` in `resourcePolicy` to bound recommendations
+- [ ] Configure PodDisruptionBudgets before enabling `Auto` mode
+- [ ] Do not enable `Auto` mode if HPA is also scaling on CPU/memory for the same workload
+- [ ] Monitor VPA events: `kubectl get events -n workloads --field-selector reason=EvictedByVPA`

--- a/platform/autoscaling/vpa/vpa-auto.yml
+++ b/platform/autoscaling/vpa/vpa-auto.yml
@@ -1,0 +1,109 @@
+# ==============================================================================
+# VPA — AUTO MODE
+# ==============================================================================
+# VerticalPodAutoscaler for apache-deployment in the workloads namespace.
+# updateMode: Auto means VPA will evict pods and allow them to be recreated
+# with updated resource requests when recommendations diverge significantly
+# from current values.
+#
+# PREREQUISITES:
+#   1. VPA CRDs and controllers must be installed (see vpa/README.md)
+#   2. Metrics Server must be installed
+#   3. apache-deployment must exist in the workloads namespace
+#   4. PodDisruptionBudget should be configured before enabling Auto mode
+#
+# CAUTION:
+#   Do NOT use Auto mode alongside HPA scaling on CPU/memory for the same
+#   workload — they will conflict. If you use HPA on CPU/memory, keep VPA
+#   in Off mode and apply recommendations manually.
+#
+# Apply:
+#   kubectl apply -f vpa-auto.yml
+#
+# Read recommendations:
+#   kubectl describe vpa -n workloads nginx-vpa
+# ==============================================================================
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: nginx-vpa
+  namespace: workloads
+  labels:
+    # Note: VPA is a CRD — the app.kubernetes.io/* label set applies to the
+    # VPA object itself (metadata.labels), not to pods it manages.
+    app.kubernetes.io/name: nginx-vpa
+    app.kubernetes.io/component: autoscaler
+    app.kubernetes.io/part-of: apache
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: "1.0.0"
+    environment: production
+  annotations:
+    kubernetes.io/description: >
+      VPA in Auto mode for apache-deployment. Automatically right-sizes CPU and
+      memory requests based on observed usage. Evicts pods when recommendations
+      diverge significantly from current requests. Ensure a PodDisruptionBudget
+      is configured before enabling this in production.
+spec:
+  # ---------------------------------------------------------------------------
+  # targetRef — the workload this VPA manages
+  # VPA supports Deployment, StatefulSet, DaemonSet, ReplicaSet, Job, CronJob
+  # ---------------------------------------------------------------------------
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: apache-deployment  # Must exist in the same namespace (workloads)
+
+  # ---------------------------------------------------------------------------
+  # updatePolicy — controls how VPA applies recommendations
+  #
+  # Modes:
+  #   Off      — recommendations only, no changes applied
+  #   Initial  — set requests at pod creation, never modify running pods
+  #   Auto     — evict pods to apply updated resource requests
+  # ---------------------------------------------------------------------------
+  updatePolicy:
+    updateMode: Auto
+
+    # minReplicas: Minimum number of replicas VPA requires before evicting any pod.
+    # VPA will NOT evict pods if doing so would bring the running replica count
+    # below this value. Set to 2+ for any production workload to ensure HA
+    # during VPA-triggered evictions.
+    # Default is 2 if not set; explicitly set here for clarity.
+    minReplicas: 2
+
+  # ---------------------------------------------------------------------------
+  # resourcePolicy — constrains VPA recommendations within safe bounds
+  #
+  # Without bounds, VPA could recommend requests larger than any node can
+  # provide (making pods unschedulable) or smaller than safe operational values
+  # (causing OOMKills or CPU starvation).
+  # ---------------------------------------------------------------------------
+  resourcePolicy:
+    containerPolicies:
+      - containerName: apache  # Must match the container name in the Deployment spec
+
+        # controlledResources — which resources VPA manages.
+        # Default is ["cpu", "memory"]. You can restrict to just ["memory"] if
+        # you want to manage CPU requests manually while letting VPA handle memory.
+        controlledResources: ["cpu", "memory"]
+
+        # minAllowed — VPA will never recommend values below these floors.
+        # Set these to the minimum safe operational values for your container.
+        # Too low → OOMKill (memory) or CPU starvation (cpu)
+        minAllowed:
+          cpu: 50m      # Never go below 50 millicores — prevents CPU starvation
+          memory: 64Mi  # Never go below 64Mi — prevents frequent OOMKills
+
+        # maxAllowed — VPA will never recommend values above these ceilings.
+        # Set these to less than the largest node's allocatable capacity.
+        # Too high → pod becomes unschedulable (no node has that much free)
+        maxAllowed:
+          cpu: "2"       # Cap at 2 cores — aligns with node capacity planning
+          memory: 2Gi    # Cap at 2Gi — prevents one pod monopolizing node memory
+
+        # controlledValues — whether VPA controls RequestsOnly or RequestsAndLimits.
+        # RequestsOnly: VPA only changes requests; limits remain unchanged.
+        #   Use this if you have a deliberate ratio between requests and limits.
+        # RequestsAndLimits: VPA scales both proportionally.
+        #   Use this for a 1:1 requests=limits setup (Guaranteed QoS class).
+        controlledValues: RequestsOnly


### PR DESCRIPTION
## Summary
- Add `hpa-cpu-memory.yml` — `autoscaling/v2` HPA targeting CPU at 50% and memory at 70% utilization; `minReplicas: 2`, `maxReplicas: 10`
- Add `hpa-with-behavior.yml` — HPA with `behavior.scaleDown.stabilizationWindowSeconds: 300` (prevents flapping) and `scaleUp.policies` rate limiting to 1 pod per 60s
- Add `vpa-auto.yml` — VPA in `Auto` mode with `resourcePolicy.containerPolicies` setting min/max CPU and memory bounds; note on VPA + HPA mutual exclusion
- Add `hpa/README.md` — metrics API chain (app → Prometheus → Adapter → `custom.metrics.k8s.io` → HPA), behavior block fields
- Add `autoscaling/README.md` — HPA vs VPA vs KEDA vs Cluster Autoscaler comparison table

## Issues referenced
Closes #35, relates to #33, #34, #36, #90

## Test plan
- [ ] `kubectl apply -f platform/autoscaling/hpa/hpa-cpu-memory.yml` creates HPA resource
- [ ] `kubectl get hpa` shows `TARGETS` once metrics-server is running
- [ ] VPA `describe` shows `Recommendation` section after 5 minutes