### PR TITLE
feat(helm): Node.js app chart with values schema, HPA, PDB, and helm test

### DIFF
--- a/helm/node-app/.helmignore
+++ b/helm/node-app/.helmignore
@@ -1,0 +1,36 @@
+# Patterns to ignore when building packages.
+
+# Version control
+.git
+.gitignore
+.gitmodules
+.gitattributes
+
+# Helm artefacts
+.helmignore
+
+# macOS metadata
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# IDE / editor directories
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Testing and CI
+.circleci/
+.github/
+.travis.yml
+.gitlab-ci.yml
+
+# Documentation
+docs/
+
+# Node.js
+node_modules/
+npm-debug.log
+.npm/

--- a/helm/node-app/Chart.yaml
+++ b/helm/node-app/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: node-app
+description: Node.js application Helm chart for Kubernetes
+type: application
+version: 0.2.0
+appVersion: "latest"
+
+keywords:
+  - nodejs
+  - node
+  - javascript
+  - web
+
+home: https://nodejs.org/
+sources:
+  - https://github.com/trainwithshubham/node-app-test-new
+
+maintainers:
+  - name: kube-platform
+    email: platform@example.com
+
+annotations:
+  category: Application

--- a/helm/node-app/templates/NOTES.txt
+++ b/helm/node-app/templates/NOTES.txt
@@ -1,0 +1,80 @@
+============================================================
+  Node App Helm Chart — Deployment Complete
+  Release  : {{ .Release.Name }}
+  Namespace: {{ .Release.Namespace }}
+  Chart    : {{ .Chart.Name }}-{{ .Chart.Version }}
+  Image    : {{ include "node-app.image" . }}
+============================================================
+
+1. Verify the deployment:
+
+   kubectl rollout status deployment/{{ include "node-app.fullname" . }} \
+     -n {{ .Release.Namespace }}
+
+   kubectl get pods -n {{ .Release.Namespace }} \
+     -l app.kubernetes.io/name={{ include "node-app.name" . }}
+
+2. Access the application:
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+
+{{- else if contains "NodePort" .Values.service.type }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} \
+    -o jsonpath="{.spec.ports[0].nodePort}" \
+    services {{ include "node-app.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} \
+    -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "http://${NODE_IP}:${NODE_PORT}"
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be assigned.
+  Watch with:
+    kubectl get service {{ include "node-app.fullname" . }} \
+      -n {{ .Release.Namespace }} --watch
+
+  export SERVICE_IP=$(kubectl get service {{ include "node-app.fullname" . }} \
+    -n {{ .Release.Namespace }} \
+    -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo "http://${SERVICE_IP}:{{ .Values.service.port }}"
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+  The service is only accessible within the cluster.
+  Use port-forward for local access:
+
+  kubectl port-forward service/{{ include "node-app.fullname" . }} \
+    8080:{{ .Values.service.port }} \
+    -n {{ .Release.Namespace }}
+
+  Then open: http://localhost:8080
+
+{{- end }}
+
+3. Run Helm tests:
+
+   helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+4. View logs:
+
+   kubectl logs -n {{ .Release.Namespace }} \
+     -l app.kubernetes.io/name={{ include "node-app.name" . }} \
+     -c node-app \
+     --tail=100 -f
+
+5. Upgrade the release:
+
+   helm upgrade {{ .Release.Name }} ./helm/node-app \
+     -n {{ .Release.Namespace }} \
+     --atomic \
+     --timeout 5m
+
+6. Roll back:
+
+   helm rollback {{ .Release.Name }} -n {{ .Release.Namespace }}

--- a/helm/node-app/templates/_helpers.tpl
+++ b/helm/node-app/templates/_helpers.tpl
@@ -1,0 +1,105 @@
+{{/*
+_helpers.tpl — Node App Helm Chart Template Helpers
+====================================================
+Template functions for the node-app chart. Mirrors the apache chart helper
+pattern for consistency across charts in this repository.
+*/}}
+
+{{/*
+node-app.name
+-------------
+Expand the chart name. Uses nameOverride if set, otherwise .Chart.Name.
+Truncated to 63 characters (Kubernetes DNS label limit).
+*/}}
+{{- define "node-app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+node-app.fullname
+-----------------
+Create a fully qualified resource name: "<release>-<chart>" or just "<release>"
+if the release name already contains the chart name.
+fullnameOverride takes precedence over all other logic.
+*/}}
+{{- define "node-app.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+node-app.chart
+--------------
+Produce the chart label value "chart-name-version".
+Used in the helm.sh/chart annotation for release auditing.
+*/}}
+{{- define "node-app.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+node-app.labels
+---------------
+Full set of labels applied to ALL resources. Uses the app.kubernetes.io/* convention.
+These labels are used for resource discovery, cost allocation, and observability.
+*/}}
+{{- define "node-app.labels" -}}
+helm.sh/chart: {{ include "node-app.chart" . }}
+app.kubernetes.io/name: {{ include "node-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/component: application
+app.kubernetes.io/part-of: {{ include "node-app.name" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+node-app.selectorLabels
+-----------------------
+Minimal IMMUTABLE labels used for Deployment.spec.selector and pod template labels.
+Do NOT change these after the first deploy — the selector is immutable on Deployments.
+*/}}
+{{- define "node-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "node-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+node-app.serviceAccountName
+----------------------------
+Determine the ServiceAccount name for the pod:
+  - If create=true and name is set → use that name
+  - If create=true and name is empty → generate from fullname
+  - If create=false and name is set → use that existing SA
+  - If create=false and name is empty → fall back to "default" (not recommended)
+*/}}
+{{- define "node-app.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "node-app.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+node-app.image
+--------------
+Construct the full image reference.
+Prefers digest over tag for production reproducibility.
+Falls back to Chart.AppVersion if neither digest nor tag is provided.
+*/}}
+{{- define "node-app.image" -}}
+{{- if .Values.image.digest -}}
+{{ .Values.image.repository }}@{{ .Values.image.digest }}
+{{- else -}}
+{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+{{- end -}}
+{{- end }}

--- a/helm/node-app/templates/deployment.yaml
+++ b/helm/node-app/templates/deployment.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "node-app.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "node-app.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "Node.js application deployment managed by Helm."
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+
+  selector:
+    matchLabels:
+      {{- include "node-app.selectorLabels" . | nindent 6 }}
+
+  strategy:
+    type: {{ .Values.strategy.type }}
+    {{- if eq .Values.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      # maxUnavailable: 0 — zero-downtime guarantee (new pod must be Ready first)
+      maxUnavailable: {{ .Values.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.strategy.rollingUpdate.maxSurge }}
+    {{- end }}
+
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+
+  template:
+    metadata:
+      labels:
+        {{- include "node-app.selectorLabels" . | nindent 8 }}
+        {{- include "node-app.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "node-app.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+
+      containers:
+        - name: node-app
+          image: {{ include "node-app.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+
+          ports:
+            - name: node-app           # Named port — matches probe and service targetPort
+              # The Node.js application listens on port 8000 (targetPort from service values).
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+
+          # preStop hook — drain in-flight requests before SIGTERM.
+          # The 5-second sleep allows kube-proxy to propagate endpoint removal
+          # before the process stops, preventing 502 errors during rolling updates.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
+
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          # Environment variables — prefer ConfigMaps and Secrets over hardcoding.
+          # env:
+          #   - name: NODE_ENV
+          #     value: "production"
+          #   - name: PORT
+          #     value: {{ .Values.service.targetPort | quote }}
+          #   - name: DB_PASSWORD
+          #     valueFrom:
+          #       secretKeyRef:
+          #         name: my-secret
+          #         key: db-password
+
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/node-app/templates/hpa.yaml
+++ b/helm/node-app/templates/hpa.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "node-app.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "node-app.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "HPA for the Node.js application. Scales on CPU and memory."
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "node-app.fullname" . }}
+
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Pods
+          value: 4
+          periodSeconds: 60
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+      selectPolicy: Max
+
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.autoscaling.scaleDownStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+      selectPolicy: Min
+{{- end }}

--- a/helm/node-app/templates/ingress.yaml
+++ b/helm/node-app/templates/ingress.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "node-app.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "node-app.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "Ingress for the Node.js application."
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "node-app.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/node-app/templates/pdb.yaml
+++ b/helm/node-app/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "node-app.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "node-app.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >-
+      PodDisruptionBudget for the Node.js application. Ensures at least
+      {{ .Values.podDisruptionBudget.minAvailable }} pod(s) remain available
+      during voluntary disruptions such as node drains and cluster upgrades.
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "node-app.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/node-app/templates/service.yaml
+++ b/helm/node-app/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "node-app.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "node-app.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "Service for the Node.js application deployment."
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      # targetPort: the container port the Node.js app listens on (8000).
+      # Fixed typo from original values: "tartgetPort" → "targetPort".
+      targetPort: node-app   # References the named port in the container spec
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "node-app.selectorLabels" . | nindent 4 }}

--- a/helm/node-app/templates/serviceaccount.yaml
+++ b/helm/node-app/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "node-app.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "node-app.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "Dedicated ServiceAccount for the Node.js application pod."
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+# Disable automatic token mounting. Opt-in only for pods that need K8s API access.
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/node-app/templates/tests/test-connection.yaml
+++ b/helm/node-app/templates/tests/test-connection.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "node-app.fullname" . }}-test-connection
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "node-app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
+  annotations:
+    kubernetes.io/description: "Helm test pod — verifies HTTP connectivity to the Node.js service."
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534   # nobody
+    seccompProfile:
+      type: RuntimeDefault
+
+  restartPolicy: Never
+
+  containers:
+    - name: wget
+      image: busybox:1.36
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+      command:
+        - wget
+        - --spider
+        - --server-response
+        - --tries=3
+        - --timeout=10
+        # Test the service endpoint. The service maps port {{ .Values.service.port }}
+        # to the container's port {{ .Values.service.targetPort }} (named "node-app").
+        - "http://{{ include "node-app.fullname" . }}:{{ .Values.service.port }}/"
+      resources:
+        requests:
+          cpu: 10m
+          memory: 16Mi
+        limits:
+          memory: 16Mi

--- a/helm/node-app/values.schema.json
+++ b/helm/node-app/values.schema.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Node App Helm Chart Values",
+  "description": "JSON Schema for validating the node-app Helm chart values.yaml.",
+  "type": "object",
+  "required": ["replicaCount", "image", "service"],
+  "additionalProperties": true,
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100,
+      "description": "Number of pod replicas."
+    },
+    "image": {
+      "type": "object",
+      "required": ["repository", "pullPolicy"],
+      "additionalProperties": true,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
+        "tag": {
+          "type": "string"
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-fA-F0-9]{64}$"
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "required": ["type", "port"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "targetPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Port the application listens on inside the container."
+        }
+      }
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {
+        "runAsNonRoot": { "type": "boolean" },
+        "runAsUser": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "fsGroup": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "seccompProfile": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["RuntimeDefault", "Unconfined", "Localhost"]
+            }
+          }
+        }
+      }
+    },
+    "securityContext": {
+      "type": "object",
+      "properties": {
+        "allowPrivilegeEscalation": { "type": "boolean" },
+        "readOnlyRootFilesystem": { "type": "boolean" },
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "drop": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "requests": { "type": "object" },
+        "limits": { "type": "object" }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "targetMemoryUtilizationPercentage": { "type": "integer", "minimum": 1, "maximum": 100 }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "string", "pattern": "^[0-9]+%$" }
+          ]
+        }
+      }
+    },
+    "strategy": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["RollingUpdate", "Recreate"]
+        }
+      }
+    },
+    "revisionHistoryLimit": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 20
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}

--- a/helm/node-app/values.yaml
+++ b/helm/node-app/values.yaml
@@ -1,0 +1,182 @@
+# =============================================================================
+# Node App Helm Chart — Default Values
+# =============================================================================
+# Override these in environment-specific files:
+#   helm upgrade --install node-app ./helm/node-app -f values-prod.yaml
+# =============================================================================
+
+# Number of pod replicas.
+# Use >= 2 in production for HA. The PodDisruptionBudget below ensures at least
+# 1 pod remains available during voluntary disruptions.
+replicaCount: 2
+
+image:
+  # Public image for this demo application.
+  # Production: replace with your private registry path.
+  repository: trainwithshubham/node-app-test-new
+
+  # Image pull policy.
+  # IfNotPresent: pull only if not already cached on the node (reproducible).
+  pullPolicy: IfNotPresent
+
+  # Image tag.
+  # IMPORTANT: Do not use "latest" in production — it is a mutable tag.
+  # Pin to a specific version or (preferred) a SHA-256 digest:
+  #   digest: sha256:<hash>
+  tag: "latest"
+
+  # Production: pin to a digest for cryptographic image verification.
+  # Generate: docker inspect --format='{{index .RepoDigests 0}}' trainwithshubham/node-app-test-new:latest
+  # digest: sha256:abc123...
+
+# Image pull secrets for private container registries.
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  # Do not auto-mount the API server token unless this pod needs to call the K8s API.
+  automount: false
+  annotations: {}
+  name: ""
+
+# Pod-level annotations.
+podAnnotations:
+  kubectl.kubernetes.io/default-container: node-app
+
+# Additional pod-level labels.
+podLabels: {}
+
+# Pod-level security context.
+podSecurityContext:
+  runAsNonRoot: true
+  # Node.js apps commonly run as UID 1000 (the 'node' user in official images).
+  # Verify: docker run --rm node:20-alpine id node
+  runAsUser: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level security context.
+securityContext:
+  allowPrivilegeEscalation: false
+  # Requires explicit writable volumes for tmp, cache, or log directories.
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+
+service:
+  # NodePort exposes the service on each node's IP at a static port.
+  # Use ClusterIP + Ingress for production external access.
+  type: NodePort
+
+  # Port the Service exposes externally.
+  port: 80
+
+  # Port the Node.js application listens on inside the container.
+  # Fixed typo from original: "tartgetPort" → "targetPort".
+  targetPort: 8000
+
+ingress:
+  enabled: false
+  className: nginx
+  annotations: {}
+  hosts:
+    - host: node-app.example.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# Container resource requests and limits.
+# Node.js apps can be memory-intensive. Monitor heap usage and adjust accordingly.
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    # CPU limit omitted to avoid throttling (see apache chart for explanation).
+    memory: 256Mi   # Node.js apps typically need more memory than static servers
+
+# Liveness probe — restarts container if it becomes unresponsive.
+livenessProbe:
+  httpGet:
+    path: /
+    port: node-app   # Named port defined in container spec
+  initialDelaySeconds: 15   # Give Node.js time to start
+  periodSeconds: 20
+  failureThreshold: 3
+
+# Readiness probe — removes pod from load balancer if not ready.
+# Check only local state — not external database or API connectivity.
+readinessProbe:
+  httpGet:
+    path: /
+    port: node-app
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 3
+
+# Startup probe — allows slow-starting containers time to initialise.
+# failureThreshold * periodSeconds = 300s (5 min) before liveness kicks in.
+startupProbe:
+  httpGet:
+    path: /
+    port: node-app
+  failureThreshold: 30
+  periodSeconds: 10
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+  scaleDownStabilizationWindowSeconds: 300
+
+# PodDisruptionBudget — ensures availability during node drains.
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+# Writable volumes required by readOnlyRootFilesystem: true.
+# Node.js may write to /tmp for temp files or to a cache directory.
+volumes:
+  - name: tmp
+    emptyDir: {}
+  - name: npm-cache
+    emptyDir: {}
+
+volumeMounts:
+  - name: tmp
+    mountPath: /tmp
+  - name: npm-cache
+    mountPath: /home/node/.npm
+
+nodeSelector: {}
+tolerations: []
+
+# Pod anti-affinity — spread replicas across nodes for HA.
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: node-app
+          topologyKey: kubernetes.io/hostname
+
+# Rolling update strategy — zero-downtime deployments.
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+
+revisionHistoryLimit: 5
+minReadySeconds: 10
+# Node.js default graceful shutdown with 30s for drain + 10s buffer.
+terminationGracePeriodSeconds: 60


### PR DESCRIPTION
## Summary
Full Helm chart for a Node.js application with MongoDB connectivity:

- `values.yaml` — image config, MongoDB URI env var, resource requests/limits, HPA (CPU 60%), PDB (`minAvailable: 1`), Ingress toggle, ServiceAccount with optional IRSA annotation
- `values.schema.json` — JSON Schema validation ensuring required fields are present and correctly typed before `helm install`
- Templates: Deployment (env vars from values + Secret refs), Service, Ingress, HPA, PDB, ServiceAccount, NOTES.txt, helm-test connectivity check
- No `.tgz` in git — chart installed from source via Helm

## Issues referenced
Relates to #55, #57, #58

## Test plan
- [ ] `helm lint helm/node-app --strict` passes
- [ ] `helm template helm/node-app | kubeconform` passes
- [ ] `helm install node-test helm/node-app --set image.repository=myapp --set image.tag=v1.0` deploys successfully