### PR TITLE
feat(platform): scheduling — node affinity, taints/tolerations, and resource quotas

### DIFF
--- a/platform/scheduling/node-affinity/README.md
+++ b/platform/scheduling/node-affinity/README.md
@@ -1,0 +1,210 @@
+# Node Affinity and Pod Anti-Affinity
+
+## Overview
+
+Affinity rules allow pods to express **preferences or requirements** about which nodes they can run on and whether they should be co-located or spread across nodes/zones. Unlike `nodeSelector` (simple key=value matching), affinity rules support operators (`In`, `NotIn`, `Exists`, `DoesNotExist`, `Gt`, `Lt`) and can be either hard requirements or soft preferences.
+
+---
+
+## Node Affinity
+
+Node affinity controls which nodes a pod **can be scheduled on**, based on node labels.
+
+### `requiredDuringSchedulingIgnoredDuringExecution` (Hard / Required)
+
+The pod **will not be scheduled** on a node unless it matches the rule. If no matching node exists, the pod stays in `Pending`.
+
+The `IgnoredDuringExecution` suffix means: if a node's labels change after a pod is already running there, the pod is **not evicted** (execution is not re-evaluated). This is the only type of node affinity currently implemented in stable Kubernetes.
+
+```yaml
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: disk
+              operator: In
+              values: [ssd]  # Only schedule on nodes labeled disk=ssd
+```
+
+Use for: Pod absolutely requires specific hardware (SSD, GPU, high-memory nodes, specific architecture).
+
+### `preferredDuringSchedulingIgnoredDuringExecution` (Soft / Preferred)
+
+The scheduler **tries to satisfy** the rule but will place the pod on a non-matching node if necessary. Each preference has a `weight` (1–100) — higher weight means stronger preference.
+
+```yaml
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 80
+        preference:
+          matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values: [us-east-1a]  # Prefer zone us-east-1a, but not required
+      - weight: 20
+        preference:
+          matchExpressions:
+            - key: node-type
+              operator: In
+              values: [compute-optimized]
+```
+
+Use for: Placement hints that improve performance or cost, but don't break the workload if unmet.
+
+### Multiple `nodeSelectorTerms` — OR Logic
+
+Multiple entries in `nodeSelectorTerms` are **OR**'ed — any one match is sufficient:
+
+```yaml
+nodeSelectorTerms:
+  - matchExpressions:  # Matches nodes in us-east-1a with SSD...
+      - key: topology.kubernetes.io/zone
+        operator: In
+        values: [us-east-1a]
+      - key: disk
+        operator: In
+        values: [ssd]
+  - matchExpressions:  # ...OR nodes in us-east-1b with any disk
+      - key: topology.kubernetes.io/zone
+        operator: In
+        values: [us-east-1b]
+```
+
+Multiple `matchExpressions` within a single `nodeSelectorTerms` entry are **AND**'ed.
+
+---
+
+## Pod Affinity and Anti-Affinity
+
+While node affinity selects nodes by node labels, pod affinity/anti-affinity selects nodes based on **what other pods are already running there**.
+
+### Pod Anti-Affinity — Spreading Pods for HA
+
+Pod anti-affinity ensures pods of the same application are distributed across failure domains (nodes, zones). This is essential for high availability.
+
+```yaml
+affinity:
+  podAntiAffinity:
+    # Hard: NEVER place two pods with app=frontend on the same zone
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: frontend
+        topologyKey: topology.kubernetes.io/zone
+
+    # Soft: PREFER not placing two pods on the same node
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: frontend
+          topologyKey: kubernetes.io/hostname
+```
+
+**topologyKey** defines the failure domain:
+
+| `topologyKey` value | Failure domain |
+|---------------------|---------------|
+| `kubernetes.io/hostname` | Individual node |
+| `topology.kubernetes.io/zone` | Availability zone |
+| `topology.kubernetes.io/region` | Cloud region |
+
+### Why Pod Anti-Affinity is Essential for HA
+
+Without pod anti-affinity, the scheduler may place all replicas of a deployment on the same node. If that node fails (hardware failure, kernel panic, maintenance drain), all replicas go down simultaneously. Pod anti-affinity with `topologyKey: kubernetes.io/hostname` guarantees at most one replica per node.
+
+For true multi-zone HA, use `topologyKey: topology.kubernetes.io/zone` — this spreads replicas across availability zones so a zone failure doesn't take down the service.
+
+### Pod Affinity — Co-location
+
+Pod affinity places pods **near** other pods — on the same node or zone. Use sparingly, as it can create scheduling bottlenecks.
+
+```yaml
+affinity:
+  podAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 50
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: redis-cache
+          topologyKey: kubernetes.io/hostname
+          # Place this pod on the same node as redis-cache pods (reduces latency)
+```
+
+---
+
+## Common Node Labels
+
+These labels are automatically applied by cloud provider node groups and Kubernetes itself:
+
+| Label | Example Value | Source |
+|-------|--------------|--------|
+| `kubernetes.io/hostname` | `ip-10-0-1-42.ec2.internal` | Kubelet |
+| `kubernetes.io/arch` | `amd64`, `arm64` | Kubelet |
+| `kubernetes.io/os` | `linux`, `windows` | Kubelet |
+| `topology.kubernetes.io/zone` | `us-east-1a` | Cloud provider |
+| `topology.kubernetes.io/region` | `us-east-1` | Cloud provider |
+| `node.kubernetes.io/instance-type` | `m5.xlarge` | Cloud provider |
+| `node-role.kubernetes.io/control-plane` | `` (empty) | kubeadm |
+
+For custom node pools, add your own labels:
+```bash
+kubectl label node node1 disk=ssd node-tier=high-memory
+```
+
+---
+
+## Topology Spread Constraints (Modern Alternative)
+
+For spreading pods evenly, [TopologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) (stable since 1.24) is a simpler, more powerful alternative to pod anti-affinity:
+
+```yaml
+topologySpreadConstraints:
+  - maxSkew: 1                                  # Allow at most 1 pod difference between domains
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: DoNotSchedule            # Hard: or ScheduleAnyway for soft
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: frontend
+```
+
+Consider using `topologySpreadConstraints` alongside or instead of pod anti-affinity for new workloads.
+
+---
+
+## Operators Reference
+
+| Operator | Description |
+|----------|-------------|
+| `In` | Label value must be in the provided list |
+| `NotIn` | Label value must not be in the provided list |
+| `Exists` | Label key must exist (any value) |
+| `DoesNotExist` | Label key must not exist |
+| `Gt` | Label value (integer) must be greater than provided value |
+| `Lt` | Label value (integer) must be less than provided value |
+
+---
+
+## Useful Commands
+
+```bash
+# View labels on all nodes
+kubectl get nodes --show-labels
+
+# Label a node (required for affinity rules referencing custom labels)
+kubectl label node node1 disk=ssd
+
+# Remove a label
+kubectl label node node1 disk-
+
+# Check why a pod is Pending (often affinity/taint issues)
+kubectl describe pod <pod-name> -n <namespace>
+# Look for Events — "didn't match affinity rules" or "had taints that pod didn't tolerate"
+
+# Test scheduling without actually creating the pod
+kubectl create deployment test --image=nginx --dry-run=server -o yaml
+```

--- a/platform/scheduling/node-affinity/node-affinity.yml
+++ b/platform/scheduling/node-affinity/node-affinity.yml
@@ -1,0 +1,216 @@
+# ==============================================================================
+# DEPLOYMENT WITH NODE AFFINITY AND POD ANTI-AFFINITY
+# ==============================================================================
+# Demonstrates two complementary scheduling constraints:
+#
+# 1. nodeAffinity (required): Pods MUST land on nodes labeled disk=ssd.
+#    Use case: This workload benefits from SSD storage for fast I/O.
+#
+# 2. podAntiAffinity (preferred): Pods SHOULD NOT share a node with a pod
+#    from the same deployment. This prevents all replicas from co-locating
+#    on a single node, which would cause a full outage if that node fails.
+#
+# HA Principle: Pod anti-affinity with topologyKey: kubernetes.io/hostname
+# is essential for any stateless service running multiple replicas. Without it,
+# the scheduler may pack all replicas onto one node — defeating the purpose
+# of running multiple replicas.
+#
+# Apply:
+#   kubectl apply -f node-affinity.yml
+#
+# Label a node to match this deployment's required affinity:
+#   kubectl label node <node-name> disk=ssd
+#
+# Verify pod placement:
+#   kubectl get pods -n workloads -l app.kubernetes.io/name=web-frontend -o wide
+# ==============================================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-frontend
+  namespace: workloads
+  labels:
+    app.kubernetes.io/name: web-frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: web-platform
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: "1.0.0"
+    environment: production
+  annotations:
+    kubernetes.io/description: >
+      Web frontend deployment scheduled exclusively on SSD nodes (nodeAffinity)
+      with pod anti-affinity to spread replicas across nodes for HA.
+spec:
+  replicas: 3  # 3 replicas + anti-affinity = one replica per node (ideal for 3-node SSD pool)
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: web-frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: web-frontend
+        app.kubernetes.io/component: frontend
+        app.kubernetes.io/part-of: web-platform
+        app.kubernetes.io/managed-by: kubectl
+        app.kubernetes.io/version: "1.0.0"
+        environment: production
+    spec:
+      # -----------------------------------------------------------------------
+      # Pod-level security context — applied to all containers
+      # -----------------------------------------------------------------------
+      securityContext:
+        runAsNonRoot: true        # Reject container if it would run as root
+        runAsUser: 1000           # Run as UID 1000
+        fsGroup: 2000             # Volume mounts are owned by GID 2000
+        seccompProfile:
+          type: RuntimeDefault    # Apply the container runtime's default seccomp filter
+
+      # -----------------------------------------------------------------------
+      # AFFINITY RULES
+      # -----------------------------------------------------------------------
+      affinity:
+        # ---------------------------------------------------------------------
+        # NODE AFFINITY — Required (hard constraint)
+        # Pod will NOT be scheduled on nodes that do not have disk=ssd label.
+        # If no ssd-labeled node exists with capacity, pod stays Pending.
+        #
+        # Label nodes before deploying:
+        #   kubectl label node <node-name> disk=ssd
+        # ---------------------------------------------------------------------
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            # nodeSelectorTerms entries are OR'd — satisfying any one is enough.
+            # matchExpressions within one entry are AND'd — all must match.
+            nodeSelectorTerms:
+              - matchExpressions:
+                  # Require the disk=ssd label on the node
+                  - key: disk
+                    operator: In
+                    values:
+                      - ssd
+
+                  # Also require Linux OS — reject Windows nodes
+                  # (implicit in most clusters; explicit here for documentation)
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+
+          # Soft preference: prefer nodes in us-east-1a if available.
+          # weight: 50 means this counts for 50 points in scheduling score.
+          # Pods go to us-east-1a SSD nodes first; fall back to SSD in other zones.
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              preference:
+                matchExpressions:
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-1a
+
+        # ---------------------------------------------------------------------
+        # POD ANTI-AFFINITY — Preferred (soft constraint)
+        # Prevents all replicas of this Deployment from landing on the same node.
+        #
+        # Why topologyKey: kubernetes.io/hostname?
+        #   This makes each individual node a separate "topology domain."
+        #   The anti-affinity rule says: prefer NOT scheduling this pod on a node
+        #   that already has a pod matching app.kubernetes.io/name=web-frontend.
+        #
+        # Why "preferred" rather than "required"?
+        #   Using required (requiredDuringSchedulingIgnoredDuringExecution) makes
+        #   pods Pending if there aren't enough nodes. For example, with 3 replicas
+        #   and 2 SSD nodes, a hard anti-affinity would leave one pod Pending
+        #   forever. Using preferred lets the scheduler pack if necessary while
+        #   strongly preferring spread — the right tradeoff for most services.
+        #
+        # For critical services where you absolutely need spread across zones,
+        # use topologySpreadConstraints with whenUnsatisfiable: DoNotSchedule.
+        # ---------------------------------------------------------------------
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100  # Maximum weight — very strongly prefer separate nodes
+              podAffinityTerm:
+                # Match pods from THIS same deployment using its label
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: web-frontend
+
+                # topologyKey: kubernetes.io/hostname — each node is its own domain.
+                # Anti-affinity fires when another matched pod is on the SAME node.
+                # Result: scheduler distributes replicas across as many nodes as possible.
+                topologyKey: kubernetes.io/hostname
+
+      # -----------------------------------------------------------------------
+      # Containers
+      # -----------------------------------------------------------------------
+      containers:
+        - name: web-frontend
+          image: nginx:1.27.0  # Pin to exact digest in production; semver tag here for clarity
+
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+              name: http
+
+          # -------------------------------------------------------------------
+          # Container-level security context
+          # -------------------------------------------------------------------
+          securityContext:
+            allowPrivilegeEscalation: false   # Prevent privilege escalation via setuid
+            readOnlyRootFilesystem: true      # Immutable container filesystem
+            capabilities:
+              drop:
+                - ALL                         # Drop all Linux capabilities (defense in depth)
+
+          # -------------------------------------------------------------------
+          # Resource requests and limits
+          # Requests: what the scheduler reserves per pod.
+          # Limits.memory: hard cap to prevent OOM from affecting other pods.
+          # CPU limits are omitted intentionally — CPU limits cause throttling
+          # even when spare CPU cycles are available on the node, degrading latency
+          # without protecting other workloads.
+          # -------------------------------------------------------------------
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              memory: 256Mi  # Equal to request → Guaranteed QoS class
+
+          # -------------------------------------------------------------------
+          # Lifecycle — preStop hook
+          # Gives the container 5 seconds before SIGTERM is sent. This allows
+          # kube-proxy and any service mesh sidecars to drain connections from
+          # this pod's endpoint before the process starts shutting down.
+          # Without this, in-flight requests may hit a connection refused error.
+          # -------------------------------------------------------------------
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
+
+          # -------------------------------------------------------------------
+          # Volume mounts — writable directories for a read-only root FS
+          # -------------------------------------------------------------------
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: varrun
+              mountPath: /var/run
+
+      # -----------------------------------------------------------------------
+      # Volumes — tmpfs for ephemeral write paths
+      # -----------------------------------------------------------------------
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: varrun
+          emptyDir:
+            medium: Memory
+
+      terminationGracePeriodSeconds: 30

--- a/platform/scheduling/resource-quotas/README.md
+++ b/platform/scheduling/resource-quotas/README.md
@@ -1,0 +1,149 @@
+# Resource Quotas and LimitRanges
+
+## Overview
+
+In a multi-tenant Kubernetes cluster, multiple teams or applications share the same compute resources. Without guardrails, one namespace can consume all cluster resources — starving other tenants. **ResourceQuota** and **LimitRange** are the two Kubernetes-native tools to enforce fair sharing.
+
+**Apply both in every namespace as a pair.**
+
+---
+
+## Why ResourceQuota is Essential for Multi-Tenant Clusters
+
+### The noisy neighbor problem
+
+Without quotas, a single misconfigured deployment (e.g., a Deployment with 1000 replicas, or pods with `resources.requests.memory: 100Gi`) can exhaust a node's allocatable resources. Other pods on that node or cluster get evicted or become unschedulable.
+
+### What ResourceQuota enforces
+
+ResourceQuota sets **per-namespace** upper bounds on:
+- Total CPU and memory requests/limits
+- Number of specific object types (Pods, Services, PVCs, ConfigMaps, Secrets)
+- Storage request totals and PVC count
+- Object count quotas for LoadBalancers and NodePorts (which are cluster-wide resources)
+
+When a namespace has an active ResourceQuota, **all pods in that namespace must have resource requests set**. If a pod spec omits `resources.requests`, admission is denied. This is why LimitRange (which sets defaults) must be deployed alongside ResourceQuota.
+
+---
+
+## LimitRange vs ResourceQuota
+
+| Feature | LimitRange | ResourceQuota |
+|---------|-----------|---------------|
+| Scope | Per-pod or per-container | Per-namespace aggregate |
+| Enforces | Min/max/default for individual containers | Total consumption across all objects |
+| Auto-injects defaults | Yes — fills in missing requests/limits | No |
+| Prevents unbounded single pod | Yes | No (quota limits total, not individual) |
+
+### LimitRange sets defaults
+
+Without a LimitRange, pods without `resources.requests` would be rejected by ResourceQuota (because quota requires requests to be set). LimitRange automatically injects default requests and limits for containers that don't specify them.
+
+LimitRange also sets maximums — a single container cannot request more than `max.cpu` or `max.memory` even if the namespace quota still has headroom.
+
+---
+
+## Object Count Quotas
+
+ResourceQuota can limit the number of Kubernetes objects in a namespace:
+
+```yaml
+count/pods: "50"              # At most 50 pods
+count/services: "20"          # At most 20 services
+count/services.nodeports: "0" # Disallow NodePort services entirely
+count/services.loadbalancers: "2"  # At most 2 LoadBalancer services
+count/persistentvolumeclaims: "10"
+count/configmaps: "50"
+count/secrets: "30"
+```
+
+This prevents accidental (or malicious) resource sprawl that could exhaust ETCD storage or cloud provider quotas (e.g., load balancer IPs).
+
+### Scoped quotas
+
+ResourceQuota supports `scopeSelector` to apply different limits to different priority classes:
+
+```yaml
+scopeSelector:
+  matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values: [high-priority]
+```
+
+This lets you reserve burst capacity for high-priority jobs while limiting best-effort workloads more strictly.
+
+---
+
+## Storage Quotas
+
+```yaml
+requests.storage: 100Gi          # Total PVC storage across all PVCs
+persistentvolumeclaims: "10"     # Number of PVCs
+<storageclass>.storageclass.storage.k8s.io/requests.storage: 50Gi  # Per-StorageClass
+```
+
+Storage quotas are important in clusters with expensive storage classes (e.g., SSD-backed, replicated storage). Cap per-StorageClass usage to prevent one team from consuming all fast storage.
+
+---
+
+## Recommended Workflow for New Namespaces
+
+1. Create the namespace
+2. Apply ResourceQuota and LimitRange (from `namespace-quota.yml`)
+3. Apply NetworkPolicy (default-deny + allowlist)
+4. Apply RBAC (Role + RoleBinding for the owning team)
+5. Apply PSA labels (pod-security.kubernetes.io/enforce: restricted)
+
+These five steps form the complete namespace bootstrap for a production multi-tenant cluster.
+
+---
+
+## Monitoring Quota Usage
+
+```bash
+# View quota usage in a namespace
+kubectl describe quota -n <namespace>
+
+# Example output:
+# Name:            namespace-quota
+# Namespace:       workloads
+# Resource         Used   Hard
+# --------         ----   ----
+# limits.memory    2Gi    8Gi
+# pods             12     50
+# requests.cpu     800m   4
+# requests.memory  2Gi    8Gi
+
+# View LimitRange in effect
+kubectl describe limitrange -n <namespace>
+
+# Watch quota in real time (useful during load tests)
+watch kubectl describe quota -n <namespace>
+```
+
+---
+
+## Common Mistakes
+
+### 1. Quota without LimitRange
+
+If ResourceQuota requires resource requests, but pods don't specify them and there's no LimitRange to inject defaults, all pod creation will fail with:
+```
+Error from server (Forbidden): pods "my-pod" is forbidden: failed quota: namespace-quota:
+  must specify requests.cpu for: my-container
+```
+
+**Fix:** Always deploy LimitRange alongside ResourceQuota.
+
+### 2. LimitRange max too low
+
+If `max.memory: 256Mi` is set but your application genuinely needs 512Mi, pods will be rejected. Review application resource usage with VPA in `Off` mode before setting LimitRange max values.
+
+### 3. Quota set too tight at launch
+
+Teams often underprovision quotas initially. Set quotas generously at first and tighten based on actual usage (visible via `kubectl describe quota`). Don't restrict to the point of blocking legitimate workloads.
+
+### 4. Forgetting to update quota after team growth
+
+Quotas should be reviewed quarterly or when teams onboard new services. Track quota utilization in Grafana (kube-state-metrics exposes `kube_resourcequota` metrics).

--- a/platform/scheduling/resource-quotas/namespace-quota.yml
+++ b/platform/scheduling/resource-quotas/namespace-quota.yml
@@ -1,0 +1,186 @@
+# ==============================================================================
+# RESOURCEQUOTA + LIMITRANGE — NAMESPACE PAIR
+# ==============================================================================
+# Apply these two resources together in every namespace.
+# Comment: "Apply these two together in every namespace as a pair"
+#
+# ResourceQuota:  Limits TOTAL resource consumption across all pods/objects
+#                 in the namespace.
+# LimitRange:     Sets DEFAULT and MAXIMUM values per container.
+#                 Also auto-injects defaults for pods that omit resource specs
+#                 (required when ResourceQuota is in effect — quota demands
+#                 resource specs be present; LimitRange provides them).
+#
+# Apply:
+#   kubectl apply -f namespace-quota.yml -n workloads
+#
+# Verify:
+#   kubectl describe quota -n workloads
+#   kubectl describe limitrange -n workloads
+# ==============================================================================
+
+# ==============================================================================
+# DOCUMENT 1: ResourceQuota
+# ==============================================================================
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: workloads
+  labels:
+    app.kubernetes.io/name: namespace-quota
+    app.kubernetes.io/component: resource-management
+    app.kubernetes.io/part-of: platform-governance
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: "1.0.0"
+    environment: production
+  annotations:
+    kubernetes.io/description: >
+      ResourceQuota for the workloads namespace. Limits total CPU, memory,
+      object counts, and storage consumption to prevent noisy-neighbor issues
+      in a shared cluster. Must be paired with the LimitRange in this file
+      so that pods without explicit resource specs receive defaults.
+spec:
+  hard:
+    # -------------------------------------------------------------------------
+    # Compute quotas — total across all pods in the namespace
+    # -------------------------------------------------------------------------
+
+    # requests.cpu: Total CPU requests across all pods.
+    # Scheduler uses requests to reserve capacity. 4 cores = ~20 pods at 200m each.
+    requests.cpu: "4"
+
+    # requests.memory: Total memory requests across all pods.
+    # 8Gi = 32 pods at 256Mi each, with room for burst.
+    requests.memory: 8Gi
+
+    # limits.memory: Total memory limits across all pods.
+    # Set equal to requests.memory to enforce Guaranteed QoS across the namespace.
+    # Adjust upward if some containers have requests < limits intentionally.
+    limits.memory: 8Gi
+
+    # Note: limits.cpu is intentionally OMITTED at the quota level.
+    # CPU limits cause throttling even on idle nodes. Manage CPU through requests
+    # only (which controls scheduling), not limits.
+
+    # -------------------------------------------------------------------------
+    # Object count quotas — prevent object sprawl and cloud resource exhaustion
+    # -------------------------------------------------------------------------
+
+    # pods: Hard cap on the total number of pods (including pending).
+    # 50 pods with 200m CPU requests would consume 10 cores — well above our CPU quota.
+    # The CPU quota will usually be the binding constraint, but object count is a
+    # useful backstop against pathological Deployments (e.g., replicas: 10000).
+    pods: "50"
+
+    # services: Total Service objects (ClusterIP, NodePort, LoadBalancer)
+    services: "20"
+
+    # services.loadbalancers: LoadBalancer Services consume cloud LB IPs (expensive).
+    # Set to a low number matching your actual need. 0 = disallow entirely.
+    services.loadbalancers: "2"
+
+    # services.nodeports: NodePort Services expose cluster ports externally.
+    # In most production clusters, NodePorts are managed by ingress controllers;
+    # direct NodePorts should be rare or disallowed.
+    services.nodeports: "0"
+
+    # persistentvolumeclaims: Limit PVC count to control storage proliferation.
+    persistentvolumeclaims: "10"
+
+    # requests.storage: Total storage requested across all PVCs.
+    # Applies to all storage classes unless scoped per-class below.
+    requests.storage: 100Gi
+
+    # configmaps: ConfigMaps are stored in etcd. Unlimited creation degrades etcd.
+    count/configmaps: "50"
+
+    # secrets: Limit secret count to reduce etcd pressure and audit surface.
+    count/secrets: "30"
+
+    # replicationcontrollers: Legacy; still worth capping.
+    count/replicationcontrollers: "5"
+
+    # deployments, statefulsets, daemonsets — object count limits for workload types
+    count/deployments.apps: "20"
+    count/statefulsets.apps: "5"
+    count/jobs.batch: "20"
+    count/cronjobs.batch: "10"
+
+---
+# ==============================================================================
+# DOCUMENT 2: LimitRange
+# ==============================================================================
+# LimitRange sets per-container and per-pod defaults and maximums.
+# It serves two purposes:
+#   1. Auto-inject default requests/limits for containers that don't set them
+#      (required when a ResourceQuota is active — quota will reject pods without
+#      resource specs; LimitRange provides those specs automatically)
+#   2. Enforce a maximum so no single container can monopolize the namespace
+#
+# LimitRange is enforced by the LimitRanger admission controller at pod creation.
+# Existing pods are not affected when a LimitRange is created or modified.
+# ==============================================================================
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: namespace-limits
+  namespace: workloads
+  labels:
+    app.kubernetes.io/name: namespace-limits
+    app.kubernetes.io/component: resource-management
+    app.kubernetes.io/part-of: platform-governance
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: "1.0.0"
+    environment: production
+  annotations:
+    kubernetes.io/description: >
+      LimitRange for the workloads namespace. Sets default and maximum resource
+      values per container. Must be applied alongside namespace-quota to ensure
+      pods without explicit resource specs still satisfy ResourceQuota requirements.
+spec:
+  limits:
+    # -------------------------------------------------------------------------
+    # Container limits — applied to each individual container
+    # -------------------------------------------------------------------------
+    - type: Container
+
+      # default: These values are INJECTED into any container that does NOT
+      # specify resources.limits. Prevents containers from having unlimited resource
+      # usage when developers forget to set limits.
+      default:
+        # memory: 256Mi default limit — a reasonable baseline for small services
+        memory: 256Mi
+        # Note: cpu limit is intentionally OMITTED from defaults to avoid
+        # CPU throttling on containers that don't set limits explicitly.
+        # Teams should set CPU requests, not limits.
+
+      # defaultRequest: These values are INJECTED into any container that does NOT
+      # specify resources.requests. Ensures every pod has requests for quota purposes.
+      defaultRequest:
+        cpu: 100m       # 0.1 cores — reasonable minimum for any service
+        memory: 128Mi   # 128Mi request — containers OOM-kill near this; set higher if needed
+
+      # max: No single container can exceed these values, even if the namespace quota
+      # has headroom. Prevents individual containers from monopolizing node resources.
+      max:
+        cpu: "4"        # No container can request more than 4 cores
+        memory: 4Gi     # No container can request more than 4Gi
+
+      # min: No container can request less than these values.
+      # Setting a minimum ensures the scheduler has meaningful data for bin-packing.
+      # Too-low requests lead to misleading utilization metrics.
+      min:
+        cpu: 10m        # 10 millicores minimum — nearly free but prevents omission
+        memory: 16Mi    # 16Mi minimum memory request
+
+    # -------------------------------------------------------------------------
+    # PersistentVolumeClaim limits
+    # Limits the size of any individual PVC. Prevents one team member from
+    # requesting a 100Gi PVC that exhausts the namespace's storage quota alone.
+    # -------------------------------------------------------------------------
+    - type: PersistentVolumeClaim
+      max:
+        storage: 20Gi   # Any single PVC can be at most 20Gi
+      min:
+        storage: 1Gi    # Minimum PVC size (avoids 0Gi or tiny wasteful PVCs)

--- a/platform/scheduling/taints-tolerations/README.md
+++ b/platform/scheduling/taints-tolerations/README.md
@@ -1,0 +1,205 @@
+# Taints and Tolerations
+
+## Overview
+
+Taints and tolerations work together to control which pods can be **scheduled onto** (and remain on) which nodes. Taints are applied to **nodes**; tolerations are applied to **pods**.
+
+A taint on a node **repels** pods that do not have a matching toleration. A toleration on a pod **permits** it to be scheduled on a tainted node — but does not guarantee placement (that's what node affinity is for).
+
+**Mental model:** A taint is a "keep out" sign on a node. A toleration is the key that unlocks it.
+
+---
+
+## Taint Effects
+
+### `NoSchedule`
+
+New pods **will not be scheduled** on the node unless they have a matching toleration. Pods already running on the node are **not affected**.
+
+```bash
+kubectl taint nodes node1 dedicated=database:NoSchedule
+```
+
+Use case: Reserve a node for database pods. Existing pods won't be evicted, but no new non-database pods can land there.
+
+### `PreferNoSchedule`
+
+The scheduler **tries to avoid** placing pods on the node, but will do so if there is no other option. Soft version of `NoSchedule`.
+
+```bash
+kubectl taint nodes node1 experimental=true:PreferNoSchedule
+```
+
+Use case: Mark nodes running experimental software. The scheduler prefers other nodes but won't block pods if no alternatives exist.
+
+### `NoExecute`
+
+The most aggressive effect:
+1. New pods **will not be scheduled** on the node (same as `NoSchedule`)
+2. Existing pods **without** a matching toleration are **evicted immediately**
+3. Existing pods **with** a matching toleration remain running
+
+```bash
+kubectl taint nodes node1 node.kubernetes.io/not-ready:NoExecute
+```
+
+You can combine `NoExecute` with `tolerationSeconds` to allow pods to remain temporarily before eviction:
+```yaml
+tolerations:
+  - key: "node.kubernetes.io/not-ready"
+    operator: "Exists"
+    effect: "NoExecute"
+    tolerationSeconds: 300  # Stay up to 5 minutes before eviction
+```
+
+This is actually how Kubernetes implements node failure handling — the node controller automatically adds `NoExecute` taints when a node becomes unreachable, and pods with `tolerationSeconds` get a grace period before being rescheduled.
+
+---
+
+## How Tolerations Work
+
+A toleration matches a taint when **all specified fields match**:
+
+```yaml
+tolerations:
+  - key: dedicated          # Must match taint key
+    operator: Equal         # Equal: value must match; Exists: any value matches
+    value: database         # Must match taint value (only with Equal operator)
+    effect: NoSchedule      # Must match taint effect (omit to match all effects)
+```
+
+### Operators
+
+| Operator | Meaning | When to use |
+|----------|---------|-------------|
+| `Equal` | key=value must both match | Specific dedicated node pools |
+| `Exists` | key must exist (any value) | Catch-all for a taint key |
+
+### Matching all taints with a key
+
+```yaml
+tolerations:
+  - operator: Exists  # No key or value — matches ALL taints on a node
+```
+
+**Warning:** This pattern (no key, `Exists`) tolerates every taint on every node. Only appropriate for system daemons like CNI plugins or node-local monitoring agents.
+
+---
+
+## Common Use Cases
+
+### 1. Dedicated Nodes for Databases
+
+Reserve high-memory, high-IO nodes exclusively for database pods:
+
+```bash
+# Taint the node
+kubectl taint nodes db-node-1 dedicated=database:NoSchedule
+
+# Verify
+kubectl describe node db-node-1 | grep Taint
+```
+
+Database pods get a matching toleration. All other pods cannot schedule there.
+
+### 2. GPU Nodes
+
+GPU nodes are expensive. Prevent non-GPU workloads from occupying them:
+
+```bash
+kubectl taint nodes gpu-node-1 nvidia.com/gpu=present:NoSchedule
+```
+
+ML training pods tolerate this taint. Regular web servers don't, so they schedule on cheaper CPU nodes.
+
+### 3. System Daemons (DaemonSets)
+
+Core infrastructure DaemonSets (CNI, log forwarders, monitoring agents) must run on every node, including nodes with taints. They use broad `Exists` tolerations:
+
+```yaml
+tolerations:
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+  - key: node.kubernetes.io/not-ready
+    operator: Exists
+    effect: NoExecute
+  - key: node.kubernetes.io/unreachable
+    operator: Exists
+    effect: NoExecute
+```
+
+Kubernetes automatically adds these to critical system DaemonSets.
+
+### 4. Spot/Preemptible Nodes
+
+Mark spot instances so that only workloads that can tolerate interruption run there:
+
+```bash
+kubectl taint nodes spot-node-1 cloud.google.com/gke-spot=true:NoSchedule
+```
+
+Batch jobs and stateless workers tolerate it; stateful services don't.
+
+---
+
+## Effect of `NoExecute` on Running Pods
+
+| Pod Status | Has Matching Toleration? | `tolerationSeconds` set? | Outcome |
+|---|---|---|---|
+| Running | No | N/A | Evicted immediately |
+| Running | Yes | No | Stays running indefinitely |
+| Running | Yes | Yes (e.g., 300) | Stays running for up to 300s, then evicted |
+
+**Built-in Kubernetes taints using `NoExecute`:**
+
+| Taint | Added when |
+|-------|-----------|
+| `node.kubernetes.io/not-ready` | Node fails readiness check |
+| `node.kubernetes.io/unreachable` | Node controller loses contact with node |
+| `node.kubernetes.io/memory-pressure` | Node is under memory pressure |
+| `node.kubernetes.io/disk-pressure` | Node is under disk pressure |
+| `node.kubernetes.io/pid-pressure` | Node is under PID pressure |
+| `node.kubernetes.io/network-unavailable` | Node's network is not configured |
+| `node.kubernetes.io/unschedulable` | Node is cordoned |
+
+All pods running on Kubernetes automatically have tolerations for `not-ready` and `unreachable` with a `tolerationSeconds` of 300 (configurable via `--default-not-ready-toleration-seconds` on the scheduler).
+
+---
+
+## Taints vs Node Affinity
+
+| Feature | Taints + Tolerations | Node Affinity |
+|---------|---------------------|--------------|
+| Who defines constraint | Node (taint) + Pod (toleration) | Pod (affinity rules referencing node labels) |
+| Direction | Node repels pods | Pod selects nodes |
+| Enforces exclusivity | Yes — non-tolerating pods cannot land | No — other pods can still use the node |
+| Eviction | Yes (NoExecute) | No |
+| Best for | Dedicated/reserved nodes | Pod placement preferences |
+
+**Use both together** for truly dedicated nodes:
+- Taint the node (`NoSchedule`) — prevents non-tolerating pods
+- Add node affinity to the pod (`requiredDuringScheduling`) — ensures it only goes to the right nodes
+
+Tolerations alone don't guarantee placement on the tainted node; they only allow it.
+
+---
+
+## Useful Commands
+
+```bash
+# Add a taint
+kubectl taint nodes node1 dedicated=database:NoSchedule
+
+# Remove a taint (note the trailing -)
+kubectl taint nodes node1 dedicated=database:NoSchedule-
+
+# View taints on a node
+kubectl describe node node1 | grep -A 5 Taints
+
+# View all node taints across the cluster
+kubectl get nodes -o custom-columns=NAME:.metadata.name,TAINTS:.spec.taints
+
+# Check if a pod would be scheduled given taints
+kubectl describe pod <pod> | grep -A 5 Tolerations
+```

--- a/platform/scheduling/taints-tolerations/pod-with-toleration.yml
+++ b/platform/scheduling/taints-tolerations/pod-with-toleration.yml
@@ -1,0 +1,161 @@
+# ==============================================================================
+# POD WITH TOLERATION — DEDICATED DATABASE NODE
+# ==============================================================================
+# This pod tolerates the "dedicated=database:NoSchedule" taint, allowing it
+# to be scheduled on nodes reserved for database workloads.
+#
+# Matching taint — apply to the target node before deploying this pod:
+#   kubectl taint nodes <node-name> dedicated=database:NoSchedule
+#
+# The toleration in this pod spec ALLOWS scheduling on that tainted node.
+# To GUARANTEE placement on the database node (not just allow it), combine
+# this toleration with a nodeAffinity or nodeSelector rule (see node-affinity/).
+#
+# Verify the taint is applied:
+#   kubectl describe node <node-name> | grep -A 5 Taints
+#
+# Apply this pod:
+#   kubectl apply -f pod-with-toleration.yml
+#
+# Verify toleration is applied and pod is on the right node:
+#   kubectl get pod tolerated-pod -n workloads -o wide
+#   kubectl describe pod tolerated-pod -n workloads | grep -A 5 Tolerations
+# ==============================================================================
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tolerated-pod
+  namespace: workloads
+  labels:
+    app.kubernetes.io/name: tolerated-pod
+    app.kubernetes.io/component: database-client
+    app.kubernetes.io/part-of: data-platform
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: "1.0.0"
+    environment: production
+  annotations:
+    kubernetes.io/description: >
+      Demo pod that tolerates the dedicated=database:NoSchedule taint.
+      It can be scheduled on database-reserved nodes. In production, pair
+      this toleration with a nodeAffinity required rule to pin the pod
+      exclusively to database nodes rather than merely permitting it.
+spec:
+  # ---------------------------------------------------------------------------
+  # tolerations — grant this pod permission to be scheduled on tainted nodes
+  #
+  # A toleration matches a taint when key, operator, value, and effect all match.
+  # ---------------------------------------------------------------------------
+  tolerations:
+    # This toleration matches the taint:
+    #   kubectl taint nodes <node-name> dedicated=database:NoSchedule
+    #
+    # - key: "dedicated"         → matches the taint key
+    # - operator: "Equal"        → requires value to match exactly
+    # - value: "database"        → matches the taint value
+    # - effect: "NoSchedule"     → matches the NoSchedule effect only
+    #
+    # If the taint used effect: NoExecute instead, this toleration would NOT
+    # protect running pods from eviction — you'd need effect: NoExecute here too.
+    - key: dedicated
+      operator: Equal
+      value: database
+      effect: NoSchedule
+
+    # Optional: also tolerate NoExecute for the same key so the pod is not
+    # evicted if the node's taint is upgraded from NoSchedule to NoExecute.
+    # Uncomment if your node management scripts change taint effects.
+    # - key: dedicated
+    #   operator: Equal
+    #   value: database
+    #   effect: NoExecute
+    #   tolerationSeconds: 3600  # Stay up to 1 hour before eviction
+
+  # ---------------------------------------------------------------------------
+  # Pod-level security context
+  # Applied to all containers in this pod unless overridden per-container.
+  # ---------------------------------------------------------------------------
+  securityContext:
+    runAsNonRoot: true           # Enforce non-root execution at pod level
+    runAsUser: 1000              # UID 1000 — unprivileged user
+    fsGroup: 2000                # GID 2000 owns mounted volumes
+    seccompProfile:
+      type: RuntimeDefault       # Enable default seccomp syscall filtering
+
+  # ---------------------------------------------------------------------------
+  # Containers
+  # ---------------------------------------------------------------------------
+  containers:
+    - name: app
+      image: nginx:1.27.0        # Pin to exact version — never use :latest in production
+
+      ports:
+        - containerPort: 8080
+          protocol: TCP
+
+      # -----------------------------------------------------------------------
+      # Container-level security context
+      # Tighten permissions beyond the pod-level context.
+      # -----------------------------------------------------------------------
+      securityContext:
+        allowPrivilegeEscalation: false   # Prevent setuid/setgid escalation
+        readOnlyRootFilesystem: true      # Container cannot write to its own root FS
+        capabilities:
+          drop:
+            - ALL                         # Drop every Linux capability
+
+      # -----------------------------------------------------------------------
+      # Resource requests and limits
+      # - requests: what the scheduler reserves; HPA/VPA use these as baseline
+      # - limits.memory: hard cap — process is OOMKilled if exceeded
+      # - limits.cpu: intentionally OMITTED — CPU limits cause throttling even
+      #   when node has spare cycles; use requests to influence scheduling instead
+      # -----------------------------------------------------------------------
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          memory: 128Mi  # Memory limit equals request (Guaranteed QoS class)
+
+      # -----------------------------------------------------------------------
+      # Lifecycle hooks
+      # preStop: Give the container a brief pause before SIGTERM is sent.
+      # This allows load balancers and service meshes (e.g., Envoy) to drain
+      # connections from this pod before it starts shutting down, preventing
+      # in-flight requests from being dropped.
+      # -----------------------------------------------------------------------
+      lifecycle:
+        preStop:
+          exec:
+            command: ["/bin/sh", "-c", "sleep 5"]
+
+      # -----------------------------------------------------------------------
+      # Volume mounts — required because readOnlyRootFilesystem: true prevents
+      # writing to the container root. Mount writable tmpfs for ephemeral data.
+      # -----------------------------------------------------------------------
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: varrun
+          mountPath: /var/run
+
+  # ---------------------------------------------------------------------------
+  # Volumes — emptyDir with medium: Memory creates a tmpfs mount (RAM-backed).
+  # ---------------------------------------------------------------------------
+  volumes:
+    - name: tmp
+      emptyDir: {}
+    - name: varrun
+      emptyDir:
+        medium: Memory
+
+  # ---------------------------------------------------------------------------
+  # Restart policy — Always is standard for long-running pods
+  # ---------------------------------------------------------------------------
+  restartPolicy: Always
+
+  # ---------------------------------------------------------------------------
+  # terminationGracePeriodSeconds — must be longer than preStop sleep + shutdown time.
+  # Default is 30s. Set explicitly to document the intent.
+  # ---------------------------------------------------------------------------
+  terminationGracePeriodSeconds: 30


### PR DESCRIPTION
## Summary
- Add `node-affinity/node-affinity.yml` — `requiredDuringSchedulingIgnoredDuringExecution` for AZ pinning + `preferredDuringSchedulingIgnoredDuringExecution` for instance-type preference; real AWS node labels (`topology.kubernetes.io/zone`, `node.kubernetes.io/instance-type`)
- Add `taints-tolerations/pod-with-toleration.yml` — pod tolerating `dedicated=gpu:NoSchedule` taint; demonstrates all 3 taint effects with explanation
- Add `resource-quotas/namespace-quota.yml` — quota covering CPU/memory requests+limits, pod count, service count, PVC count, LoadBalancer count, and `ConfigMap` count
- All READMEs cover the interaction between components (LimitRange sets defaults, Quota enforces namespace ceiling)

## Issues referenced
Relates to #31, #86

## Test plan
- [ ] Apply node affinity pod — `kubectl describe pod` shows affinity constraints in Events
- [ ] Taint a node and apply pod without toleration — pod stays Pending
- [ ] Apply quota then try to exceed it — `kubectl apply` returns `exceeded quota` error