### PR TITLE
feat(security): RBAC — ServiceAccount, Role, ClusterRole, and bindings

### DIFF
--- a/platform/security/rbac/README.md
+++ b/platform/security/rbac/README.md
@@ -1,0 +1,258 @@
+# RBAC (Role-Based Access Control) — Deep Dive
+
+## Overview
+
+Kubernetes RBAC controls **who** can perform **what actions** on **which resources**. Every API request is authenticated (who are you?) and then authorized (are you allowed to do this?). RBAC is the standard Kubernetes authorization mechanism for production clusters.
+
+RBAC works with three core concepts: **Subjects**, **Roles**, and **Bindings**.
+
+---
+
+## Subjects
+
+A subject is the identity making the API request. There are three types:
+
+### User
+
+Kubernetes does not manage users internally. Users are external identities authenticated via:
+- X.509 client certificates (common name = username, organization = group)
+- OIDC tokens (e.g., from Dex, Google, Okta)
+- Bearer tokens
+
+```yaml
+subjects:
+  - kind: User
+    name: jane.doe@example.com  # Must match the identity the cluster sees
+    apiGroup: rbac.authorization.k8s.io
+```
+
+### Group
+
+Groups aggregate multiple users. In X.509 certificates, the `organization` field maps to groups. OIDC claims can also include groups.
+
+```yaml
+subjects:
+  - kind: Group
+    name: platform-team           # Organization in cert, or OIDC groups claim
+    apiGroup: rbac.authorization.k8s.io
+```
+
+### ServiceAccount
+
+ServiceAccounts are Kubernetes-native identities for **pods and automation**. They are namespaced, managed by the API server, and automatically receive a mounted token (unless `automountServiceAccountToken: false` is set).
+
+```yaml
+subjects:
+  - kind: ServiceAccount
+    name: my-service-account
+    namespace: workloads          # ServiceAccounts are namespaced; namespace is required
+    # No apiGroup field for ServiceAccount
+```
+
+---
+
+## Role vs ClusterRole
+
+### Role (Namespaced)
+
+A Role grants permissions to resources **within a single namespace**. It cannot reference cluster-scoped resources (nodes, PVs, namespaces, ClusterRoles).
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-reader
+  namespace: workloads  # Permissions only apply within this namespace
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+```
+
+### ClusterRole (Cluster-Wide)
+
+A ClusterRole grants permissions to resources **across all namespaces** or to cluster-scoped resources (nodes, PVs, StorageClasses, Namespaces, ClusterRoles themselves).
+
+**A ClusterRole can be bound with a RoleBinding** to limit its scope to a single namespace — this is a common pattern for reusable roles.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-reader  # No namespace field — cluster-scoped
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+```
+
+---
+
+## RoleBinding vs ClusterRoleBinding
+
+### RoleBinding (Namespaced)
+
+Binds a Role or ClusterRole to subjects **within a single namespace**. Even if it references a ClusterRole, the resulting permissions are limited to the binding's namespace.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-reader-binding
+  namespace: workloads
+subjects:
+  - kind: ServiceAccount
+    name: my-app
+    namespace: workloads
+roleRef:
+  kind: Role              # Can also be ClusterRole
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io
+```
+
+### ClusterRoleBinding (Cluster-Wide)
+
+Binds a ClusterRole to subjects **cluster-wide**. A ServiceAccount bound with a ClusterRoleBinding can act on all namespaces (or cluster-scoped resources).
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-reader-binding
+subjects:
+  - kind: ServiceAccount
+    name: monitoring-agent
+    namespace: monitoring
+roleRef:
+  kind: ClusterRole
+  name: node-reader
+  apiGroup: rbac.authorization.k8s.io
+```
+
+---
+
+## Principle of Least Privilege
+
+Grant **only the permissions required** for a specific task, to a specific subject, in a specific namespace. Audit regularly.
+
+**Checklist:**
+- [ ] Use ServiceAccounts, not User credentials, for in-cluster automation
+- [ ] Set `automountServiceAccountToken: false` on ServiceAccounts — let pods opt in
+- [ ] Use `Role` + `RoleBinding` unless cluster-scope is explicitly needed
+- [ ] Scope secrets access to specific secret names using `resourceNames`
+- [ ] Never grant `*` verbs or `*` resources (wildcard)
+- [ ] Never bind to `cluster-admin` except for true cluster administrators
+- [ ] Review bindings quarterly: `kubectl get clusterrolebindings -o wide`
+
+---
+
+## Auditing with `kubectl auth can-i`
+
+```bash
+# Can the current user create pods in the workloads namespace?
+kubectl auth can-i create pods -n workloads
+
+# Can the app-service-account ServiceAccount read secrets in workloads?
+kubectl auth can-i get secrets -n workloads \
+  --as=system:serviceaccount:workloads:app-service-account
+
+# Can monitoring-agent list nodes (cluster-wide)?
+kubectl auth can-i list nodes \
+  --as=system:serviceaccount:monitoring:monitoring-agent
+
+# List ALL permissions for a ServiceAccount
+kubectl auth can-i --list -n workloads \
+  --as=system:serviceaccount:workloads:app-service-account
+
+# Check if a specific user can access a specific resource
+kubectl auth can-i delete deployments -n production \
+  --as=jane.doe@example.com
+```
+
+---
+
+## Common Mistakes
+
+### 1. Binding to `cluster-admin`
+
+`cluster-admin` is a built-in ClusterRole with **full permissions on all resources in all namespaces**. It is appropriate only for cluster administrators. Binding it to a ServiceAccount for an application is a critical security vulnerability — if the pod is compromised, the attacker has full cluster access.
+
+```bash
+# Audit existing cluster-admin bindings
+kubectl get clusterrolebindings -o json \
+  | jq '.items[] | select(.roleRef.name=="cluster-admin") | {name: .metadata.name, subjects: .subjects}'
+```
+
+### 2. Wildcard Resources or Verbs
+
+```yaml
+# DANGEROUS — grants access to all resources and all actions
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+```
+
+This effectively grants `cluster-admin`. Specify exact resources and verbs.
+
+### 3. Forgetting to Scope Secrets with `resourceNames`
+
+Without `resourceNames`, a rule like:
+```yaml
+resources: ["secrets"]
+verbs: ["get"]
+```
+allows reading **all secrets** in the namespace, including other applications' secrets. Use `resourceNames` to restrict access to only the specific secrets your application needs.
+
+### 4. Using the Default ServiceAccount
+
+Every namespace has a `default` ServiceAccount. Many tools create pods without specifying a ServiceAccount — they get `default`. If you attach RBAC permissions to `default`, you're granting them to **every pod that doesn't specify a ServiceAccount**, which is dangerous.
+
+**Fix:** Create dedicated ServiceAccounts per application. Set `automountServiceAccountToken: false` on the `default` ServiceAccount.
+
+### 5. ClusterRoleBinding when RoleBinding would suffice
+
+A ClusterRoleBinding grants access to all namespaces. If an application only needs to operate in one namespace, use a RoleBinding (even when binding a ClusterRole). The binding scope limits the permission scope.
+
+---
+
+## Scoping Secret Access with `resourceNames`
+
+```yaml
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+    resourceNames: ["app-secret", "db-credentials"]  # ONLY these secrets
+```
+
+This is the correct pattern for application secrets. Without `resourceNames`, the `get` verb on `secrets` would allow reading any secret in the namespace — including other teams' secrets in the same namespace.
+
+---
+
+## Useful Commands
+
+```bash
+# List all Roles in a namespace
+kubectl get roles -n workloads
+
+# List all RoleBindings in a namespace
+kubectl get rolebindings -n workloads -o wide
+
+# List all ClusterRoles
+kubectl get clusterroles
+
+# List all ClusterRoleBindings
+kubectl get clusterrolebindings
+
+# Show the rules in a specific Role
+kubectl describe role app-role -n workloads
+
+# Show who is bound to a specific ClusterRole
+kubectl get clusterrolebindings -o json \
+  | jq '.items[] | select(.roleRef.name=="cluster-node-reader")'
+
+# Detect RBAC issues (pod can't access resource)
+kubectl logs <pod> -n workloads  # Look for "forbidden" in application logs
+kubectl get events -n workloads  # Look for RBAC-related events
+```

--- a/platform/security/rbac/cluster-role.yml
+++ b/platform/security/rbac/cluster-role.yml
@@ -1,0 +1,100 @@
+# ==============================================================================
+# CLUSTERROLE — cluster-node-reader
+# ==============================================================================
+# ClusterRole needed for resources that are not namespaced: nodes, PVs,
+# StorageClasses, Namespaces, ClusterRoles, and other cluster-scoped objects.
+#
+# A regular Role cannot reference these resources — they exist at the cluster
+# level, not within any namespace. Only a ClusterRole can grant permissions
+# on cluster-scoped resources.
+#
+# This ClusterRole grants READ-ONLY access to:
+#   - nodes        — for monitoring agents to collect node metrics/status
+#   - persistentvolumes — for storage management tools to inventory PVs
+#   - storageclasses    — to check available storage classes
+#
+# Bind this ClusterRole to a subject using:
+#   - ClusterRoleBinding — grants access cluster-wide (all namespaces + cluster resources)
+#   - RoleBinding        — grants access only within a specific namespace
+#                          NOTE: for cluster-scoped resources like nodes and PVs,
+#                          you MUST use ClusterRoleBinding — a RoleBinding of a
+#                          ClusterRole only affects namespaced resources in that namespace.
+#
+# Apply:
+#   kubectl apply -f cluster-role.yml
+#
+# Bind with:
+#   kubectl apply -f cluster-rolebinding.yml
+#
+# Verify:
+#   kubectl describe clusterrole cluster-node-reader
+#   kubectl auth can-i list nodes \
+#     --as=system:serviceaccount:monitoring:monitoring-agent
+# ==============================================================================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  # ClusterRole has no namespace field — it is a cluster-scoped resource
+  name: cluster-node-reader
+  labels:
+    app.kubernetes.io/name: cluster-node-reader
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: monitoring-platform
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: "1.0.0"
+    environment: production
+  annotations:
+    kubernetes.io/description: >
+      ClusterRole granting read-only access to cluster-scoped resources:
+      nodes, PersistentVolumes, and StorageClasses. Intended for monitoring
+      agents (e.g., node-exporter, kube-state-metrics) that need to enumerate
+      cluster-level infrastructure. Bound via cluster-node-reader-binding
+      ClusterRoleBinding to the monitoring-agent ServiceAccount.
+rules:
+  # ---------------------------------------------------------------------------
+  # Nodes — cluster-scoped resource
+  # Monitoring agents need node status, capacity, and allocatable resources.
+  # "get" — retrieve a specific node by name
+  # "list" — list all nodes (needed for initial inventory)
+  # "watch" — receive updates as node status changes (efficient long-polling)
+  #
+  # NOTE: ClusterRole needed for resources that are not namespaced:
+  # nodes, PVs, StorageClasses, Namespaces, ClusterRoles
+  # ---------------------------------------------------------------------------
+  - apiGroups: [""]          # Core API group — nodes are in v1 (core)
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+
+  # Node metrics endpoint — required for monitoring tools that scrape node metrics
+  # via the API server proxy (e.g., cadvisor metrics, node summaries)
+  - apiGroups: [""]
+    resources: ["nodes/metrics", "nodes/stats", "nodes/proxy"]
+    verbs: ["get"]
+
+  # ---------------------------------------------------------------------------
+  # PersistentVolumes — cluster-scoped resource
+  # PVs are not namespaced — they exist at the cluster level even though PVCs
+  # that bind to them are namespaced. Storage management tools need to list PVs
+  # to track capacity and reclaim policy.
+  # ---------------------------------------------------------------------------
+  - apiGroups: [""]          # Core API group — PVs are in v1 (core)
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list"]
+
+  # ---------------------------------------------------------------------------
+  # StorageClasses — cluster-scoped resource (storage.k8s.io/v1)
+  # StorageClasses define the parameters for dynamic volume provisioning.
+  # Monitoring and platform tools need to enumerate available storage classes.
+  # ---------------------------------------------------------------------------
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list"]
+
+  # ---------------------------------------------------------------------------
+  # Namespaces — cluster-scoped resource
+  # Allow listing namespaces so monitoring agents can discover all namespaces
+  # and collect metrics across the cluster without needing per-namespace access.
+  # ---------------------------------------------------------------------------
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]

--- a/platform/security/rbac/cluster-rolebinding.yml
+++ b/platform/security/rbac/cluster-rolebinding.yml
@@ -1,0 +1,68 @@
+# ==============================================================================
+# CLUSTERROLEBINDING — node-reader-binding
+# ==============================================================================
+# Binds the "cluster-node-reader" ClusterRole to the "monitoring-agent"
+# ServiceAccount in the "monitoring" namespace.
+#
+# A ClusterRoleBinding grants permissions CLUSTER-WIDE — the bound subject
+# can act on the specified resources in ALL namespaces (for namespaced resources)
+# or on all cluster-scoped resources (for cluster-scoped resources like nodes).
+#
+# When to use ClusterRoleBinding vs RoleBinding:
+#   - Use ClusterRoleBinding when the subject needs access to cluster-scoped
+#     resources (nodes, PVs, StorageClasses) — these can ONLY be granted via
+#     ClusterRoleBinding (RoleBinding cannot grant cluster-scoped access).
+#   - Use ClusterRoleBinding when the subject legitimately needs access to
+#     resources across ALL namespaces (e.g., a cluster-wide monitoring agent).
+#   - Use RoleBinding in all other cases — even when binding a ClusterRole,
+#     a RoleBinding limits the scope to the binding's namespace.
+#
+# Apply:
+#   kubectl apply -f cluster-rolebinding.yml
+#
+# Verify:
+#   kubectl auth can-i list nodes \
+#     --as=system:serviceaccount:monitoring:monitoring-agent
+#   # Expected: yes
+#
+#   kubectl auth can-i list persistentvolumes \
+#     --as=system:serviceaccount:monitoring:monitoring-agent
+#   # Expected: yes
+#
+#   kubectl auth can-i delete nodes \
+#     --as=system:serviceaccount:monitoring:monitoring-agent
+#   # Expected: no  (only get, list, watch granted)
+# ==============================================================================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  # ClusterRoleBinding has no namespace field — it is a cluster-scoped resource
+  name: node-reader-binding
+  labels:
+    app.kubernetes.io/name: node-reader-binding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: monitoring-platform
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: "1.0.0"
+    environment: production
+  annotations:
+    kubernetes.io/description: >
+      ClusterRoleBinding granting the monitoring-agent ServiceAccount (monitoring
+      namespace) read-only access to nodes, PersistentVolumes, StorageClasses,
+      and Namespaces cluster-wide. Required for node-level monitoring agents that
+      need to enumerate cluster infrastructure.
+subjects:
+  # The ServiceAccount receiving cluster-wide permissions.
+  # For ClusterRoleBinding, the subject's namespace must be specified — a
+  # ServiceAccount in the "monitoring" namespace is a different identity than
+  # one named "monitoring-agent" in the "workloads" namespace.
+  - kind: ServiceAccount
+    name: monitoring-agent
+    namespace: monitoring   # ServiceAccount must exist in this namespace
+
+roleRef:
+  # roleRef must reference a ClusterRole when binding cluster-scoped permissions.
+  # A ClusterRoleBinding cannot reference a namespaced Role.
+  kind: ClusterRole
+  name: cluster-node-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/platform/security/rbac/namespace-role.yml
+++ b/platform/security/rbac/namespace-role.yml
@@ -1,0 +1,82 @@
+# ==============================================================================
+# ROLE — app-role (Namespaced)
+# ==============================================================================
+# A Role grants permissions ONLY within the namespace it is created in (workloads).
+# It cannot grant access to cluster-scoped resources (nodes, PVs, namespaces).
+# Use ClusterRole for cluster-scoped resources (see cluster-role.yml).
+#
+# This Role follows the principle of least privilege:
+#   - Pods: read-only (get, list, watch) — for self-discovery and health monitoring
+#   - ConfigMaps: get only — read application configuration
+#   - Secrets: get only — scoped to ONLY "app-secret" via resourceNames
+#
+# The resourceNames field on the secrets rule is critical security hygiene.
+# Without resourceNames, "get secrets" would allow reading EVERY secret in
+# the namespace, including other applications' credentials.
+#
+# Apply:
+#   kubectl apply -f namespace-role.yml
+#
+# Bind with:
+#   kubectl apply -f rolebinding.yml
+#
+# Verify:
+#   kubectl describe role app-role -n workloads
+#   kubectl auth can-i get secrets/app-secret -n workloads \
+#     --as=system:serviceaccount:workloads:app-service-account
+# ==============================================================================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: app-role
+  namespace: workloads
+  labels:
+    app.kubernetes.io/name: app-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: app-platform
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: "1.0.0"
+    environment: production
+  annotations:
+    kubernetes.io/description: >
+      Namespaced Role for the app workload. Grants read-only access to pods and
+      a specific ConfigMap, plus get access to a single named secret (app-secret).
+      Binds to app-service-account via app-rolebinding.
+rules:
+  # ---------------------------------------------------------------------------
+  # Pods — read-only access
+  # Required for applications that use the Downward API, query their own pod
+  # spec, or implement leader election via pod label inspection.
+  # apiGroups: [""] means the core API group (v1 resources: pods, services, etc.)
+  # ---------------------------------------------------------------------------
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+
+  # ---------------------------------------------------------------------------
+  # ConfigMaps — get only
+  # Applications often read ConfigMaps at startup for configuration.
+  # "get" (by name) is sufficient; "list" and "watch" are not needed unless
+  # the application implements config hot-reloading via the watch API.
+  # ---------------------------------------------------------------------------
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+
+  # ---------------------------------------------------------------------------
+  # Secrets — get only, scoped to a specific named secret
+  #
+  # resourceNames scopes secret access to only the specific secret this app needs.
+  # Without resourceNames, "get secrets" grants read access to ALL secrets in
+  # the namespace — including other applications' database passwords, API keys, etc.
+  #
+  # Always use resourceNames for secrets in production RBAC configurations.
+  # This is a defense-in-depth measure: even if the application's service account
+  # token is compromised, the attacker can only read this one named secret.
+  # ---------------------------------------------------------------------------
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+    # Comment: resourceNames scopes secret access to only the specific secret this app needs
+    resourceNames:
+      - app-secret  # Only this exact secret name is accessible

--- a/platform/security/rbac/rolebinding.yml
+++ b/platform/security/rbac/rolebinding.yml
@@ -1,0 +1,65 @@
+# ==============================================================================
+# ROLEBINDING — app-rolebinding
+# ==============================================================================
+# Binds the "app-role" Role to the "app-service-account" ServiceAccount,
+# granting the ServiceAccount the permissions defined in app-role, but ONLY
+# within the "workloads" namespace.
+#
+# Key properties of RoleBinding:
+#   - Scope: Permissions are limited to the binding's namespace (workloads).
+#   - Can bind a Role OR a ClusterRole — when binding a ClusterRole, permissions
+#     are still limited to the binding's namespace.
+#   - Does NOT grant permissions on cluster-scoped resources (nodes, PVs, etc.)
+#     Use ClusterRoleBinding for those (see cluster-rolebinding.yml).
+#
+# Apply:
+#   kubectl apply -f rolebinding.yml
+#
+# Verify the binding is working:
+#   kubectl auth can-i get pods -n workloads \
+#     --as=system:serviceaccount:workloads:app-service-account
+#   # Expected: yes
+#
+#   kubectl auth can-i get secrets/app-secret -n workloads \
+#     --as=system:serviceaccount:workloads:app-service-account
+#   # Expected: yes
+#
+#   kubectl auth can-i get secrets/other-secret -n workloads \
+#     --as=system:serviceaccount:workloads:app-service-account
+#   # Expected: no  (resourceNames restriction in the Role)
+#
+#   kubectl auth can-i list nodes \
+#     --as=system:serviceaccount:workloads:app-service-account
+#   # Expected: no  (nodes are cluster-scoped, not in this Role)
+# ==============================================================================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: app-rolebinding
+  namespace: workloads
+  labels:
+    app.kubernetes.io/name: app-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: app-platform
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: "1.0.0"
+    environment: production
+  annotations:
+    kubernetes.io/description: >
+      RoleBinding granting app-service-account the permissions defined in app-role
+      within the workloads namespace. Grants read-only access to pods, a ConfigMap,
+      and the specific secret named app-secret.
+subjects:
+  # The ServiceAccount that receives the permissions.
+  # kind: ServiceAccount — requires namespace field (ServiceAccounts are namespaced)
+  # The namespace in subjects must match where the ServiceAccount exists,
+  # which may differ from the RoleBinding's namespace if needed.
+  - kind: ServiceAccount
+    name: app-service-account
+    namespace: workloads    # Namespace where this ServiceAccount lives
+
+roleRef:
+  # roleRef is immutable after creation. To change it, delete and recreate the binding.
+  kind: Role              # "Role" for namespaced roles; "ClusterRole" for cluster-wide roles
+  name: app-role          # Must exist in the same namespace as this RoleBinding
+  apiGroup: rbac.authorization.k8s.io

--- a/platform/security/rbac/serviceaccount.yml
+++ b/platform/security/rbac/serviceaccount.yml
@@ -1,0 +1,53 @@
+# ==============================================================================
+# SERVICE ACCOUNT — app-service-account
+# ==============================================================================
+# ServiceAccounts are the identity for in-cluster workloads. Every pod should
+# use a dedicated ServiceAccount (not the namespace "default" ServiceAccount)
+# so that RBAC permissions can be scoped precisely to what each application needs.
+#
+# automountServiceAccountToken: false
+#   By default, Kubernetes automatically mounts a ServiceAccount token into
+#   every pod that uses this ServiceAccount. This token gives the pod access
+#   to the Kubernetes API (limited by RBAC, but still an attack surface).
+#   Setting false here means pods must EXPLICITLY opt in by setting:
+#     spec.automountServiceAccountToken: true
+#   in their pod spec. This enforces the principle of least privilege — only
+#   pods that actually need API access get a token.
+#
+# Apply:
+#   kubectl apply -f serviceaccount.yml
+#
+# Verify:
+#   kubectl describe serviceaccount app-service-account -n workloads
+#   kubectl auth can-i --list --as=system:serviceaccount:workloads:app-service-account -n workloads
+# ==============================================================================
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: app-service-account
+  namespace: workloads
+  labels:
+    app.kubernetes.io/name: app-service-account
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/part-of: app-platform
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: "1.0.0"
+    environment: production
+  annotations:
+    kubernetes.io/description: >
+      ServiceAccount for the app workload in the workloads namespace.
+      Granted read access to its own pods, a named ConfigMap, and a specific
+      named Secret (app-secret) via the app-role RoleBinding. This is the
+      identity used by the application to query the Kubernetes API at runtime.
+    # Document the RBAC permissions this ServiceAccount has — makes auditing easier
+    rbac.example.com/permissions: >
+      pods: get, list, watch (namespace-scoped via app-role);
+      configmaps: get (namespace-scoped via app-role);
+      secrets: get — limited to app-secret only (namespace-scoped via app-role)
+
+# Opt-out of automatic token mounting.
+# Pods using this ServiceAccount must explicitly set:
+#   spec.automountServiceAccountToken: true
+# to receive an API token. This prevents unintended API access from pods that
+# don't actually need to query the Kubernetes API.
+automountServiceAccountToken: false


### PR DESCRIPTION
## Summary
- Add `serviceaccount.yml` — SA with `automountServiceAccountToken: false` (security default), `imagePullSecrets` reference
- Add `namespace-role.yml` — least-privilege Role: `get, list, watch` on pods and logs; `get, list` on configmaps; no secrets access
- Add `rolebinding.yml` — binds namespace Role to the ServiceAccount; namespace-scoped
- Add `cluster-role.yml` — ClusterRole for node metrics read access; `resourceNames` scoped secret access to prevent broad secret reads
- Add `cluster-rolebinding.yml` — binds ClusterRole to monitoring ServiceAccount
- Add `README.md` — Role vs ClusterRole, `kubectl auth can-i` verification commands, TokenRequest API for short-lived tokens

## Issues referenced
Closes #37, #38, #39, #94

## Test plan
- [ ] `kubectl auth can-i get pods --as system:serviceaccount:default:app-sa` returns `yes`
- [ ] `kubectl auth can-i get secrets --as system:serviceaccount:default:app-sa` returns `no`
- [ ] ClusterRole binding enables node read without namespace restriction