### PR TITLE
feat(security): External Secrets Operator — AWS Secrets Manager integration

### DIFF
--- a/platform/security/eso/README.md
+++ b/platform/security/eso/README.md
@@ -1,0 +1,164 @@
+# External Secrets Operator (ESO)
+
+External Secrets Operator is the **2025 production standard** for secrets management in Kubernetes. It syncs secrets from external stores (AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, HashiCorp Vault) into native Kubernetes Secrets automatically.
+
+## Why ESO Over SealedSecrets
+
+| Dimension | SealedSecrets | External Secrets Operator |
+|---|---|---|
+| Production rating | Workable | Production standard |
+| Secret storage | Encrypted in Git | Cloud provider (AWS SM, GCP SM, Azure KV) |
+| Automatic rotation | No | Yes (configurable refresh interval) |
+| Multi-cluster | Complex (one key pair per cluster) | Native (one cloud secret, many clusters) |
+| Key management risk | Critical — losing private key = locked out | Delegated to cloud provider |
+| Audit logging | K8s audit logs only | Cloud provider logs (CloudTrail, etc.) |
+| Dynamic credentials | No | No (use Vault for this) |
+| Operational complexity | Low | Medium |
+| Best for | GitOps-first small teams | Cloud-native production teams |
+
+**Recommendation:** Use ESO for production. Use SealedSecrets for local development or small GitOps-only teams. Use Vault only if you need dynamic credentials or a hard compliance audit requirement.
+
+## Installation
+
+```bash
+# Add the ESO Helm repository
+helm repo add external-secrets https://charts.external-secrets.io
+helm repo update
+
+# Install ESO (cluster-wide)
+helm upgrade --install external-secrets external-secrets/external-secrets \
+  --namespace external-secrets \
+  --create-namespace \
+  --set installCRDs=true
+
+# Verify installation
+kubectl get pods -n external-secrets
+kubectl get crd | grep external-secrets
+```
+
+## Concepts
+
+```
+External Store (AWS SM / GCP SM / Azure KV / Vault)
+         │
+         │ ESO polls on refreshInterval
+         ▼
+   ExternalSecret (CR) ──→ reads from SecretStore/ClusterSecretStore
+         │
+         │ ESO creates/updates
+         ▼
+   Kubernetes Secret (native, auto-populated)
+         │
+         │ mounted by pod
+         ▼
+   Container environment / volume
+```
+
+### SecretStore vs ClusterSecretStore
+
+- **SecretStore**: Namespaced. Can only be referenced by ExternalSecrets in the same namespace.
+- **ClusterSecretStore**: Cluster-scoped. Can be referenced by ExternalSecrets in any namespace.
+
+Use `ClusterSecretStore` for platform-wide secrets (certificates, shared credentials).
+Use `SecretStore` for application-specific secrets with namespace isolation.
+
+## AWS Secrets Manager Setup
+
+### Step 1: Create IAM role with IRSA (IAM Roles for Service Accounts)
+
+```bash
+# Associate OIDC provider with the cluster (run once per cluster)
+eksctl utils associate-iam-oidc-provider --region us-east-1 --cluster my-cluster --approve
+
+# Create IAM policy for Secrets Manager access
+aws iam create-policy \
+  --policy-name ESO-SecretsManager-Policy \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret"
+      ],
+      "Resource": "arn:aws:secretsmanager:us-east-1:*:secret:production/*"
+    }]
+  }'
+
+# Create ServiceAccount with IRSA annotation
+eksctl create iamserviceaccount \
+  --name external-secrets-sa \
+  --namespace external-secrets \
+  --cluster my-cluster \
+  --attach-policy-arn arn:aws:iam::ACCOUNT_ID:policy/ESO-SecretsManager-Policy \
+  --approve
+```
+
+### Step 2: Create a ClusterSecretStore
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: aws-secrets-manager
+  annotations:
+    kubernetes.io/description: "Cluster-wide SecretStore backed by AWS Secrets Manager"
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: us-east-1
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: external-secrets-sa
+            namespace: external-secrets
+```
+
+### Step 3: Create an ExternalSecret
+
+See `external-secret-example.yaml` for a complete example.
+
+## Usage Pattern
+
+```bash
+# Create a secret in AWS Secrets Manager
+aws secretsmanager create-secret \
+  --name production/notes-app \
+  --secret-string '{"db_password":"supersecret","api_key":"xyz123"}'
+
+# Apply the ExternalSecret
+kubectl apply -f platform/security/eso/external-secret-example.yaml
+
+# Verify the K8s Secret was created
+kubectl get secret notes-app-secret -n notes-app -o jsonpath='{.data}' | \
+  python3 -c "import sys,json,base64; d=json.load(sys.stdin); [print(k,'=',base64.b64decode(v).decode()) for k,v in d.items()]"
+```
+
+## Automatic Rotation
+
+ESO polls the external store on the `refreshInterval` schedule. When the secret changes in AWS/GCP/Azure:
+
+1. ESO detects the new version on the next poll
+2. ESO updates the Kubernetes Secret
+3. **Important**: pods do NOT automatically restart when the Secret changes
+
+### Force pod restart on secret rotation
+
+```bash
+# Option 1: Annotate the Deployment with the secret version (triggers rollout)
+kubectl annotate deployment notes-app \
+  secrets.kyverno.io/secret-version="$(date +%s)" --overwrite
+
+# Option 2: Use Reloader (Stakater Reloader watches Secrets and auto-rolls pods)
+helm install reloader stakater/reloader --namespace kube-system
+# Then annotate the Deployment:
+# annotations:
+#   reloader.stakater.com/auto: "true"
+```
+
+## References
+
+- [ESO Documentation](https://external-secrets.io/latest/)
+- [ESO GitHub](https://github.com/external-secrets/external-secrets)
+- [Supported Providers](https://external-secrets.io/latest/provider/aws-secrets-manager/)

--- a/platform/security/eso/clustersecretstore-aws.yaml
+++ b/platform/security/eso/clustersecretstore-aws.yaml
@@ -1,0 +1,36 @@
+---
+# ClusterSecretStore: AWS Secrets Manager
+#
+# Prerequisites:
+#   - ESO installed (see README.md)
+#   - IRSA configured for external-secrets-sa ServiceAccount
+#   - IAM policy granting secretsmanager:GetSecretValue on target secrets
+#
+# This is a ClusterSecretStore (not namespaced) so it can be referenced
+# by ExternalSecrets in any namespace.
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: aws-secrets-manager
+  labels:
+    app.kubernetes.io/name: aws-secrets-manager
+    app.kubernetes.io/component: secret-store
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: >
+      Cluster-wide SecretStore backed by AWS Secrets Manager.
+      Uses IRSA (IAM Roles for Service Accounts) for credential-free authentication.
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      # Replace with your AWS region
+      region: us-east-1
+      auth:
+        # IRSA: the ESO controller uses the ServiceAccount's IAM role
+        # This avoids storing AWS credentials as Kubernetes Secrets
+        jwt:
+          serviceAccountRef:
+            name: external-secrets-sa
+            namespace: external-secrets

--- a/platform/security/eso/external-secret-example.yaml
+++ b/platform/security/eso/external-secret-example.yaml
@@ -1,0 +1,92 @@
+---
+# ExternalSecret: Sync a secret from AWS Secrets Manager
+#
+# This creates a Kubernetes Secret named 'notes-app-secret' in the 'notes-app'
+# namespace by fetching values from AWS Secrets Manager path 'production/notes-app'.
+#
+# The ExternalSecret (this file) is safe to commit to Git — it contains no secrets.
+# The actual secret values live in AWS Secrets Manager.
+#
+# ESO polls every refreshInterval and updates the K8s Secret automatically
+# when the external secret changes.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: notes-app-external-secret
+  namespace: notes-app
+  labels:
+    app.kubernetes.io/name: notes-app
+    app.kubernetes.io/instance: notes-app
+    app.kubernetes.io/component: secret-sync
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: >
+      Syncs notes-app secrets from AWS Secrets Manager into a Kubernetes Secret.
+      The resulting Secret is mounted as a volume in the Deployment.
+spec:
+  # How often ESO checks for updates in the external store
+  # Set to 1h for stable secrets; use shorter intervals for frequently rotated credentials
+  refreshInterval: 1h
+
+  # Reference to the ClusterSecretStore that defines the AWS connection
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+
+  target:
+    # Name of the Kubernetes Secret that ESO will create/update
+    name: notes-app-secret
+    # creationPolicy: Owner means ESO owns this Secret
+    # It will be deleted when this ExternalSecret is deleted
+    creationPolicy: Owner
+    # deletionPolicy: Retain means the K8s Secret survives ExternalSecret deletion
+    # Change to Delete if you want cleanup on ExternalSecret removal
+    deletionPolicy: Retain
+    template:
+      type: Opaque
+      engineVersion: v2
+
+  # Map each AWS Secrets Manager key to a Kubernetes Secret key
+  data:
+    - secretKey: DB_PASSWORD       # Key in the Kubernetes Secret
+      remoteRef:
+        key: production/notes-app  # Path in AWS Secrets Manager
+        property: db_password      # JSON key within the secret value
+
+    - secretKey: API_KEY
+      remoteRef:
+        key: production/notes-app
+        property: api_key
+
+    - secretKey: SECRET_KEY
+      remoteRef:
+        key: production/notes-app
+        property: django_secret_key
+
+---
+# How to consume this secret in a Pod (volume mount — preferred over env vars)
+#
+# Mount as a volume so secrets are not exposed via /proc/<pid>/environ:
+#
+# spec:
+#   volumes:
+#     - name: app-secrets
+#       secret:
+#         secretName: notes-app-secret
+#         defaultMode: 0440
+#   containers:
+#     - name: notes-app
+#       volumeMounts:
+#         - name: app-secrets
+#           mountPath: /etc/secrets
+#           readOnly: true
+#
+# Then read in Python:
+#   with open('/etc/secrets/DB_PASSWORD') as f:
+#       password = f.read().strip()
+#
+# Alternatively, as environment variables (less secure but simpler):
+#   envFrom:
+#     - secretRef:
+#         name: notes-app-secret


### PR DESCRIPTION
## Summary
- Add `clustersecretstore-aws.yaml` — ClusterSecretStore using IRSA JWT authentication; cluster-wide secret store requiring no per-namespace credentials
- Add `external-secret-example.yaml` — ExternalSecret pulling `DB_PASSWORD`, `API_KEY`, `SECRET_KEY` from `production/notes-app` path in AWS Secrets Manager; `refreshInterval: 1h`, `creationPolicy: Owner`, `deletionPolicy: Retain`; comment shows volume-mount consumption pattern (preferred over env vars)
- Add `README.md` — ESO install via Helm, IRSA IAM policy, automatic rotation via `refreshInterval`, Reloader integration for pod restart on secret change, ESO vs SealedSecrets decision matrix

## Issues referenced
Closes #42, #43, relates to #65

## Test plan
- [ ] `make install-sealed-secrets` installs ESO CRDs
- [ ] ExternalSecret `READY: True` status after ClusterSecretStore is configured
- [ ] K8s Secret appears in namespace after ExternalSecret sync