### PR TITLE
feat(helm): Apache chart with PDB, HPA, values schema validation, and helm test

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,359 @@
+# Helm — Kubernetes Package Manager
+
+## What Is Helm?
+
+Helm is the package manager for Kubernetes. It lets you define, install, and upgrade even
+the most complex Kubernetes applications. Helm uses a packaging format called **charts** — a
+collection of files that describe a related set of Kubernetes resources.
+
+Think of Helm as `apt` / `brew` for Kubernetes:
+- A **chart** is a Helm package (like a `.deb` or formula)
+- A **repository** is where charts are stored and shared
+- A **release** is an instance of a chart running in a cluster
+
+---
+
+## Chart Structure
+
+```
+my-chart/
+├── Chart.yaml            # Chart metadata (name, version, appVersion, dependencies)
+├── .helmignore           # Files to exclude when packaging
+├── values.yaml           # Default configuration values
+├── values.schema.json    # JSON Schema validation for values (optional but recommended)
+├── charts/               # Dependency charts (populated by `helm dependency update`)
+└── templates/
+    ├── _helpers.tpl      # Template helper functions (not rendered directly)
+    ├── deployment.yaml
+    ├── service.yaml
+    ├── serviceaccount.yaml
+    ├── hpa.yaml
+    ├── pdb.yaml
+    ├── ingress.yaml
+    ├── NOTES.txt         # Post-install instructions printed to stdout
+    └── tests/
+        └── test-connection.yaml   # Helm test pods
+```
+
+### Chart.yaml Fields
+
+| Field          | Description                                          |
+|----------------|------------------------------------------------------|
+| `apiVersion`   | `v2` (Helm 3 only) or `v1` (Helm 2 compatible)       |
+| `name`         | Chart name — must match the directory name           |
+| `description`  | Human-readable description                           |
+| `type`         | `application` (deployable) or `library` (helpers)   |
+| `version`      | SemVer of the chart itself                           |
+| `appVersion`   | Version of the application being packaged            |
+| `dependencies` | List of chart dependencies                           |
+
+---
+
+## Key Commands
+
+### Create a New Chart
+
+```bash
+helm create my-chart
+```
+
+Scaffolds the standard chart directory structure. Remove unused templates before committing.
+
+### Install a Chart
+
+```bash
+# Install with default values
+helm install my-release ./my-chart
+
+# Install into a specific namespace (create if missing)
+helm install my-release ./my-chart \
+  --namespace my-namespace \
+  --create-namespace
+
+# Install with custom values file
+helm install my-release ./my-chart \
+  -f values-prod.yaml
+
+# Dry-run (no cluster changes) — useful for CI validation
+helm install my-release ./my-chart \
+  --dry-run --debug
+```
+
+### Upgrade a Release
+
+```bash
+# Upgrade with new values
+helm upgrade my-release ./my-chart -f values-prod.yaml
+
+# Install if not present, upgrade if present (idempotent — preferred in CI/CD)
+helm upgrade --install my-release ./my-chart \
+  --namespace my-namespace \
+  --create-namespace \
+  -f values-prod.yaml \
+  --atomic \          # Roll back automatically on failure
+  --timeout 5m
+```
+
+### Rollback a Release
+
+```bash
+# List release history
+helm history my-release -n my-namespace
+
+# Roll back to previous revision
+helm rollback my-release -n my-namespace
+
+# Roll back to a specific revision
+helm rollback my-release 3 -n my-namespace
+```
+
+### Uninstall a Release
+
+```bash
+helm uninstall my-release -n my-namespace
+
+# Keep release history (allows rollback after uninstall)
+helm uninstall my-release -n my-namespace --keep-history
+```
+
+### Lint a Chart
+
+```bash
+# Lint with default values
+helm lint ./my-chart
+
+# Lint with production values (catches value-specific issues)
+helm lint ./my-chart -f values-prod.yaml
+```
+
+### Render Templates Without Installing
+
+```bash
+# Render all templates to stdout
+helm template my-release ./my-chart -f values-prod.yaml
+
+# Render only a specific template
+helm template my-release ./my-chart -s templates/deployment.yaml
+
+# Pipe to kubectl apply (GitOps-adjacent pattern)
+helm template my-release ./my-chart -f values-prod.yaml | kubectl apply -f -
+```
+
+### Package a Chart
+
+```bash
+# Package into a .tgz archive for distribution
+helm package ./my-chart
+
+# Package with a specific destination
+helm package ./my-chart -d ./dist/
+
+# Sign the package (requires GPG key)
+helm package ./my-chart --sign --key 'Platform Team' --keyring ~/.gnupg/pubring.kbx
+```
+
+### Repository Management
+
+```bash
+# Add a chart repository
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add stable https://charts.helm.sh/stable
+
+# Update repository cache
+helm repo update
+
+# Search for charts
+helm search repo nginx
+helm search hub wordpress   # Search Artifact Hub
+
+# Show chart values
+helm show values bitnami/nginx
+```
+
+### Inspect a Release
+
+```bash
+# List all releases in a namespace
+helm list -n my-namespace
+
+# List across all namespaces
+helm list -A
+
+# Show computed values of a running release
+helm get values my-release -n my-namespace
+
+# Show all manifests of a running release
+helm get manifest my-release -n my-namespace
+```
+
+---
+
+## Values Override Pattern
+
+Helm merges values files in order — later files win. Use this to layer environments:
+
+```
+values.yaml           # Shared defaults (committed)
+values-staging.yaml   # Staging overrides (committed)
+values-prod.yaml      # Production overrides (committed)
+values-local.yaml     # Developer overrides (gitignored)
+```
+
+### Installing with layered values
+
+```bash
+helm upgrade --install my-release ./my-chart \
+  -f values.yaml \
+  -f values-prod.yaml \
+  --set image.tag="${GIT_SHA}"    # Final override — use sparingly
+```
+
+### When to use `--set` vs `-f`
+
+| Use Case                        | Approach                   |
+|---------------------------------|----------------------------|
+| One-off values in CI            | `--set image.tag=abc123`   |
+| Environment config              | `-f values-prod.yaml`      |
+| Secrets (avoid in values files) | External secrets manager   |
+| Structured/complex values       | Always use `-f` (not --set)|
+
+---
+
+## Best Practices
+
+### 1. Always Quote Strings in Templates
+
+```yaml
+# Bad — numeric-looking string gets cast to int
+version: {{ .Values.app.version }}
+
+# Good
+version: {{ .Values.app.version | quote }}
+```
+
+### 2. Use `required` for Mandatory Values
+
+```yaml
+# Fails at render time with a clear error if not set
+image: {{ required "image.repository is required" .Values.image.repository }}
+```
+
+### 3. Pin Image Digests in Production
+
+```yaml
+# values-prod.yaml
+image:
+  repository: nginx
+  # Never use :latest in production — it's not reproducible
+  # Generate with: docker inspect --format='{{index .RepoDigests 0}}' nginx:1.27
+  digest: sha256:a484819eb60211f5299034ac80f6a681b06f89e65866ce91f356ed7c72af059c
+  tag: ""   # ignored when digest is set
+```
+
+Template logic to prefer digest over tag:
+
+```yaml
+image: "{{ .Values.image.repository }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ else }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ end }}"
+```
+
+### 4. Use `_helpers.tpl` for All Labels
+
+Centralise label generation in `_helpers.tpl`. Never hardcode labels in resource templates —
+this ensures the full `app.kubernetes.io/*` label set is applied consistently.
+
+### 5. Validate with JSON Schema
+
+Include a `values.schema.json` to catch configuration errors before deployment. Helm
+validates values against the schema during `install`, `upgrade`, `lint`, and `template`.
+
+### 6. Set `revisionHistoryLimit`
+
+```yaml
+# Keep only 5 ReplicaSets to avoid etcd bloat
+revisionHistoryLimit: 5
+```
+
+### 7. Use `--atomic` in CI/CD
+
+```bash
+helm upgrade --install my-release ./my-chart --atomic --timeout 5m
+```
+
+`--atomic` rolls back automatically if the release fails, leaving the cluster in a known
+good state. Without it, a failed upgrade leaves the release in a broken state.
+
+### 8. Never Store Secrets in values.yaml
+
+Use external secret management:
+- [External Secrets Operator](https://external-secrets.io/) + AWS Secrets Manager / Vault
+- [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets)
+- Helm + Vault Agent injection (via annotations)
+
+---
+
+## Charts in This Repository
+
+| Chart                        | Description                        | App Version |
+|------------------------------|------------------------------------|-------------|
+| [`helm/apache`](./apache/)   | Apache HTTP Server (production)    | 2.4         |
+| [`helm/node-app`](./node-app/) | Node.js application              | latest      |
+
+### Using the Apache Chart
+
+```bash
+# Install with defaults (development)
+helm upgrade --install apache ./helm/apache \
+  --namespace webapps \
+  --create-namespace
+
+# Install with production values
+helm upgrade --install apache ./helm/apache \
+  --namespace webapps \
+  --create-namespace \
+  -f helm/apache/values.yaml \
+  --set image.digest="sha256:<pinned-digest>" \
+  --atomic \
+  --timeout 5m
+
+# Lint before deploy
+helm lint ./helm/apache
+
+# Preview rendered templates
+helm template apache ./helm/apache | kubectl apply --dry-run=client -f -
+
+# Run Helm tests post-deploy
+helm test apache -n webapps
+```
+
+### Using the Node App Chart
+
+```bash
+helm upgrade --install node-app ./helm/node-app \
+  --namespace apps \
+  --create-namespace \
+  --atomic \
+  --timeout 5m
+
+# Run Helm tests
+helm test node-app -n apps
+```
+
+---
+
+## Installing Helm
+
+See [`get_helm.sh`](./get_helm.sh) for an automated installer, or:
+
+```bash
+# macOS
+brew install helm
+
+# Linux — official script
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+# Verify
+helm version
+```
+
+Helm 3 requires no server-side component (Tiller was removed). It stores release state as
+Secrets in the release namespace.

--- a/helm/apache/.helmignore
+++ b/helm/apache/.helmignore
@@ -1,0 +1,38 @@
+# Patterns to ignore when building packages.
+# Helm evaluates these patterns relative to the chart root.
+
+# Compiled binary archives
+*.tgz
+
+# Version control
+.git
+.gitignore
+.gitmodules
+.gitattributes
+
+# Helm artefacts (avoid packaging an already-packaged chart)
+.helmignore
+
+# macOS metadata
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# IDE / editor directories
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Testing and CI
+.circleci/
+.github/
+.travis.yml
+.gitlab-ci.yml
+
+# Documentation that should not be shipped in the chart archive
+docs/
+
+# Node.js (if tooling exists at chart root)
+node_modules/

--- a/helm/apache/Chart.yaml
+++ b/helm/apache/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: apache
+description: Apache HTTP Server Helm chart for Kubernetes — production-grade example
+type: application
+version: 0.2.0
+appVersion: "2.4"
+
+keywords:
+  - apache
+  - http
+  - web
+
+home: https://httpd.apache.org/
+sources:
+  - https://github.com/apache/httpd
+
+maintainers:
+  - name: kube-platform
+    email: platform@example.com
+
+annotations:
+  category: WebServer

--- a/helm/apache/templates/NOTES.txt
+++ b/helm/apache/templates/NOTES.txt
@@ -1,0 +1,83 @@
+============================================================
+  Apache Helm Chart — Deployment Complete
+  Release  : {{ .Release.Name }}
+  Namespace: {{ .Release.Namespace }}
+  Chart    : {{ .Chart.Name }}-{{ .Chart.Version }}
+  App      : Apache HTTP Server {{ .Chart.AppVersion }}
+============================================================
+
+1. Verify the deployment is running:
+
+   kubectl rollout status deployment/{{ include "apache.fullname" . }} \
+     -n {{ .Release.Namespace }}
+
+   kubectl get pods -l {{ include "apache.selectorLabels" . | replace ": " "=" | replace "\n" "," }} \
+     -n {{ .Release.Namespace }}
+
+2. Access the application:
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+
+{{- else if contains "NodePort" .Values.service.type }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "apache.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "http://${NODE_IP}:${NODE_PORT}"
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be provisioned.
+  Watch for the EXTERNAL-IP column to become available:
+
+  kubectl get service {{ include "apache.fullname" . }} \
+    -n {{ .Release.Namespace }} \
+    --watch
+
+  export SERVICE_IP=$(kubectl get service {{ include "apache.fullname" . }} \
+    -n {{ .Release.Namespace }} \
+    -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo "http://${SERVICE_IP}:{{ .Values.service.port }}"
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+  The service is only accessible within the cluster (ClusterIP).
+  Use port-forward for local development:
+
+  kubectl port-forward service/{{ include "apache.fullname" . }} \
+    8080:{{ .Values.service.port }} \
+    -n {{ .Release.Namespace }}
+
+  Then open: http://localhost:8080
+
+{{- end }}
+
+3. Run the Helm test to verify connectivity:
+
+   helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+4. View logs:
+
+   kubectl logs -l {{ include "apache.selectorLabels" . | replace ": " "=" | replace "\n" "," }} \
+     -n {{ .Release.Namespace }} \
+     --tail=100 -f
+
+5. Upgrade the release:
+
+   helm upgrade {{ .Release.Name }} ./helm/apache \
+     -n {{ .Release.Namespace }} \
+     -f values-prod.yaml \
+     --atomic \
+     --timeout 5m
+
+6. Roll back to the previous release:
+
+   helm rollback {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+7. Uninstall the release:
+
+   helm uninstall {{ .Release.Name }} -n {{ .Release.Namespace }}

--- a/helm/apache/templates/_helpers.tpl
+++ b/helm/apache/templates/_helpers.tpl
@@ -1,0 +1,150 @@
+{{/*
+_helpers.tpl — Apache Helm Chart Template Helpers
+==================================================
+Template functions defined here are available to all templates in this chart.
+Files whose names begin with an underscore are not rendered as Kubernetes
+manifests — they exist solely to define reusable helpers.
+
+Usage: {{ include "apache.fullname" . }}
+*/}}
+
+{{/*
+apache.name
+-----------
+Expand the name of the chart. If the user sets .Values.nameOverride, that takes
+precedence. The result is truncated to 63 characters because Kubernetes DNS label
+names have a 63-character maximum length.
+
+Example output: "apache"
+*/}}
+{{- define "apache.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+apache.fullname
+---------------
+Create a fully qualified app name by combining the Helm release name and the
+chart name. This avoids name collisions when multiple releases of the same chart
+are installed in the same namespace.
+
+If .Values.fullnameOverride is set, it is used verbatim (truncated to 63 chars).
+If the release name already contains the chart name, we don't duplicate it.
+
+Examples:
+  Release "my-release", chart "apache" → "my-release-apache"
+  Release "apache", chart "apache"     → "apache"             (no duplication)
+  fullnameOverride "my-app"            → "my-app"
+*/}}
+{{- define "apache.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+apache.chart
+------------
+Produces the "chart label" value in the format "chart-name-version".
+Used in the helm.sh/chart annotation to record which chart version created
+the resource — useful for auditing and debugging.
+
+Example output: "apache-0.2.0"
+*/}}
+{{- define "apache.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+apache.labels
+-------------
+Standard set of labels applied to ALL resources in this chart.
+These labels follow the app.kubernetes.io/* label convention:
+  https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+
+Labels here are IMMUTABLE on Deployments/StatefulSets (selector labels).
+Do NOT add user-supplied labels here — add them only to the pod template metadata.
+
+Fields:
+  app.kubernetes.io/name        — The name of the application (the chart name)
+  app.kubernetes.io/instance    — The Helm release name (unique per installation)
+  app.kubernetes.io/version     — The version of the application (appVersion)
+  app.kubernetes.io/component   — The role this resource plays (e.g., webserver)
+  app.kubernetes.io/part-of     — The higher-level application this belongs to
+  app.kubernetes.io/managed-by  — The tool managing this resource (Helm)
+  helm.sh/chart                 — Chart name + version for auditing
+*/}}
+{{- define "apache.labels" -}}
+helm.sh/chart: {{ include "apache.chart" . }}
+app.kubernetes.io/name: {{ include "apache.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/component: webserver
+app.kubernetes.io/part-of: {{ include "apache.name" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+apache.selectorLabels
+---------------------
+A MINIMAL subset of labels used as the Deployment selector and Pod template labels.
+These labels MUST be stable across upgrades — changing them requires deleting and
+re-creating the Deployment. Do NOT include version or chart labels here, as those
+change with every release and would break the selector immutability requirement.
+
+These same labels are used by:
+  - Deployment.spec.selector.matchLabels
+  - Deployment.spec.template.metadata.labels (must be a superset)
+  - Service.spec.selector
+  - PodDisruptionBudget.spec.selector
+  - HPA.spec.scaleTargetRef (via Deployment name)
+*/}}
+{{- define "apache.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "apache.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+apache.serviceAccountName
+--------------------------
+Determine the name of the ServiceAccount to use for the Deployment pods.
+
+Logic:
+  1. If serviceAccount.create is true and serviceAccount.name is set → use the provided name
+  2. If serviceAccount.create is true and name is empty → generate from apache.fullname
+  3. If serviceAccount.create is false and name is set → use the provided name (existing SA)
+  4. If serviceAccount.create is false and name is empty → use "default" (not recommended)
+*/}}
+{{- define "apache.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "apache.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+apache.image
+------------
+Construct the full image reference, preferring digest over tag for production
+reproducibility. When a digest is provided, the tag is ignored.
+
+Examples:
+  digest set:  "httpd@sha256:abc123..."
+  tag set:     "httpd:2.4"
+  neither:     "httpd:2.4"   (falls back to Chart.AppVersion)
+*/}}
+{{- define "apache.image" -}}
+{{- if .Values.image.digest -}}
+{{ .Values.image.repository }}@{{ .Values.image.digest }}
+{{- else -}}
+{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+{{- end -}}
+{{- end }}

--- a/helm/apache/templates/deployment.yaml
+++ b/helm/apache/templates/deployment.yaml
@@ -1,0 +1,157 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "apache.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "Apache HTTP Server deployment managed by Helm."
+spec:
+  # Number of pod replicas. Controlled by HPA when autoscaling.enabled=true.
+  # When HPA is enabled, this field is managed by the HPA controller and changes
+  # here will be overwritten. Use minReplicas/maxReplicas in the HPA instead.
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+
+  # Selector is IMMUTABLE after creation. Never change selectorLabels.
+  selector:
+    matchLabels:
+      {{- include "apache.selectorLabels" . | nindent 6 }}
+
+  # Rolling update strategy — controls how pods are replaced during updates.
+  strategy:
+    type: {{ .Values.strategy.type }}
+    {{- if eq .Values.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      # maxUnavailable: 0 = zero-downtime (no pods go down until new pod is Ready)
+      maxUnavailable: {{ .Values.strategy.rollingUpdate.maxUnavailable }}
+      # maxSurge: 1 = one extra pod is created above replicaCount during the update
+      maxSurge: {{ .Values.strategy.rollingUpdate.maxSurge }}
+    {{- end }}
+
+  # Number of old ReplicaSets to retain for rollback via `helm rollback` or
+  # `kubectl rollout undo`. Higher values use more etcd storage.
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+
+  # Pod must be Ready for this many seconds before it is considered Available.
+  # Prevents premature traffic during container startup transients.
+  minReadySeconds: {{ .Values.minReadySeconds }}
+
+  template:
+    metadata:
+      labels:
+        # Selector labels must be present on the pod template.
+        {{- include "apache.selectorLabels" . | nindent 8 }}
+        # Full label set (includes version, component, etc.) for observability.
+        {{- include "apache.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        # Trigger a rolling restart when the ConfigMap or Secret changes by
+        # embedding a checksum annotation. Without this, pods may run stale config.
+        # Example (add in a real chart with configmap):
+        # checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      # Use the dedicated ServiceAccount (not the namespace default).
+      serviceAccountName: {{ include "apache.serviceAccountName" . }}
+
+      # Do not auto-mount the ServiceAccount token unless the pod needs API access.
+      # This reduces the blast radius if the pod is compromised.
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+
+      # Image pull secrets for private registries.
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      # Pod-level security context — applies to all containers and init containers.
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+
+      # Time to wait after SIGTERM before forcibly killing (SIGKILL) the pod.
+      # Must be longer than your application's graceful drain time.
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+
+      containers:
+        - name: apache
+          image: {{ include "apache.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+
+          # Container-level security context — overrides pod-level where applicable.
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+
+          ports:
+            - name: http         # Named port — referenced by probes and Service
+              containerPort: 80
+              protocol: TCP
+
+          # Lifecycle hooks — run before the container stops.
+          # preStop: gives the container time to finish in-flight requests before
+          # SIGTERM is sent. The sleep ensures the Service endpoint is removed
+          # before the pod stops accepting connections (avoids 502 errors during
+          # rolling updates with slow load balancers).
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5 && httpd -k graceful-stop"]
+
+          # Startup probe — evaluated before liveness kicks in.
+          # The container has failureThreshold * periodSeconds seconds to start.
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+
+          # Liveness probe — kills and restarts the container if it fails.
+          # Must be a fast, local check — not an external dependency check.
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+
+          # Readiness probe — removes the pod from Service endpoints if it fails.
+          # Traffic is only sent to pods that pass this probe.
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+
+          # Resource requests and limits.
+          # Requests: used by the scheduler for bin-packing decisions.
+          # Limits: hard caps; exceeding memory limit triggers OOMKilled.
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+
+          # Volume mounts for this container.
+          # Required because readOnlyRootFilesystem: true prevents writes to the
+          # container filesystem; writable paths must be backed by explicit volumes.
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+      # Pod-level volumes available to all containers.
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      # Node selector — restrict to nodes with specific labels.
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      # Affinity rules — pod anti-affinity spreads replicas across nodes for HA.
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      # Tolerations — allow scheduling on tainted nodes.
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/apache/templates/hpa.yaml
+++ b/helm/apache/templates/hpa.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "apache.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "HPA for the Apache deployment. Scales on CPU and memory utilisation."
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "apache.fullname" . }}
+
+  # Minimum replicas — must be >= 2 when using a PodDisruptionBudget with minAvailable: 1.
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+
+  # Maximum replicas — set based on cluster capacity and cost budget.
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+
+  metrics:
+    # CPU utilisation — scale out when average CPU across all pods exceeds the target.
+    # Uses resource requests as the 100% baseline, so accurate requests are critical.
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+
+    # Memory utilisation — scale out when average memory across all pods exceeds the target.
+    # Note: memory-based scaling is less reactive than CPU because memory is not released
+    # immediately. Use this as a safety net alongside CPU scaling.
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+
+  behavior:
+    # Scale-up behavior — aggressive scaling to handle sudden traffic spikes.
+    scaleUp:
+      # Allow scale-up immediately when the threshold is crossed.
+      stabilizationWindowSeconds: 0
+      policies:
+        # Allow adding up to 4 pods per 60 seconds (fast scale-out).
+        - type: Pods
+          value: 4
+          periodSeconds: 60
+        # Alternative: allow doubling the pod count every 60 seconds.
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+      # selectPolicy: Max means the most aggressive of the above policies is used.
+      selectPolicy: Max
+
+    # Scale-down behavior — conservative scaling to avoid oscillation (flapping).
+    scaleDown:
+      # Wait for this many seconds of sustained low utilisation before scaling down.
+      # Prevents removing pods that are needed during brief traffic dips.
+      stabilizationWindowSeconds: {{ .Values.autoscaling.scaleDownStabilizationWindowSeconds }}
+      policies:
+        # Remove at most 1 pod every 60 seconds during scale-down.
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+      # selectPolicy: Min means the most conservative policy is used.
+      selectPolicy: Min
+{{- end }}

--- a/helm/apache/templates/ingress.yaml
+++ b/helm/apache/templates/ingress.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "apache.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "Ingress for the Apache HTTP Server."
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  # IngressClass selects which Ingress controller handles this resource.
+  # Run `kubectl get ingressclass` to list available classes in your cluster.
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+
+  # TLS configuration — one entry per certificate (can cover multiple hosts with SAN).
+  # Requires a TLS Secret with keys tls.crt and tls.key.
+  # Use cert-manager with a ClusterIssuer to automate certificate provisioning.
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "apache.fullname" $ }}
+                port:
+                  # Reference the service port by number for clarity.
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/apache/templates/pdb.yaml
+++ b/helm/apache/templates/pdb.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "apache.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >-
+      PodDisruptionBudget for the Apache deployment. Ensures at least
+      {{ .Values.podDisruptionBudget.minAvailable }} pod(s) remain available
+      during voluntary disruptions such as node drains or cluster upgrades.
+spec:
+  # minAvailable: the minimum number of pods that must remain available during
+  # a voluntary disruption. Accepts an integer or a percentage string (e.g., "50%").
+  #
+  # With replicaCount: 2 and minAvailable: 1:
+  #   - 1 pod can be disrupted at a time (e.g., during a node drain)
+  #   - Rolling deploys proceed normally
+  #   - The cluster upgrade controller cannot drain a second node until the
+  #     first disrupted pod is rescheduled and Ready on another node.
+  #
+  # Alternatively, use maxUnavailable for percentage-based budgets:
+  #   maxUnavailable: 1  (at most 1 pod down at a time)
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+
+  selector:
+    matchLabels:
+      {{- include "apache.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/apache/templates/service.yaml
+++ b/helm/apache/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "apache.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "ClusterIP Service for the Apache HTTP Server deployment."
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      # targetPort must match the named port in the container spec.
+      targetPort: http
+      protocol: TCP
+      # Name the service port — required when using multiple ports or with Istio.
+      name: http
+  # Selector must match the pod template's selectorLabels exactly.
+  selector:
+    {{- include "apache.selectorLabels" . | nindent 4 }}

--- a/helm/apache/templates/serviceaccount.yaml
+++ b/helm/apache/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "apache.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "Dedicated ServiceAccount for the Apache HTTP Server pod."
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+# Disable automatic mounting of the API server credential.
+# Only opt-in workloads that genuinely call the Kubernetes API should set this
+# to true. Leaving it false reduces the blast radius if the pod is compromised.
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/apache/templates/tests/test-connection.yaml
+++ b/helm/apache/templates/tests/test-connection.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "apache.fullname" . }}-test-connection
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
+  annotations:
+    kubernetes.io/description: "Helm test pod — verifies HTTP connectivity to the Apache service."
+    # This annotation marks the pod as a Helm test. It is run by `helm test <release>`.
+    "helm.sh/hook": test
+    # Delete the test pod after it completes (pass or fail).
+    # Options: before-hook-creation, keep, hook-succeeded, hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  # Test pod runs as a non-root user with a restricted security context,
+  # consistent with the production standards of this chart.
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534   # nobody
+    seccompProfile:
+      type: RuntimeDefault
+
+  restartPolicy: Never   # The test pod must not be restarted on failure
+
+  containers:
+    - name: wget
+      image: busybox:1.36
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+      # Send an HTTP GET to the Apache service and verify a 200 response.
+      # wget returns exit code 1 on any non-2xx response, which causes the
+      # test pod to enter a Failed state and `helm test` to report failure.
+      command:
+        - wget
+        - --spider                        # Do not download the body
+        - --server-response               # Print response headers for debugging
+        - --tries=3                       # Retry up to 3 times
+        - --timeout=10                    # 10 second timeout per attempt
+        - "http://{{ include "apache.fullname" . }}:{{ .Values.service.port }}/"
+      resources:
+        requests:
+          cpu: 10m
+          memory: 16Mi
+        limits:
+          memory: 16Mi

--- a/helm/apache/values.schema.json
+++ b/helm/apache/values.schema.json
@@ -1,0 +1,309 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Apache Helm Chart Values",
+  "description": "JSON Schema for validating the Apache Helm chart values.yaml. Helm validates values against this schema during install, upgrade, lint, and template.",
+  "type": "object",
+  "required": ["replicaCount", "image", "service"],
+  "additionalProperties": true,
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100,
+      "description": "Number of pod replicas. Must be >= 2 for HA with PodDisruptionBudget."
+    },
+    "image": {
+      "type": "object",
+      "required": ["repository", "pullPolicy"],
+      "additionalProperties": true,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Container image repository path (without tag)."
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "description": "Kubernetes imagePullPolicy. Use IfNotPresent with pinned digest in production."
+        },
+        "tag": {
+          "type": "string",
+          "description": "Image tag. Overridden by digest in production."
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-fA-F0-9]{64}$",
+          "description": "Image digest for cryptographic pinning. Preferred over tag in production."
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "List of image pull secrets for private registries."
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the chart name portion of generated resource names."
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the full resource name prefix."
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Whether to create a dedicated ServiceAccount."
+        },
+        "automount": {
+          "type": "boolean",
+          "description": "Whether to auto-mount the service account token. Set false by default."
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations for the ServiceAccount (e.g., IRSA role ARN)."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the ServiceAccount. Generated if empty and create=true."
+        }
+      }
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Annotations applied to the Pod spec."
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Additional labels applied to the Pod spec."
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Pod-level security context applied to all containers.",
+      "properties": {
+        "runAsNonRoot": {
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "UID to run the container process. Must not be 0 (root)."
+        },
+        "fsGroup": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "GID applied to volume mounts for group-readable files."
+        },
+        "seccompProfile": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["RuntimeDefault", "Unconfined", "Localhost"]
+            }
+          }
+        }
+      }
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Container-level security context.",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "type": "boolean"
+        },
+        "readOnlyRootFilesystem": {
+          "type": "boolean"
+        },
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "drop": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "add": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "required": ["type", "port"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"],
+          "description": "Kubernetes Service type."
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Port the Service exposes."
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["host", "paths"],
+            "properties": {
+              "host": { "type": "string" },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["path", "pathType"],
+                  "properties": {
+                    "path": { "type": "string" },
+                    "pathType": {
+                      "type": "string",
+                      "enum": ["Prefix", "Exact", "ImplementationSpecific"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array"
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "description": "Container resource requests and limits.",
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "targetMemoryUtilizationPercentage": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "scaleDownStabilizationWindowSeconds": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "string", "pattern": "^[0-9]+%$" }
+          ],
+          "description": "Minimum available pods during disruption. Integer or percentage string."
+        }
+      }
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100
+    },
+    "volumes": {
+      "type": "array",
+      "description": "Extra volumes to attach to the pod (e.g., emptyDir for tmp)."
+    },
+    "volumeMounts": {
+      "type": "array",
+      "description": "Volume mounts for the apache container."
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "strategy": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["RollingUpdate", "Recreate"]
+        },
+        "rollingUpdate": {
+          "type": "object",
+          "properties": {
+            "maxSurge": {
+              "oneOf": [
+                { "type": "integer", "minimum": 0 },
+                { "type": "string" }
+              ]
+            },
+            "maxUnavailable": {
+              "oneOf": [
+                { "type": "integer", "minimum": 0 },
+                { "type": "string" }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "revisionHistoryLimit": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 20
+    },
+    "minReadySeconds": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Must be >= your application's graceful shutdown time."
+    }
+  }
+}

--- a/helm/apache/values.yaml
+++ b/helm/apache/values.yaml
@@ -1,0 +1,299 @@
+# =============================================================================
+# Apache Helm Chart — Default Values
+# =============================================================================
+# All values here act as defaults and are intended to be overridden by
+# environment-specific values files (-f values-prod.yaml).
+#
+# Every property has a comment explaining its purpose and any production notes.
+# =============================================================================
+
+# Number of pod replicas.
+# Production: set to >= 2 to ensure high availability and support PodDisruptionBudget.
+replicaCount: 2
+
+image:
+  # Container image repository. Do not include the tag here.
+  repository: httpd
+
+  # Image pull policy.
+  # Production: use IfNotPresent with a pinned digest (not :latest) to ensure
+  # reproducible deployments and avoid unexpected updates.
+  pullPolicy: IfNotPresent
+
+  # Image tag. Overrides Chart.AppVersion when set.
+  # Production: prefer digest pinning over mutable tags (see 'digest' below).
+  tag: "2.4"
+
+  # Image digest — recommended for production for cryptographic image verification.
+  # When set, 'tag' is ignored and the image is pulled by digest.
+  # Generate: docker inspect --format='{{index .RepoDigests 0}}' httpd:2.4
+  # digest: sha256:abc123...
+
+# Image pull secrets for private container registries.
+# Create secrets with: kubectl create secret docker-registry my-secret --docker-server=...
+# Example: [{ name: my-pull-secret }]
+imagePullSecrets: []
+
+# Override the chart name portion of resource names.
+# Useful when installing multiple releases of this chart in the same namespace.
+nameOverride: ""
+
+# Override the full resource name prefix (overrides both chart and release names).
+fullnameOverride: ""
+
+serviceAccount:
+  # Whether to create a dedicated ServiceAccount for this workload.
+  # Best practice: always create a dedicated SA — never use the 'default' SA.
+  create: true
+
+  # Disable automatic mounting of the service account token.
+  # Opt-in per workload: set automountServiceAccountToken: true on the Pod spec
+  # only for workloads that genuinely need to call the Kubernetes API.
+  automount: false
+
+  # Annotations to add to the ServiceAccount.
+  # Useful for IRSA (IAM Roles for Service Accounts on EKS) or Workload Identity (GKE):
+  # annotations:
+  #   eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/my-role
+  annotations: {}
+
+  # Name of the ServiceAccount to use.
+  # If empty and create=true, a name is generated using the fullname helper.
+  name: ""
+
+# Pod-level annotations.
+# Common uses:
+#   - Prometheus scraping: prometheus.io/scrape: "true"
+#   - Vault agent injection: vault.hashicorp.com/agent-inject: "true"
+#   - Datadog APM: ad.datadoghq.com/apache.check_names: '["apache"]'
+podAnnotations:
+  # Tells kubectl which container is the primary one (for logs, exec, etc.)
+  kubectl.kubernetes.io/default-container: apache
+
+# Additional pod-level labels.
+# These are merged with the standard app.kubernetes.io/* labels.
+podLabels: {}
+
+# Pod-level security context — applies to ALL containers in the pod.
+# These settings establish the security baseline for the entire pod.
+podSecurityContext:
+  # Reject containers that run as root (UID 0).
+  # This is enforced before the container starts.
+  runAsNonRoot: true
+
+  # Run as UID 33 (www-data). The Apache image must support this user.
+  # Verify with: docker run --rm httpd:2.4 id www-data
+  runAsUser: 33
+
+  # Set the owning GID for volume mounts. Allows the process to read/write volumes.
+  fsGroup: 33
+
+  # Apply the RuntimeDefault seccomp profile — restricts syscalls to a safe allowlist.
+  # This is the minimum recommended seccomp profile; consider Localhost for stricter control.
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level security context — applied to the apache container specifically.
+securityContext:
+  # Prevent the container from gaining additional privileges via setuid binaries.
+  allowPrivilegeEscalation: false
+
+  # Mount the root filesystem as read-only. Requires explicit writable volumes
+  # for any paths the app writes to (e.g., /tmp, log directories).
+  readOnlyRootFilesystem: true
+
+  # Drop all Linux capabilities. Add back only what is strictly required.
+  # Apache running on port 80 requires NET_BIND_SERVICE if not using a proxy;
+  # on Kubernetes, prefer port 8080 and a Service to avoid needing this capability.
+  capabilities:
+    drop: ["ALL"]
+
+service:
+  # Service type.
+  # - ClusterIP: internal traffic only (recommended; use Ingress for external access)
+  # - NodePort: exposes on each node's IP (use for non-Ingress external access)
+  # - LoadBalancer: provisions a cloud load balancer (expensive; prefer Ingress)
+  type: ClusterIP
+
+  # Port the Service exposes.
+  port: 80
+
+ingress:
+  # Enable Ingress resource creation.
+  # Requires an Ingress controller (e.g., ingress-nginx, Traefik, AWS ALB) installed.
+  enabled: false
+
+  # IngressClass name — must match an available IngressClass in the cluster.
+  className: nginx
+
+  # Ingress-controller-specific annotations.
+  # Examples:
+  #   nginx.ingress.kubernetes.io/rewrite-target: /
+  #   cert-manager.io/cluster-issuer: letsencrypt-prod
+  annotations: {}
+
+  hosts:
+    - host: apache.example.local
+      paths:
+        - path: /
+          # Prefix: matches any path starting with /
+          # Exact: matches only the exact path
+          # ImplementationSpecific: controller-defined semantics
+          pathType: Prefix
+
+  # TLS configuration. Requires cert-manager or manually created TLS secrets.
+  # tls:
+  #   - secretName: apache-tls
+  #     hosts:
+  #       - apache.example.local
+  tls: []
+
+# Container resource requests and limits.
+# Requests: what the scheduler uses to place the pod.
+# Limits: hard upper bounds; exceeding memory limit = OOMKilled.
+#
+# Production guidance:
+#   - Set requests based on p50 observed usage.
+#   - Set memory limit at ~2x the p99 observed usage to prevent OOM on spikes.
+#   - CPU limits are intentionally omitted: CPU throttling causes latency spikes
+#     and the Kubernetes scheduler already uses requests for bin-packing.
+#     Monitor CPU usage and adjust requests if pods are consistently near the limit.
+resources:
+  requests:
+    cpu: 100m      # 0.1 vCPU — baseline Apache serving static content
+    memory: 128Mi  # 128 MiB — adjust based on actual usage metrics
+  limits:
+    # CPU limit intentionally omitted to avoid CPU throttling.
+    # See: https://erickhun.com/posts/kubernetes-faster-services-no-cpu-limits/
+    memory: 128Mi  # Hard OOM protection
+
+# Liveness probe — detects a hung or deadlocked process and restarts the container.
+# IMPORTANT: The liveness probe must be cheap and reliable. If it fails, the
+# container is killed. Do NOT check external dependencies in liveness probes.
+livenessProbe:
+  httpGet:
+    path: /
+    port: http   # Named port defined in the container spec
+  initialDelaySeconds: 10   # Wait before the first probe (allow container to start)
+  periodSeconds: 15         # Probe every 15 seconds
+  failureThreshold: 3       # Kill container after 3 consecutive failures (45s)
+
+# Readiness probe — signals when the container is ready to receive traffic.
+# Failing readiness probe removes the pod from Service endpoints (no traffic).
+# IMPORTANT: Readiness probes MUST NOT check external dependencies — they are
+# evaluated on every sync. Use a dedicated /health endpoint for local state only.
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3   # Remove from endpoint pool after 3 failures (30s)
+
+# Startup probe — gives slow-starting containers time to initialize before liveness
+# kicks in. The container has failureThreshold * periodSeconds seconds to start.
+# Here: 30 * 10 = 300 seconds (5 minutes) before liveness takes over.
+startupProbe:
+  httpGet:
+    path: /
+    port: http
+  failureThreshold: 30
+  periodSeconds: 10
+
+autoscaling:
+  # Enable Horizontal Pod Autoscaler.
+  enabled: false
+
+  # Minimum number of replicas (should match or exceed replicaCount when enabled).
+  minReplicas: 2
+
+  # Maximum number of replicas. Set based on cluster capacity and cost constraints.
+  maxReplicas: 10
+
+  # Target CPU utilisation percentage across all pods.
+  # Scale out when average CPU across all pods exceeds this threshold.
+  targetCPUUtilizationPercentage: 70
+
+  # Target memory utilisation percentage.
+  targetMemoryUtilizationPercentage: 80
+
+  # Stabilization window for scale-down decisions.
+  # Prevents flapping by requiring the scale-down condition to be true for this
+  # many seconds before actually scaling down.
+  scaleDownStabilizationWindowSeconds: 300
+
+# PodDisruptionBudget — ensures minimum availability during voluntary disruptions
+# such as node drains, cluster upgrades, or rolling deployments.
+podDisruptionBudget:
+  enabled: true
+  # At least 1 pod must remain available at all times.
+  # With replicaCount: 2, this allows only 1 pod to be disrupted at a time.
+  minAvailable: 1
+
+# Extra volumes to mount into the pod.
+# Required because readOnlyRootFilesystem: true means the container cannot write
+# to any path in the root filesystem. Apache needs a writable /tmp directory.
+volumes:
+  - name: tmp
+    emptyDir: {}   # In-memory scratch space; lost on pod restart
+
+# Volume mounts for the apache container.
+volumeMounts:
+  - name: tmp
+    mountPath: /tmp
+
+# Node selector — constrain pods to nodes with specific labels.
+# Example: { kubernetes.io/os: linux, node-role: web }
+nodeSelector: {}
+
+# Tolerations — allow pods to be scheduled on tainted nodes.
+# Example:
+# tolerations:
+#   - key: "dedicated"
+#     operator: "Equal"
+#     value: "web"
+#     effect: "NoSchedule"
+tolerations: []
+
+# Affinity rules — fine-grained pod placement control.
+# The default configuration uses pod anti-affinity to spread replicas across
+# nodes for high availability. If a node fails, not all pods are lost.
+affinity:
+  podAntiAffinity:
+    # preferredDuringScheduling: best-effort — the scheduler tries to honour this
+    # but places the pod even if it cannot. Use requiredDuringScheduling for strict HA.
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100   # Highest preference weight (1–100)
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              # Matches other apache pods from this chart
+              app.kubernetes.io/name: apache
+          # Spread across different nodes
+          topologyKey: kubernetes.io/hostname
+
+# Deployment update strategy.
+# RollingUpdate: replaces pods incrementally (zero-downtime deployments).
+# Recreate: kills all pods first, then creates new ones (causes downtime).
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    # Maximum number of pods that can be created above the desired replicaCount.
+    maxSurge: 1
+    # Maximum number of pods that can be unavailable during the update.
+    # 0 = no pods go down until a new pod is Ready (zero-downtime guarantee).
+    maxUnavailable: 0
+
+# Number of old ReplicaSets to retain for rollback.
+# Higher values consume etcd space. 5 is a reasonable balance.
+revisionHistoryLimit: 5
+
+# Minimum seconds a newly created pod should be Ready before it is considered Available.
+# Protects against flapping: a pod is not counted as available until it has been
+# ready for this many seconds, preventing premature traffic during startup.
+minReadySeconds: 10
+
+# Time the kubelet waits after sending SIGTERM before sending SIGKILL.
+# Must be longer than your application's graceful shutdown time.
+# Apache default graceful shutdown: ~30s. Set to 60s for safety margin.
+terminationGracePeriodSeconds: 60

--- a/helm/get_helm.sh
+++ b/helm/get_helm.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# get_helm.sh — Simplified Helm installer for Linux and macOS
+#
+# Usage:
+#   ./get_helm.sh                       # Install default version
+#   HELM_VERSION=3.16.0 ./get_helm.sh  # Install specific version
+#
+# The official installer is at:
+#   https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+#
+# This script:
+#   1. Detects OS and CPU architecture
+#   2. Downloads the Helm binary archive from get.helm.sh
+#   3. Verifies the SHA-256 checksum
+#   4. Installs the binary to /usr/local/bin/helm
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+HELM_VERSION="${HELM_VERSION:-3.17.0}"
+INSTALL_DIR="${HELM_INSTALL_DIR:-/usr/local/bin}"
+
+# ---------------------------------------------------------------------------
+# Detect OS
+# ---------------------------------------------------------------------------
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+
+case "${OS}" in
+  linux)   OS="linux"   ;;
+  darwin)  OS="darwin"  ;;
+  *)
+    echo "ERROR: Unsupported operating system: ${OS}"
+    echo "       Supported: linux, darwin"
+    exit 1
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Detect CPU architecture
+# ---------------------------------------------------------------------------
+ARCH="$(uname -m)"
+
+case "${ARCH}" in
+  x86_64)          ARCH="amd64"  ;;
+  aarch64|arm64)   ARCH="arm64"  ;;
+  armv7l)          ARCH="arm"    ;;
+  i386|i686)       ARCH="386"    ;;
+  *)
+    echo "ERROR: Unsupported architecture: ${ARCH}"
+    echo "       Supported: x86_64, aarch64/arm64, armv7l, i386/i686"
+    exit 1
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Construct download URLs
+# ---------------------------------------------------------------------------
+PACKAGE_NAME="helm-v${HELM_VERSION}-${OS}-${ARCH}.tar.gz"
+BASE_URL="https://get.helm.sh"
+URL="${BASE_URL}/${PACKAGE_NAME}"
+CHECKSUM_URL="${URL}.sha256sum"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT   # Always clean up temp dir on exit
+
+# ---------------------------------------------------------------------------
+# Check for required tools
+# ---------------------------------------------------------------------------
+for cmd in curl sha256sum tar; do
+  if ! command -v "${cmd}" &>/dev/null; then
+    # On macOS, sha256sum is provided by 'shasum -a 256'
+    if [[ "${cmd}" == "sha256sum" && "$(uname -s)" == "Darwin" ]]; then
+      : # handled below
+    else
+      echo "ERROR: Required command not found: ${cmd}"
+      exit 1
+    fi
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Download
+# ---------------------------------------------------------------------------
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Helm Installer"
+echo "  Version : v${HELM_VERSION}"
+echo "  OS      : ${OS}"
+echo "  Arch    : ${ARCH}"
+echo "  URL     : ${URL}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+echo ""
+echo "Downloading Helm archive..."
+curl -fsSL "${URL}" -o "${TMP_DIR}/helm.tar.gz"
+
+echo "Downloading checksum file..."
+curl -fsSL "${CHECKSUM_URL}" -o "${TMP_DIR}/helm.tar.gz.sha256sum"
+
+# ---------------------------------------------------------------------------
+# Verify checksum
+# ---------------------------------------------------------------------------
+echo "Verifying SHA-256 checksum..."
+
+# Normalise checksum file: the downloaded file contains an absolute path
+# like "./linux-amd64/helm.tar.gz"; we need to match against our local path.
+# Extract only the hash, then compare manually for portability.
+EXPECTED_HASH="$(awk '{print $1}' "${TMP_DIR}/helm.tar.gz.sha256sum")"
+ACTUAL_HASH="$(sha256sum "${TMP_DIR}/helm.tar.gz" 2>/dev/null | awk '{print $1}' \
+               || shasum -a 256 "${TMP_DIR}/helm.tar.gz" | awk '{print $1}')"
+
+if [[ "${EXPECTED_HASH}" != "${ACTUAL_HASH}" ]]; then
+  echo "ERROR: Checksum verification failed!"
+  echo "  Expected : ${EXPECTED_HASH}"
+  echo "  Actual   : ${ACTUAL_HASH}"
+  echo "  The downloaded file may be corrupt or tampered with."
+  exit 1
+fi
+
+echo "Checksum verified: ${ACTUAL_HASH}"
+
+# ---------------------------------------------------------------------------
+# Extract and install
+# ---------------------------------------------------------------------------
+echo "Extracting archive..."
+tar -xzf "${TMP_DIR}/helm.tar.gz" -C "${TMP_DIR}"
+
+HELM_BINARY="${TMP_DIR}/${OS}-${ARCH}/helm"
+
+if [[ ! -f "${HELM_BINARY}" ]]; then
+  echo "ERROR: Helm binary not found at expected path: ${HELM_BINARY}"
+  exit 1
+fi
+
+echo "Installing Helm to ${INSTALL_DIR}/helm..."
+
+# Use sudo if the install directory is not writable by the current user
+if [[ -w "${INSTALL_DIR}" ]]; then
+  mv "${HELM_BINARY}" "${INSTALL_DIR}/helm"
+  chmod +x "${INSTALL_DIR}/helm"
+else
+  sudo mv "${HELM_BINARY}" "${INSTALL_DIR}/helm"
+  sudo chmod +x "${INSTALL_DIR}/helm"
+fi
+
+# ---------------------------------------------------------------------------
+# Verify installation
+# ---------------------------------------------------------------------------
+if ! command -v helm &>/dev/null; then
+  echo ""
+  echo "WARNING: helm is not on your PATH."
+  echo "  Add ${INSTALL_DIR} to your PATH, e.g.:"
+  echo "    export PATH=\"${INSTALL_DIR}:\$PATH\""
+else
+  echo ""
+  helm version
+  echo ""
+  echo "Helm installed successfully."
+fi
+
+# ---------------------------------------------------------------------------
+# Post-install hints
+# ---------------------------------------------------------------------------
+cat <<'EOF'
+
+Next steps:
+  helm repo add bitnami https://charts.bitnami.com/bitnami
+  helm repo update
+  helm search repo bitnami
+
+Documentation:
+  https://helm.sh/docs/
+
+EOF


### PR DESCRIPTION
## Summary
Full production-grade Helm chart for Apache httpd:

- `Chart.yaml` — semantic versioning, maintainer metadata
- `values.yaml` — 300-line fully commented values file covering: image digest pinning, rolling update strategy, `podAntiAffinity` across nodes, HPA (CPU/memory), PDB (`minAvailable`), Ingress with TLS, security context defaults (`runAsNonRoot`, `readOnlyRootFilesystem`), `terminationGracePeriodSeconds: 60`, `serviceAccount.automount: false`
- `values.schema.json` — JSON Schema with `required: [replicaCount, image, service]`, type validation, `enum` for `pullPolicy` and service `type`, `minimum: 1` on `replicaCount`
- Templates: Deployment, Service, Ingress, HPA (gated), PDB (gated), ServiceAccount, NOTES.txt, helm-test Job
- No `.tgz` files committed (CI installs from source)

## Issues referenced
Relates to #55, #57

## Test plan
- [ ] `helm lint helm/apache` passes
- [ ] `helm template helm/apache | kubeconform` passes
- [ ] `helm install apache-test helm/apache --dry-run` renders without error
- [ ] `helm install apache-test helm/apache --set autoscaling.enabled=false` deploys to cluster