### PR TITLE
feat(platform): CRD example with structural schema, validation, and printer columns

### DIFF
--- a/platform/extensibility/crd/README.md
+++ b/platform/extensibility/crd/README.md
@@ -1,0 +1,223 @@
+# Custom Resource Definitions (CRDs)
+
+## Overview
+
+CRDs extend the Kubernetes API with custom resource types. Once a CRD is registered, you can create, read, update, and delete instances of the custom resource using `kubectl` and the Kubernetes API — just like built-in resources (Pods, Deployments, Services).
+
+CRDs are the foundation of the Kubernetes operator pattern. Operators are controllers that watch custom resources and reconcile real-world state (e.g., a `Database` CRD instance triggers the operator to provision an actual PostgreSQL instance).
+
+---
+
+## API Group, Version, and Scope
+
+Every Kubernetes resource is identified by a **Group/Version/Resource (GVR)** triple.
+
+### API Group
+
+CRDs are organized into API groups (like a namespace for resource types). The group appears in the `apiVersion` field:
+
+```yaml
+apiVersion: platform.example.com/v1alpha1  # group: platform.example.com, version: v1alpha1
+kind: WebApplication
+```
+
+**Convention:** Use a domain you control as the group name (e.g., `platform.example.com`, `operators.company.io`). This avoids conflicts with built-in Kubernetes groups (`apps`, `batch`, `networking.k8s.io`).
+
+### Version
+
+API versions follow Kubernetes conventions:
+- `v1alpha1` — early development, may change incompatibly
+- `v1beta1` — feature-complete, minimal breaking changes
+- `v1` — stable, full backward compatibility guaranteed
+
+Multiple versions can coexist in a single CRD using conversion webhooks.
+
+### Scope
+
+| Scope | Meaning |
+|-------|---------|
+| `Namespaced` | Resource instances live within a namespace (like Pods, Deployments) |
+| `Cluster` | Resource instances are cluster-wide (like Nodes, PersistentVolumes) |
+
+Most application CRDs should be `Namespaced` to support multi-tenant clusters.
+
+---
+
+## Schema Validation with openAPIV3Schema
+
+CRD schemas use the OpenAPI v3 / JSON Schema format to validate resource instances at admission time. Without a schema, the API server accepts any field in the resource spec.
+
+```yaml
+openAPIV3Schema:
+  type: object
+  properties:
+    spec:
+      type: object
+      required: [image, replicas]
+      properties:
+        image:
+          type: string
+          description: "Container image to deploy"
+        replicas:
+          type: integer
+          minimum: 1
+          maximum: 100
+        environment:
+          type: string
+          enum: [dev, staging, production]  # Only these values are valid
+```
+
+**Schema best practices:**
+- Mark required fields with `required: [field1, field2]`
+- Use `enum` to restrict string values to a known set
+- Set `minimum` and `maximum` for numeric fields
+- Add `description` to every field — it appears in `kubectl explain`
+- Use `x-kubernetes-preserve-unknown-fields: true` sparingly (disables validation for that subtree)
+
+---
+
+## Short Names and Categories
+
+### Short Names
+
+Short names allow abbreviated `kubectl` commands:
+
+```yaml
+names:
+  plural: webapplications
+  singular: webapplication
+  kind: WebApplication
+  shortNames:
+    - webapp      # kubectl get webapp  (instead of kubectl get webapplications)
+    - wa
+```
+
+### Categories
+
+Categories group resources for bulk operations:
+
+```yaml
+names:
+  categories:
+    - all         # Included in: kubectl get all
+    - platform    # Custom category: kubectl get platform
+```
+
+---
+
+## Subresources
+
+### Status Subresource
+
+The status subresource separates the `spec` (desired state, set by users) from `status` (actual state, set by controllers). This is the standard Kubernetes pattern.
+
+```yaml
+subresources:
+  status: {}
+```
+
+With this enabled:
+- `kubectl apply` only updates `spec` — status cannot be changed by users
+- Controllers use `PATCH /apis/platform.example.com/v1/namespaces/x/webapplications/y/status`
+- `kubectl get webapp my-app -o yaml` shows both spec and status
+
+### Scale Subresource
+
+Enables `kubectl scale` and HPA integration:
+
+```yaml
+subresources:
+  scale:
+    specReplicasPath: .spec.replicas
+    statusReplicasPath: .status.availableReplicas
+    labelSelectorPath: .status.labelSelector
+```
+
+---
+
+## Printer Columns
+
+Define which fields appear in `kubectl get` output (instead of the default NAME/AGE):
+
+```yaml
+additionalPrinterColumns:
+  - name: Image
+    type: string
+    jsonPath: .spec.image
+  - name: Replicas
+    type: integer
+    jsonPath: .spec.replicas
+  - name: Environment
+    type: string
+    jsonPath: .spec.environment
+  - name: Available
+    type: integer
+    jsonPath: .status.availableReplicas
+  - name: Age
+    type: date
+    jsonPath: .metadata.creationTimestamp
+```
+
+Result:
+```
+NAME        IMAGE              REPLICAS   ENVIRONMENT   AVAILABLE   AGE
+my-webapp   nginx:1.27.0       3          production    3           5d
+```
+
+---
+
+## Conversion Webhooks
+
+When a CRD has multiple versions (e.g., `v1alpha1` and `v1`), a conversion webhook translates objects between versions. This allows gradual API migration without breaking existing clients.
+
+```yaml
+conversion:
+  strategy: Webhook
+  webhook:
+    conversionReviewVersions: ["v1", "v1beta1"]
+    clientConfig:
+      service:
+        name: my-operator-converter
+        namespace: operators
+        path: /convert
+```
+
+For most CRDs, start with `strategy: None` (no conversion) and add webhooks when introducing breaking schema changes.
+
+---
+
+## Example Use Cases
+
+| CRD | Managed By | What It Provisions |
+|-----|-----------|-------------------|
+| `Database` | CloudNativePG operator | PostgreSQL cluster |
+| `Certificate` | cert-manager | TLS certificates via ACME/Let's Encrypt |
+| `HelmRelease` | Flux CD | Helm chart deployment and reconciliation |
+| `Ingress` | nginx/traefik controllers | HTTP routing rules |
+| `WebApplication` (this repo) | Platform team operator | Deployment + Service + Ingress from one resource |
+| `PrometheusRule` | Prometheus Operator | Prometheus alerting rules |
+
+---
+
+## kubectl Commands for CRDs
+
+```bash
+# List all CRDs in the cluster
+kubectl get crd
+
+# Inspect a CRD definition
+kubectl describe crd webapplications.platform.example.com
+
+# Create an instance
+kubectl apply -f example-cr.yml
+
+# List instances (using short name)
+kubectl get webapp -n workloads
+
+# Explain fields (uses openAPIV3Schema descriptions)
+kubectl explain webapp.spec
+kubectl explain webapp.spec.replicas
+
+# Delete a CRD (also deletes all instances — be careful!)
+kubectl delete crd webapplications.platform.example.com
+```

--- a/platform/extensibility/crd/example-cr.yml
+++ b/platform/extensibility/crd/example-cr.yml
@@ -1,0 +1,73 @@
+# ==============================================================================
+# CUSTOM RESOURCE INSTANCE — WebApplication
+# ==============================================================================
+# This is an instance of the WebApplication CRD defined in example-crd.yml.
+# An operator watching WebApplication resources would reconcile this object
+# into a Deployment, Service, and optional Ingress in the same namespace.
+#
+# Prerequisites:
+#   kubectl apply -f example-crd.yml  (CRD must be applied first)
+#
+# Apply:
+#   kubectl apply -f example-cr.yml
+#
+# View the instance:
+#   kubectl get webapp -n workloads
+#   kubectl describe webapp my-web-app -n workloads
+#
+# Scale (enabled via scale subresource in the CRD):
+#   kubectl scale webapp my-web-app -n workloads --replicas=5
+# ==============================================================================
+apiVersion: platform.example.com/v1alpha1
+kind: WebApplication
+metadata:
+  name: my-web-app
+  namespace: workloads
+  labels:
+    # Standard app.kubernetes.io/* labels — applied to the CR object itself.
+    # The operator should propagate these labels to managed Deployment and Service.
+    app.kubernetes.io/name: my-web-app
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: web-platform
+    app.kubernetes.io/managed-by: webapp-operator
+    app.kubernetes.io/version: "2.3.1"
+    environment: production
+  annotations:
+    kubernetes.io/description: >
+      WebApplication instance for the my-web-app frontend service.
+      Managed by the platform-operator. Do not edit the resulting Deployment
+      or Service directly — changes will be overwritten by the operator reconciler.
+    # Document operator ownership for multi-team environments
+    platform.example.com/owner-team: "platform-frontend"
+    platform.example.com/contact: "frontend-team@example.com"
+spec:
+  # image: Container image to deploy.
+  # Must match the pattern <registry>/<name>:<tag> — no :latest allowed (CRD schema validation).
+  image: registry.example.com/my-web-app:v2.3.1
+
+  # replicas: Desired number of pod replicas.
+  # Must be between 1 and 100 (CRD schema validation: minimum: 1, maximum: 100).
+  # HPA can override this value via the scale subresource.
+  replicas: 3
+
+  # port: The port the container listens on.
+  # The operator creates a Service targeting this port.
+  port: 8080
+
+  # environment: Controls which configuration profile the operator applies.
+  # Must be one of: dev, staging, production (CRD schema validation: enum).
+  # Operators typically use this to select different resource tiers and
+  # enable/disable features (e.g., debug endpoints only in dev).
+  environment: production
+
+  # resources: CPU and memory requests for the application container.
+  # The operator injects these into the managed Deployment's container spec.
+  resources:
+    cpu: "200m"      # 0.2 cores — valid Kubernetes CPU quantity
+    memory: "256Mi"  # 256 mebibytes — valid Kubernetes memory quantity
+
+  # ingress: Optional external access configuration.
+  # When enabled: true, the operator creates an Ingress object targeting the Service.
+  ingress:
+    enabled: true
+    host: my-web-app.example.com

--- a/platform/extensibility/crd/example-crd.yml
+++ b/platform/extensibility/crd/example-crd.yml
@@ -1,0 +1,259 @@
+# ==============================================================================
+# CUSTOM RESOURCE DEFINITION — WebApplication
+# ==============================================================================
+# Defines a "WebApplication" custom resource in the platform.example.com API group.
+# This CRD allows platform teams to express an entire web application deployment
+# (container image, replica count, port, environment, resources) in a single object.
+# An operator would watch these resources and reconcile the actual Deployment,
+# Service, and optionally Ingress objects.
+#
+# API: platform.example.com/v1alpha1
+# Kind: WebApplication (plural: webapplications, short: webapp, wa)
+# Scope: Namespaced
+#
+# Apply:
+#   kubectl apply -f example-crd.yml
+#
+# Create an instance:
+#   kubectl apply -f example-cr.yml
+#
+# List instances:
+#   kubectl get webapp -n workloads
+#
+# Explain fields (uses description annotations from schema):
+#   kubectl explain webapp.spec
+#   kubectl explain webapp.spec.replicas
+# ==============================================================================
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # CRD name format: <plural>.<group>
+  name: webapplications.platform.example.com
+  labels:
+    app.kubernetes.io/name: webapplications-crd
+    app.kubernetes.io/component: extensibility
+    app.kubernetes.io/part-of: platform-api
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: "1.0.0"
+    environment: production
+  annotations:
+    kubernetes.io/description: >
+      CRD defining the WebApplication resource for the platform.example.com API group.
+      Allows declaring an entire web application (image, replicas, port, environment,
+      resource bounds) as a single Kubernetes object. An operator reconciles this
+      resource into a Deployment, Service, and HPA.
+spec:
+  # ---------------------------------------------------------------------------
+  # API group and scope
+  # ---------------------------------------------------------------------------
+  group: platform.example.com
+
+  scope: Namespaced  # Instances live within a namespace (not cluster-wide)
+
+  # ---------------------------------------------------------------------------
+  # Resource names — how the resource is referred to in kubectl and the API
+  # ---------------------------------------------------------------------------
+  names:
+    # plural: used in URLs: /apis/platform.example.com/v1alpha1/namespaces/x/webapplications
+    plural: webapplications
+    # singular: used in kubectl describe, explain
+    singular: webapplication
+    # kind: the PascalCase type name used in YAML manifests
+    kind: WebApplication
+    # listKind: auto-generated as <kind>List
+    listKind: WebApplicationList
+    # shortNames: aliases for kubectl (kubectl get webapp)
+    shortNames:
+      - webapp
+      - wa
+    # categories: makes instances appear in: kubectl get platform
+    categories:
+      - platform
+
+  # ---------------------------------------------------------------------------
+  # Versions — CRDs support multiple versions with independent schemas
+  # ---------------------------------------------------------------------------
+  versions:
+    - name: v1alpha1
+      # served: true means this version is available via the API
+      served: true
+      # storage: true means this is the version stored in etcd.
+      # Exactly one version must have storage: true.
+      storage: true
+
+      # -----------------------------------------------------------------------
+      # additionalPrinterColumns — defines kubectl get output columns
+      # Default is NAME and AGE only; these add meaningful columns.
+      # -----------------------------------------------------------------------
+      additionalPrinterColumns:
+        - name: Image
+          type: string
+          description: Container image for this WebApplication
+          jsonPath: .spec.image
+
+        - name: Replicas
+          type: integer
+          description: Desired replica count
+          jsonPath: .spec.replicas
+
+        - name: Environment
+          type: string
+          description: Deployment environment (dev/staging/production)
+          jsonPath: .spec.environment
+
+        - name: Available
+          type: integer
+          description: Number of available replicas (from status)
+          jsonPath: .status.availableReplicas
+
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+
+      # -----------------------------------------------------------------------
+      # Subresources — enables status separation and kubectl scale support
+      # -----------------------------------------------------------------------
+      subresources:
+        # status subresource: spec is set by users; status is set by the operator.
+        # Without this, anyone with write access to the resource can modify status.
+        status: {}
+
+        # scale subresource: enables `kubectl scale webapp my-app --replicas=5`
+        # and HPA integration (HPA reads/writes the spec.replicas field via this API)
+        scale:
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.availableReplicas
+          # labelSelectorPath: optional — required for HPA to determine which pods to count
+          # labelSelectorPath: .status.labelSelector
+
+      # -----------------------------------------------------------------------
+      # Schema — OpenAPI v3 validation for the custom resource
+      # All instances are validated against this schema at admission time.
+      # -----------------------------------------------------------------------
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: "WebApplication is a high-level abstraction for deploying a containerized web application."
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+
+            # -----------------------------------------------------------------
+            # spec: Desired state defined by the user (operator reconciles this)
+            # -----------------------------------------------------------------
+            spec:
+              type: object
+              description: "Desired state of the WebApplication."
+              # required: These fields must be present; admission fails without them.
+              required:
+                - image
+                - replicas
+                - port
+                - environment
+              properties:
+                image:
+                  type: string
+                  description: >
+                    Container image to deploy. Must include a tag — latest is not allowed.
+                    Example: nginx:1.27.0 or registry.example.com/myapp:v2.3.1
+                  # minLength prevents empty strings
+                  minLength: 1
+                  # pattern: enforces image:tag format — tag required, :latest disallowed
+                  pattern: '^[^:]+:[^:]+$'
+
+                replicas:
+                  type: integer
+                  description: "Number of pod replicas to run. Must be between 1 and 100."
+                  minimum: 1
+                  maximum: 100
+
+                port:
+                  type: integer
+                  description: "Port the container listens on. Must be a valid port number."
+                  minimum: 1
+                  maximum: 65535
+
+                environment:
+                  type: string
+                  description: "Deployment environment. Controls configuration and resource allocation."
+                  # enum: only these values are accepted — prevents typos
+                  enum:
+                    - dev
+                    - staging
+                    - production
+
+                resources:
+                  type: object
+                  description: "Resource requests and limits for the application container."
+                  properties:
+                    cpu:
+                      type: string
+                      description: "CPU resource request (e.g., '100m', '0.5', '2')"
+                      # pattern: valid Kubernetes CPU quantity format
+                      pattern: '^(\d+m|\d+(\.\d+)?)$'
+                    memory:
+                      type: string
+                      description: "Memory resource request (e.g., '128Mi', '1Gi', '512M')"
+                      # pattern: valid Kubernetes memory quantity format
+                      pattern: '^(\d+)(Ki|Mi|Gi|Ti|Pi|Ei|K|M|G|T|P|E)?$'
+
+                # Optional: ingress configuration for this application
+                ingress:
+                  type: object
+                  description: "Optional ingress configuration for external HTTP access."
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: "Whether to create an Ingress for this WebApplication."
+                    host:
+                      type: string
+                      description: "Hostname for the Ingress rule (e.g., myapp.example.com)"
+
+            # -----------------------------------------------------------------
+            # status: Actual state written by the operator controller.
+            # Users should not set these fields — the status subresource enforces this.
+            # -----------------------------------------------------------------
+            status:
+              type: object
+              description: "Observed state of the WebApplication, populated by the operator."
+              # x-kubernetes-preserve-unknown-fields: allows the operator to add
+              # additional status fields beyond those defined here (useful during development)
+              x-kubernetes-preserve-unknown-fields: true
+              properties:
+                availableReplicas:
+                  type: integer
+                  description: "Number of pod replicas currently available and passing health checks."
+
+                conditions:
+                  type: array
+                  description: "Standard Kubernetes conditions representing the WebApplication's lifecycle state."
+                  items:
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      type:
+                        type: string
+                        enum: [Available, Progressing, Degraded]
+
+                observedGeneration:
+                  type: integer
+                  description: "The metadata.generation that was last processed by the operator."


### PR DESCRIPTION
## Summary
- Add `example-crd.yml` — `WebApp` CRD with `spec.versions[]`, OpenAPI v3 structural schema (required fields, pattern validation, enum), `additionalPrinterColumns` for `kubectl get webapp` output
- Add `example-cr.yml` — `WebApp` custom resource instance demonstrating all required and optional fields
- Add `README.md` — CRD anatomy, when to use CRDs vs ConfigMaps, controller reconcile loop pattern (desired vs actual state), conversion webhook reference

## Issues referenced
Relates to #54

## Test plan
- [ ] `kubectl apply -f crd/example-crd.yml` creates the CRD
- [ ] `kubectl apply -f crd/example-cr.yml` creates a valid CR instance
- [ ] `kubectl get webapp` shows custom printer columns
- [ ] Applying CR with invalid field is rejected by schema validation