### PR TITLE
feat(gitops): ArgoCD App-of-Apps pattern with AppProject and install guide

### DIFF
--- a/gitops/README.md
+++ b/gitops/README.md
@@ -1,0 +1,153 @@
+# GitOps
+
+## What Is GitOps?
+
+GitOps is an operational framework that takes DevOps best practices used for application
+development — version control, collaboration, compliance, CI/CD — and applies them to
+infrastructure automation.
+
+**Core principle: Git is the single source of truth for the desired state of your system.**
+
+The GitOps loop:
+1. Developers commit desired state to Git (manifests, Helm values, Kustomize overlays)
+2. A GitOps operator (ArgoCD, Flux) detects the change
+3. The operator reconciles the cluster state to match Git
+4. If cluster state drifts from Git (manual `kubectl apply`), the operator corrects it
+
+Benefits:
+- Full audit trail — every change is a Git commit with author, timestamp, and reason
+- Rollback = `git revert` (fast and reliable)
+- Disaster recovery — any cluster can be rebuilt by pointing the GitOps operator at the repo
+- Separation of concerns — developers push to Git; operators never touch production directly
+- Pull-based security — the cluster pulls changes; no inbound firewall rules needed for CD
+
+---
+
+## Push-Based vs Pull-Based Deployment
+
+| Aspect              | Push-Based (traditional CI/CD)          | Pull-Based (GitOps)                     |
+|---------------------|-----------------------------------------|-----------------------------------------|
+| Trigger             | CI pipeline pushes changes              | In-cluster operator polls Git           |
+| Cluster access      | CI server needs cluster credentials     | Cluster pulls; no external access needed|
+| Drift detection     | None — drift goes unnoticed             | Continuous — drift is detected and healed|
+| Audit trail         | CI logs (may be purged)                 | Git history (immutable)                 |
+| Rollback            | Re-run pipeline with old image tag      | `git revert` + auto-sync               |
+| Secrets handling    | CI env vars / vault integration         | External Secrets Operator + Vault       |
+| Multi-cluster       | Credentials per cluster in CI           | One operator instance per cluster       |
+| Complexity          | Lower initial setup                     | Higher initial setup, lower operational |
+
+**Recommendation:** Use GitOps (pull-based) for production. Use push-based for dev/preview
+environments where speed matters more than auditability.
+
+---
+
+## ArgoCD vs Flux Comparison
+
+| Feature                    | ArgoCD                                    | Flux                                       |
+|----------------------------|-------------------------------------------|--------------------------------------------|
+| Architecture               | Server + controller + UI                  | Set of controllers (no separate UI)        |
+| UI                         | Built-in web UI + CLI                     | CLI only (Weave GitOps for UI)             |
+| Sync model                 | App-of-Apps, ApplicationSets              | Kustomization + HelmRelease CRDs           |
+| Helm support               | Native (renders and applies)              | Native via HelmRelease CRD                 |
+| Kustomize support          | Native                                    | Native                                     |
+| Multi-tenancy              | AppProject RBAC                           | Multi-tenancy via tenants                  |
+| Image automation           | Separate ArgoCD Image Updater             | Built-in image reflector + automation      |
+| Notification               | Notification controller                   | Notification controller                    |
+| RBAC                       | ArgoCD-specific RBAC + SSO                | Kubernetes RBAC                            |
+| Learning curve             | Lower (great UI, clear concepts)          | Higher (more CRDs, more composable)        |
+| Community                  | CNCF graduated, large community           | CNCF graduated, large community            |
+| Best for                   | Teams wanting a full GitOps platform      | Teams preferring Kubernetes-native tooling |
+
+### When to Use ArgoCD
+
+- You want a visual dashboard to see sync status across applications
+- Your team is new to GitOps and benefits from the UI
+- You need multi-tenancy with AppProject scoping
+- You have complex multi-cluster deployments (ArgoCD manages multiple remote clusters)
+
+### When to Use Flux
+
+- You prefer pure Kubernetes RBAC (no ArgoCD-specific RBAC layer)
+- You need built-in image automation (update manifests when new images are pushed)
+- You want a fully declarative bootstrap (the bootstrap process itself is GitOps)
+- You use Kustomize heavily and want native Kustomization CRD control
+
+---
+
+## App-of-Apps Pattern (ArgoCD)
+
+The App-of-Apps pattern uses one "root" ArgoCD Application to manage all other Applications.
+This enables bootstrapping an entire cluster from a single `kubectl apply`.
+
+```
+gitops/argocd/
+├── app-of-apps.yml          ← Root Application (deploy this once)
+└── apps/
+    ├── apache.yml           ← Application for the Apache chart
+    ├── node-app.yml         ← Application for the node-app chart
+    └── monitoring.yml       ← Application for the Prometheus stack
+```
+
+Bootstrap sequence:
+```bash
+# 1. Install ArgoCD
+kubectl apply -k https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+
+# 2. Apply the root Application only — ArgoCD manages everything else
+kubectl apply -f gitops/argocd/app-of-apps.yml -n argocd
+```
+
+ArgoCD then automatically creates and syncs all child Applications.
+
+---
+
+## Multi-Cluster GitOps
+
+### ArgoCD Multi-Cluster
+
+ArgoCD runs in one "hub" cluster and deploys to many "spoke" clusters:
+
+```bash
+# Add a spoke cluster to ArgoCD
+argocd cluster add my-spoke-cluster --name production-eu
+
+# Applications can target any registered cluster
+# destination:
+#   server: https://my-spoke-cluster-api.example.com
+#   namespace: apps
+```
+
+### Flux Multi-Cluster
+
+Each cluster runs its own Flux controllers, all pointing at the same Git repository but
+reading different paths:
+
+```
+gitops/
+├── clusters/
+│   ├── production-us/    ← Flux in prod-us reads this path
+│   │   └── kustomization.yaml
+│   └── production-eu/    ← Flux in prod-eu reads this path
+│       └── kustomization.yaml
+└── apps/                 ← Shared app definitions referenced by both clusters
+    ├── apache/
+    └── node-app/
+```
+
+---
+
+## Repository Structure for GitOps
+
+This repository follows the following GitOps layout:
+
+```
+gitops/
+├── README.md                   ← This file
+├── argocd/
+│   ├── install.md              ← ArgoCD installation guide
+│   ├── app-of-apps.yml         ← Root Application (bootstrap entry point)
+│   ├── app-project.yml         ← AppProject for RBAC scoping
+│   └── apps/                   ← Child Application manifests (one per service)
+└── flux/
+    └── README.md               ← Flux installation and usage guide
+```

--- a/gitops/argocd/app-of-apps.yml
+++ b/gitops/argocd/app-of-apps.yml
@@ -1,0 +1,86 @@
+---
+# App-of-Apps Root Application
+# =============================
+# This Application manages all other ArgoCD Applications in this repository.
+# Deploy this single manifest to bootstrap the entire platform:
+#
+#   kubectl apply -f gitops/argocd/app-of-apps.yml -n argocd
+#
+# ArgoCD will then discover and sync all Application manifests under
+# gitops/argocd/apps/ automatically. Adding a new Application manifest to
+# that directory will cause ArgoCD to create it on the next sync.
+#
+# Pattern reference:
+#   https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: app-of-apps
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: app-of-apps
+    app.kubernetes.io/instance: app-of-apps
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: bootstrap
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: argocd
+  annotations:
+    kubernetes.io/description: >-
+      Root ArgoCD Application that manages all child Applications in the
+      kube-platform GitOps repository. This is the single bootstrap entry point.
+    # Prevent ArgoCD from deleting this Application if it falls out of sync
+    # (would cause a cascade deletion of all managed applications).
+    argocd.argoproj.io/sync-options: Delete=false
+  # finalizers: [] — Omitting the default finalizer means deleting this
+  # Application will NOT delete child Applications (safer for the root app).
+  # To cascade-delete everything, add:
+  #   finalizers:
+  #     - resources-finalizer.argocd.argoproj.io
+spec:
+  # AppProject — scope this application to the kube-platform project.
+  # Uses 'default' here for bootstrapping; change to 'kube-platform' after
+  # applying app-project.yml.
+  project: default
+
+  source:
+    # Replace with your actual repository URL.
+    repoURL: https://github.com/your-org/your-kubernetes-repo.git
+
+    # Track the main branch. In production, consider pinning to a tag or SHA
+    # for immutable deployments.
+    targetRevision: main
+
+    # Directory containing child Application manifests.
+    # ArgoCD will render all .yml/.yaml files in this directory as manifests.
+    path: gitops/argocd/apps
+
+    # Directory-specific configuration.
+    directory:
+      # Recurse into subdirectories of apps/ if you use sub-folders per team.
+      recurse: true
+
+  destination:
+    # Deploy child Application resources to the ArgoCD namespace of this cluster.
+    server: https://kubernetes.default.svc
+    namespace: argocd
+
+  syncPolicy:
+    automated:
+      # Remove Application resources from the cluster when they are deleted from Git.
+      # Safe here because removing an Application manifest from Git is intentional.
+      prune: true
+
+      # Continuously reconcile — correct any manual changes to Application CRs.
+      selfHeal: true
+
+    syncOptions:
+      # Do not apply individual resource health checks (Applications manage their own).
+      - RespectIgnoreDifferences=true
+
+    # Retry failed syncs with exponential backoff.
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/gitops/argocd/app-project.yml
+++ b/gitops/argocd/app-project.yml
@@ -1,0 +1,174 @@
+---
+# ArgoCD AppProject — kube-platform
+# ===================================
+# An AppProject restricts what an Application can deploy, where it can deploy to,
+# and who can manage it. Think of it as a security boundary within ArgoCD.
+#
+# Apply this BEFORE creating Applications that reference this project:
+#   kubectl apply -f gitops/argocd/app-project.yml -n argocd
+#
+# Reference:
+#   https://argo-cd.readthedocs.io/en/stable/user-guide/projects/
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: kube-platform
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: kube-platform
+    app.kubernetes.io/instance: kube-platform
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: gitops
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: argocd
+  annotations:
+    kubernetes.io/description: >-
+      ArgoCD AppProject for the kube-platform team. Restricts deployments to
+      approved source repositories, destination namespaces, and resource types.
+  # finalizers: delete this project by removing apps first, then the project.
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+
+spec:
+  description: "kube-platform GitOps deployment project — production workloads"
+
+  # sourceRepos — allowlist of Git repositories this project can deploy from.
+  # Use specific URLs to prevent Applications in this project from deploying
+  # from untrusted repositories.
+  sourceRepos:
+    - https://github.com/your-org/your-kubernetes-repo.git
+    # Allow Bitnami Helm charts for infrastructure components.
+    - https://charts.bitnami.com/bitnami
+    # Allow ArgoCD Helm charts.
+    - https://argoproj.github.io/argo-helm
+
+  # destinations — allowlist of clusters and namespaces this project can deploy to.
+  # Each entry is an (cluster, namespace) pair. Use '*' to allow all namespaces
+  # within a specific cluster (but prefer explicit namespace lists in production).
+  destinations:
+    # Application workloads
+    - server: https://kubernetes.default.svc
+      namespace: webapps
+    - server: https://kubernetes.default.svc
+      namespace: apps
+    - server: https://kubernetes.default.svc
+      namespace: notes-app
+    # Platform tooling
+    - server: https://kubernetes.default.svc
+      namespace: monitoring
+    - server: https://kubernetes.default.svc
+      namespace: logging
+    - server: https://kubernetes.default.svc
+      namespace: ingress-nginx
+    # ArgoCD manages itself
+    - server: https://kubernetes.default.svc
+      namespace: argocd
+
+  # clusterResourceWhitelist — cluster-scoped resources this project can manage.
+  # Be conservative: only allow what is strictly needed.
+  # An empty list means no cluster-scoped resources are allowed.
+  clusterResourceWhitelist:
+    - group: ""
+      kind: Namespace
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRole
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+    - group: networking.k8s.io
+      kind: IngressClass
+    - group: storage.k8s.io
+      kind: StorageClass
+    - group: policy
+      kind: PodSecurityPolicy   # deprecated in 1.25; included for backward compat
+
+  # namespaceResourceWhitelist — namespace-scoped resources this project can manage.
+  # List explicitly to avoid accidentally allowing sensitive resource types.
+  namespaceResourceWhitelist:
+    # Core workload resources
+    - group: apps
+      kind: Deployment
+    - group: apps
+      kind: ReplicaSet
+    - group: apps
+      kind: StatefulSet
+    - group: apps
+      kind: DaemonSet
+    # Core v1 resources
+    - group: ""
+      kind: Service
+    - group: ""
+      kind: ServiceAccount
+    - group: ""
+      kind: ConfigMap
+    - group: ""
+      kind: Secret
+    - group: ""
+      kind: PersistentVolumeClaim
+    - group: ""
+      kind: Pod
+    # Networking
+    - group: networking.k8s.io
+      kind: Ingress
+    - group: networking.k8s.io
+      kind: NetworkPolicy
+    # Autoscaling
+    - group: autoscaling
+      kind: HorizontalPodAutoscaler
+    - group: policy
+      kind: PodDisruptionBudget
+    # RBAC (namespace-scoped)
+    - group: rbac.authorization.k8s.io
+      kind: Role
+    - group: rbac.authorization.k8s.io
+      kind: RoleBinding
+    # Batch
+    - group: batch
+      kind: Job
+    - group: batch
+      kind: CronJob
+
+  # namespaceResourceBlacklist — resources explicitly DENIED even if whitelisted.
+  # Use this to block sensitive resources within otherwise permitted groups.
+  namespaceResourceBlacklist:
+    # Prevent Applications in this project from managing ResourceQuotas
+    # (those are platform-team only resources).
+    - group: ""
+      kind: ResourceQuota
+    - group: ""
+      kind: LimitRange
+
+  # roles — project-level RBAC for ArgoCD users.
+  roles:
+    # Read-only access — for developers who need visibility without deploy rights.
+    - name: readonly
+      description: "Read-only access to kube-platform Applications"
+      policies:
+        - p, proj:kube-platform:readonly, applications, get, kube-platform/*, allow
+      groups:
+        - developers   # Maps to your SSO group name
+
+    # Deploy access — for senior engineers and the CI/CD service account.
+    - name: deployer
+      description: "Deploy access to kube-platform Applications"
+      policies:
+        - p, proj:kube-platform:deployer, applications, get, kube-platform/*, allow
+        - p, proj:kube-platform:deployer, applications, sync, kube-platform/*, allow
+        - p, proj:kube-platform:deployer, applications, override, kube-platform/*, allow
+      groups:
+        - senior-engineers
+        - ci-cd-service-accounts
+
+  # orphanedResources — warn when resources exist in a namespace that are NOT
+  # managed by any Application in this project. Useful for catching manual changes.
+  orphanedResources:
+    warn: true
+
+  # syncWindows — restrict when automated sync is allowed.
+  # Uncomment to prevent deployments during business-critical hours.
+  # syncWindows:
+  #   - kind: deny
+  #     schedule: "0 9 * * 1-5"     # Monday–Friday 09:00
+  #     duration: 8h                 # for 8 hours (business hours)
+  #     applications: ["*"]
+  #     namespaces: ["*"]
+  #     clusters: ["*"]

--- a/gitops/argocd/install.md
+++ b/gitops/argocd/install.md
@@ -1,0 +1,320 @@
+# ArgoCD Installation and Configuration Guide
+
+## Prerequisites
+
+- Kubernetes cluster (>= 1.25)
+- `kubectl` configured to talk to the cluster
+- `helm` >= 3.0 installed
+- `argocd` CLI installed (see below)
+
+---
+
+## Install the ArgoCD CLI
+
+```bash
+# macOS
+brew install argocd
+
+# Linux
+curl -sSL -o /usr/local/bin/argocd \
+  https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+chmod +x /usr/local/bin/argocd
+
+# Verify
+argocd version --client
+```
+
+---
+
+## Install ArgoCD via Helm (Recommended for Production)
+
+The Helm chart gives you full control over configuration via values.
+
+```bash
+# Add the ArgoCD Helm repository
+helm repo add argo https://argoproj.github.io/argo-helm
+helm repo update
+
+# Create the namespace
+kubectl create namespace argocd
+
+# Install ArgoCD with production settings
+helm upgrade --install argocd argo/argo-cd \
+  --namespace argocd \
+  --version 7.7.0 \
+  --set global.image.tag="v2.13.0" \
+  --set configs.params."server.insecure"=false \
+  --set server.service.type=ClusterIP \
+  --wait \
+  --timeout 10m
+```
+
+### Key Production Values to Override
+
+Create a `values-argocd-prod.yaml`:
+
+```yaml
+global:
+  image:
+    # Pin to a specific ArgoCD version — never use :latest in production
+    tag: "v2.13.0"
+
+configs:
+  params:
+    # Never run ArgoCD server without TLS in production
+    server.insecure: false
+  cm:
+    # Restrict which repositories ArgoCD can read (allowlist)
+    repositories: |
+      - url: https://github.com/your-org/your-repo.git
+        name: your-repo
+
+server:
+  # Use ClusterIP + Ingress in production (not LoadBalancer)
+  service:
+    type: ClusterIP
+  ingress:
+    enabled: true
+    ingressClassName: nginx
+    hostname: argocd.example.com
+    tls: true
+
+repoServer:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+applicationSet:
+  enabled: true
+
+notifications:
+  enabled: true
+```
+
+```bash
+helm upgrade --install argocd argo/argo-cd \
+  --namespace argocd \
+  -f values-argocd-prod.yaml \
+  --atomic \
+  --timeout 10m
+```
+
+---
+
+## Alternative: Install via Raw Manifests
+
+For quick cluster bootstrapping (not recommended for production):
+
+```bash
+kubectl create namespace argocd
+kubectl apply -n argocd \
+  -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+```
+
+---
+
+## Accessing the ArgoCD UI
+
+### Port-Forward (Development)
+
+```bash
+# Forward the ArgoCD server to localhost
+kubectl port-forward svc/argocd-server \
+  -n argocd \
+  8080:443
+
+# Open in browser
+open https://localhost:8080
+```
+
+### Get the Initial Admin Password
+
+The default admin password is auto-generated and stored as a Secret.
+
+```bash
+# Get the initial password
+kubectl -n argocd get secret argocd-initial-admin-secret \
+  -o jsonpath="{.data.password}" | base64 -d && echo
+
+# IMPORTANT: Change the password immediately after first login
+argocd account update-password
+```
+
+### Via Ingress (Production)
+
+After configuring Ingress, access ArgoCD at your configured hostname:
+
+```
+https://argocd.example.com
+```
+
+---
+
+## CLI Login
+
+```bash
+# Login via the UI hostname (production)
+argocd login argocd.example.com
+
+# Login via port-forward (development)
+argocd login localhost:8080 --insecure
+
+# Using SSO (if configured)
+argocd login argocd.example.com --sso
+```
+
+---
+
+## Connecting a Git Repository
+
+ArgoCD needs credentials to pull from private repositories.
+
+### HTTPS Repository
+
+```bash
+argocd repo add https://github.com/your-org/your-repo.git \
+  --username your-user \
+  --password your-token    # Use a GitHub PAT with 'repo' scope
+```
+
+### SSH Repository
+
+```bash
+# Add using an SSH private key
+argocd repo add git@github.com:your-org/your-repo.git \
+  --ssh-private-key-path ~/.ssh/id_rsa
+```
+
+### Declarative (GitOps way — preferred)
+
+Create a Secret in the `argocd` namespace:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-repo-creds
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+type: Opaque
+stringData:
+  url: https://github.com/your-org/your-repo.git
+  password: <github-pat>   # Use External Secrets Operator in production
+  username: not-used
+```
+
+```bash
+kubectl apply -f my-repo-creds.yaml
+```
+
+---
+
+## Creating Your First Application
+
+### Via the CLI
+
+```bash
+argocd app create apache \
+  --repo https://github.com/your-org/your-repo.git \
+  --path helm/apache \
+  --dest-server https://kubernetes.default.svc \
+  --dest-namespace webapps \
+  --sync-policy automated \
+  --auto-prune \
+  --self-heal \
+  --helm-set replicaCount=2
+```
+
+### Via a Manifest (Preferred — GitOps)
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apache
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/your-org/your-repo.git
+    targetRevision: main
+    path: helm/apache
+    helm:
+      valueFiles:
+        - values.yaml
+        - values-prod.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: webapps
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+```
+
+```bash
+kubectl apply -f gitops/argocd/apps/apache.yml -n argocd
+```
+
+---
+
+## Common ArgoCD CLI Commands
+
+```bash
+# List all applications
+argocd app list
+
+# Get application details and sync status
+argocd app get apache
+
+# Manually sync an application (force reconciliation)
+argocd app sync apache
+
+# Wait for sync to complete
+argocd app wait apache --sync --health
+
+# View application diff (what would change)
+argocd app diff apache
+
+# Rollback to a previous deployment
+argocd app rollback apache
+
+# View application history
+argocd app history apache
+
+# Hard refresh (bypass cache, fetch latest from Git)
+argocd app get apache --hard-refresh
+
+# Delete an application (does NOT delete cluster resources)
+argocd app delete apache
+
+# Delete application AND cluster resources
+argocd app delete apache --cascade
+```
+
+---
+
+## Troubleshooting
+
+```bash
+# Check ArgoCD component status
+kubectl get pods -n argocd
+
+# View ArgoCD server logs
+kubectl logs -n argocd deployment/argocd-server -f
+
+# View application controller logs (reconciliation)
+kubectl logs -n argocd deployment/argocd-application-controller -f
+
+# View repo server logs (template rendering)
+kubectl logs -n argocd deployment/argocd-repo-server -f
+
+# Describe a failing application
+argocd app get apache --output json | jq .status.conditions
+```


### PR DESCRIPTION
## Summary
- Add `gitops/README.md` — GitOps principles, pull-based vs push-based deployment comparison, ArgoCD vs Flux feature matrix
- Add `gitops/argocd/install.md` — Helm install, initial admin password retrieval, `argocd` CLI login, RBAC configuration, and namespace setup
- Add `gitops/argocd/app-project.yml` — AppProject scoping: allowed source repos, destination cluster/namespace, denied resource kinds (prevents cluster-admin escalation), and role definitions
- Add `gitops/argocd/app-of-apps.yml` — Root Application with `sync-wave` annotations managing child Applications; `syncPolicy.automated.prune: true`, `selfHeal: true`; `ignoreDifferences` for HPA replicas

## Issues referenced
Closes #59, #60, relates to #61, #62

## Test plan
- [ ] `make install-argocd` completes without error
- [ ] App-of-Apps appears in ArgoCD UI as `Synced`
- [ ] AppProject restricts Applications to only allowed repos and namespaces