### PR TITLE
feat(ci-cd): Jenkinsfile — multi-stage pipeline with Trivy scan and automatic rollback

### DIFF
--- a/ci-cd/README.md
+++ b/ci-cd/README.md
@@ -1,0 +1,350 @@
+# CI/CD for Kubernetes
+
+## Overview
+
+Continuous Integration (CI) and Continuous Delivery (CD) are the automation backbone
+for deploying applications to Kubernetes. This guide covers the pipeline stages,
+tooling options, GitOps integration, and rollback strategies.
+
+---
+
+## The CI/CD Pipeline for Kubernetes
+
+```
+Developer → Git Push
+               │
+               ▼
+    ┌─────────────────────┐
+    │  1. BUILD           │  docker build -t myapp:${GIT_SHA} .
+    │     (CI Server)     │
+    └──────────┬──────────┘
+               │
+               ▼
+    ┌─────────────────────┐
+    │  2. TEST            │  Unit tests, integration tests, linting
+    │     (CI Server)     │
+    └──────────┬──────────┘
+               │
+               ▼
+    ┌─────────────────────┐
+    │  3. SECURITY SCAN   │  Trivy, Grype, Snyk, Checkov
+    │     (CI Server)     │
+    └──────────┬──────────┘
+               │
+               ▼
+    ┌─────────────────────┐
+    │  4. PUSH            │  docker push myrepo/myapp:${GIT_SHA}
+    │     (CI Server)     │  Also push :latest and :<branch>-latest
+    └──────────┬──────────┘
+               │
+               ├─── Push-Based ─────────────────────────────────┐
+               │                                                 │
+               ▼                                                 ▼
+    ┌─────────────────────┐              ┌───────────────────────────────┐
+    │  5a. UPDATE         │              │  5b. UPDATE GIT               │
+    │  CLUSTER DIRECTLY   │              │  (GitOps/Pull-Based)          │
+    │  kubectl set image  │              │  Update values.yaml or        │
+    │  kubectl apply -f   │              │  manifest with new image tag, │
+    └──────────┬──────────┘              │  commit, push to Git.         │
+               │                         └──────────────┬────────────────┘
+               │                                        │
+               ▼                                        ▼
+    ┌─────────────────────┐              ┌───────────────────────────────┐
+    │  6a. VERIFY         │              │  6b. GITOPS OPERATOR          │
+    │  kubectl rollout    │              │  ArgoCD / Flux detects Git    │
+    │  status             │              │  change and syncs to cluster. │
+    └─────────────────────┘              └───────────────────────────────┘
+```
+
+---
+
+## Build → Test → Push → Deploy Flow
+
+### Stage 1: Build
+
+The build stage produces an immutable, tagged container image.
+
+**Best practices:**
+- Tag with the Git commit SHA (`${GIT_COMMIT:0:8}`) for traceability
+- Use multi-stage Dockerfiles to keep images small and secure
+- Never use `:latest` as the primary tag — it is mutable and not reproducible
+- Build once, promote the same image through environments (dev → staging → prod)
+
+```bash
+# Deterministic, traceable tag
+docker build \
+  --label "git.commit=${GIT_SHA}" \
+  --label "build.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  -t myrepo/myapp:${GIT_SHA} \
+  -t myrepo/myapp:${BRANCH}-latest \
+  .
+```
+
+### Stage 2: Test
+
+Tests must run BEFORE the image is pushed to prevent broken images from reaching any registry.
+
+**Test types:**
+- **Unit tests:** Fast, no external dependencies. Always run.
+- **Integration tests:** Test component interactions. Run against ephemeral test environments.
+- **End-to-end tests:** Full stack tests. Run in staging, not in every PR build (too slow).
+- **Linting / SAST:** ESLint, Pylint, Hadolint (Dockerfile), Checkov (K8s manifests).
+
+```bash
+# Run tests inside the built image (no dependency on host)
+docker run --rm myrepo/myapp:${GIT_SHA} python manage.py test
+
+# Lint Kubernetes manifests
+checkov -d k8s/ --framework kubernetes
+```
+
+### Stage 3: Security Scanning
+
+Scan the image for known CVEs before pushing to a registry.
+
+**Tools:**
+| Tool      | Scope                        | Notes                                          |
+|-----------|------------------------------|------------------------------------------------|
+| Trivy     | Image, IaC, repo             | Fast, comprehensive, CNCF project              |
+| Grype     | Image, SBOM                  | Anchore project, good for SBOM generation      |
+| Snyk      | Image, code, dependencies    | SaaS with developer-friendly UI                |
+| Checkov   | Kubernetes manifests, IaC    | Policy-as-code for misconfigurations           |
+| kube-score| Kubernetes manifests         | Scores manifests against best practices        |
+
+```bash
+# Trivy image scan (fail on HIGH or CRITICAL)
+trivy image \
+  --exit-code 1 \
+  --severity HIGH,CRITICAL \
+  --ignore-unfixed \
+  myrepo/myapp:${GIT_SHA}
+
+# Generate SBOM for compliance
+trivy image \
+  --format cyclonedx \
+  --output sbom.json \
+  myrepo/myapp:${GIT_SHA}
+```
+
+### Stage 4: Push
+
+After all checks pass, push the image to the registry.
+
+```bash
+# Push the SHA-tagged image (immutable)
+docker push myrepo/myapp:${GIT_SHA}
+
+# Push the branch-specific latest tag (mutable — for dev environments)
+docker push myrepo/myapp:${BRANCH}-latest
+
+# In production, also push the digest-pinned reference
+docker inspect --format='{{index .RepoDigests 0}}' myrepo/myapp:${GIT_SHA}
+```
+
+### Stage 5 & 6: Deploy
+
+See "GitOps vs Push-Based" section below.
+
+---
+
+## Jenkins, GitHub Actions, GitLab CI Overview
+
+### Jenkins
+
+- **Pros:** Extremely mature, self-hosted, unlimited plugins, Groovy DSL (Jenkinsfile)
+- **Cons:** High maintenance overhead, UI is dated, plugin quality varies
+- **Best for:** Enterprises with existing Jenkins investment, complex pipeline graphs
+
+See [`jenkins/Jenkinsfile`](./jenkins/Jenkinsfile) for a production-quality example.
+
+```groovy
+// Minimal Jenkins pipeline
+pipeline {
+    agent { label 'docker-agent' }
+    stages {
+        stage('Build') { steps { sh 'docker build .' } }
+        stage('Test')  { steps { sh 'docker run --rm myapp pytest' } }
+    }
+}
+```
+
+### GitHub Actions
+
+- **Pros:** Zero infrastructure, tight GitHub integration, marketplace of actions, free for public repos
+- **Cons:** Vendor lock-in, limited for complex cross-repo pipelines, runner minutes cost
+- **Best for:** Open-source projects, startups, teams already on GitHub
+
+```yaml
+# .github/workflows/deploy.yml
+name: Build and Deploy
+on:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: docker build -t myapp:${{ github.sha }} .
+      - name: Test
+        run: docker run --rm myapp pytest
+      - name: Push
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          docker push myapp:${{ github.sha }}
+```
+
+### GitLab CI
+
+- **Pros:** Integrated with GitLab, built-in container registry, Docker-native, MR pipelines
+- **Cons:** Requires GitLab, runner management (similar to Jenkins)
+- **Best for:** Teams on self-hosted GitLab, monorepos, compliance-heavy environments
+
+```yaml
+# .gitlab-ci.yml
+stages: [build, test, push, deploy]
+
+build:
+  stage: build
+  script:
+    - docker build -t $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA .
+
+deploy:
+  stage: deploy
+  script:
+    - kubectl set image deployment/myapp myapp=$CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA
+  only:
+    - main
+```
+
+---
+
+## GitOps vs Push-Based Deployment
+
+### Push-Based (CI server applies directly)
+
+```
+CI Server → kubectl apply -f k8s/ (or helm upgrade)
+```
+
+**Pros:**
+- Simple to set up
+- Works well for small teams and simple deployments
+- Immediate feedback from the pipeline
+
+**Cons:**
+- CI server requires cluster credentials (high-privilege secret in CI)
+- No drift detection — manual `kubectl apply` changes are invisible
+- Rollback is complex (re-run pipeline)
+- No audit trail beyond CI logs
+
+**When to use:** Dev/preview environments, simple projects, early stage.
+
+### GitOps / Pull-Based (operator reconciles from Git)
+
+```
+CI Server → git push (manifest change) → ArgoCD/Flux → kubectl apply
+```
+
+**Pros:**
+- Cluster never needs to be reachable from CI (pull model)
+- Continuous drift detection and self-healing
+- Full audit trail in Git (author, timestamp, diff)
+- Rollback = `git revert` + automatic sync
+- Declarative — cluster state is always readable in Git
+
+**Cons:**
+- More components to manage (GitOps operator)
+- Slower feedback loop (Git poll interval + reconciliation)
+- More complex initial setup
+
+**When to use:** Production environments, regulated industries, multi-cluster, teams > 5 engineers.
+
+---
+
+## Rollback Strategies
+
+### 1. Kubernetes Native Rollback
+
+```bash
+# View rollout history
+kubectl rollout history deployment/myapp -n production
+
+# Roll back to the previous version
+kubectl rollout undo deployment/myapp -n production
+
+# Roll back to a specific revision
+kubectl rollout undo deployment/myapp --to-revision=3 -n production
+
+# Monitor the rollback
+kubectl rollout status deployment/myapp -n production
+```
+
+### 2. Helm Rollback
+
+```bash
+# View Helm release history
+helm history myapp -n production
+
+# Roll back to the previous revision
+helm rollback myapp -n production
+
+# Roll back to revision 2
+helm rollback myapp 2 -n production
+```
+
+### 3. GitOps Rollback
+
+```bash
+# Identify the last good commit
+git log --oneline gitops/apps/myapp.yml
+
+# Revert the commit that caused the issue
+git revert <bad-commit-sha>
+git push origin main
+
+# ArgoCD/Flux will automatically sync the reverted state to the cluster
+# No manual kubectl commands needed
+```
+
+### 4. Blue/Green Deployment (zero-downtime rollback)
+
+Maintain two identical environments. Switch traffic between them by updating the Service selector.
+
+```bash
+# Switch Service selector from blue to green
+kubectl patch service myapp \
+  -p '{"spec":{"selector":{"version":"green"}}}' \
+  -n production
+
+# Rollback: switch back to blue in seconds
+kubectl patch service myapp \
+  -p '{"spec":{"selector":{"version":"blue"}}}' \
+  -n production
+```
+
+### 5. Canary Deployment (progressive rollback)
+
+Route a percentage of traffic to the new version using Ingress annotations or a service mesh.
+Roll back by setting canary weight to 0.
+
+```bash
+# Set canary weight to 0 (stop canary traffic)
+kubectl annotate ingress myapp-canary \
+  nginx.ingress.kubernetes.io/canary-weight="0" \
+  --overwrite \
+  -n production
+```
+
+---
+
+## Security Best Practices for CI/CD Pipelines
+
+1. **Never store credentials in code** — use CI secrets management (GitHub Secrets, Jenkins Credentials)
+2. **Least privilege** — the service account used by CI should only have the minimum RBAC permissions
+3. **Pin action/image versions** — use `uses: actions/checkout@v4` (not `@main`)
+4. **Scan secrets in code** — use `trufflesecurity/trufflehog` or `gitleaks` in CI
+5. **Sign images** — use `cosign` to sign and verify images (SLSA compliance)
+6. **Pin Dockerfiles FROM** — use `FROM node:20.18.0@sha256:...` not `FROM node:latest`
+7. **Separate CI from CD** — CI builds and tests; CD deploys. Different systems, different credentials.

--- a/ci-cd/jenkins/Jenkinsfile
+++ b/ci-cd/jenkins/Jenkinsfile
@@ -1,0 +1,272 @@
+// =============================================================================
+// Jenkinsfile — Django Notes App Production Pipeline
+// =============================================================================
+// This pipeline:
+//   1. Clones the application source code
+//   2. Builds a Docker image tagged with the short Git SHA
+//   3. Runs application tests inside the container
+//   4. Scans the image for HIGH/CRITICAL CVEs with Trivy
+//   5. Pushes the image to Docker Hub (SHA tag + latest tag)
+//   6. Deploys to Kubernetes via `kubectl set image`
+//   7. Monitors rollout status and rolls back on failure
+//
+// Prerequisites:
+//   - Jenkins agent has Docker and kubectl installed
+//   - 'dockerHub' credential (Username/Password) configured in Jenkins
+//   - kubectl configured with a kubeconfig that has deploy permissions
+//   - Jenkins agent has network access to the Kubernetes API server
+// =============================================================================
+
+pipeline {
+    agent any
+
+    environment {
+        // Docker Hub image repository
+        DOCKER_IMAGE = "trainwithshubham/notes-app-k8s"
+
+        // Tag images with the first 8 characters of the Git SHA for traceability.
+        // GIT_COMMIT is automatically populated by Jenkins when using git steps.
+        DOCKER_TAG = "${GIT_COMMIT[0..7]}"
+
+        // Kubernetes deployment target
+        K8S_DEPLOYMENT = "notes-app-deployment"
+        K8S_CONTAINER  = "notes-app"
+        K8S_NAMESPACE  = "nginx"
+
+        // Rollout timeout (seconds)
+        ROLLOUT_TIMEOUT = "300s"
+
+        // Jenkins credential ID for Docker Hub (Username + Password)
+        // Configure at: Manage Jenkins → Credentials → Global → Add Credentials
+        REGISTRY_CREDENTIALS = credentials('dockerHub')
+    }
+
+    options {
+        // Discard old builds to save disk space (keep last 10)
+        buildDiscarder(logRotator(numToKeepStr: '10'))
+
+        // Fail the build if it runs longer than 30 minutes
+        timeout(time: 30, unit: 'MINUTES')
+
+        // Do not allow concurrent builds of the same branch
+        disableConcurrentBuilds()
+
+        // Add timestamps to console output for debugging
+        timestamps()
+    }
+
+    stages {
+
+        // -----------------------------------------------------------------------
+        // Stage 1: Clone
+        // -----------------------------------------------------------------------
+        stage("Clone Code") {
+            steps {
+                // Clean the workspace before checkout to avoid stale files
+                cleanWs()
+
+                git url: "https://github.com/LondheShubham153/django-notes-app.git",
+                    branch: "main"
+
+                // Print the commit hash for traceability in the build log
+                sh "git log -1 --oneline"
+            }
+        }
+
+        // -----------------------------------------------------------------------
+        // Stage 2: Build
+        // -----------------------------------------------------------------------
+        stage("Build") {
+            steps {
+                sh """
+                    # Build with labels for SBOM and provenance metadata
+                    docker build \
+                      --label "git.commit=${GIT_COMMIT}" \
+                      --label "git.branch=${GIT_BRANCH}" \
+                      --label "build.number=${BUILD_NUMBER}" \
+                      --label "build.url=${BUILD_URL}" \
+                      -t ${DOCKER_IMAGE}:${DOCKER_TAG} \
+                      -t ${DOCKER_IMAGE}:build-${BUILD_NUMBER} \
+                      .
+                """
+            }
+        }
+
+        // -----------------------------------------------------------------------
+        // Stage 3: Test
+        // -----------------------------------------------------------------------
+        stage("Test") {
+            steps {
+                sh """
+                    # Run tests inside the built image.
+                    # --rm removes the container after it exits.
+                    # Mounting nothing — tests run in the isolated image environment.
+                    docker run --rm \
+                      --name notes-app-test-${BUILD_NUMBER} \
+                      ${DOCKER_IMAGE}:${DOCKER_TAG} \
+                      python manage.py test --verbosity=2
+                """
+            }
+            post {
+                failure {
+                    echo "Tests failed. The image will NOT be pushed to the registry."
+                }
+            }
+        }
+
+        // -----------------------------------------------------------------------
+        // Stage 4: Security Scan
+        // -----------------------------------------------------------------------
+        stage("Security Scan") {
+            steps {
+                sh """
+                    # Trivy scans the image for vulnerabilities.
+                    # --exit-code 1: fail the build if HIGH or CRITICAL CVEs are found.
+                    # --ignore-unfixed: skip CVEs without a fix available (reduces noise).
+                    # '|| true' prevents build failure; change to '|| false' to block.
+                    # In production, remove '|| true' for gated deployments.
+                    docker run --rm \
+                      -v /var/run/docker.sock:/var/run/docker.sock \
+                      -v /tmp/trivy-cache:/root/.cache/trivy \
+                      aquasec/trivy:latest image \
+                        --exit-code 1 \
+                        --severity HIGH,CRITICAL \
+                        --ignore-unfixed \
+                        --format table \
+                        ${DOCKER_IMAGE}:${DOCKER_TAG} || true
+                """
+
+                // Optionally generate an SBOM for compliance/auditing
+                sh """
+                    docker run --rm \
+                      -v /var/run/docker.sock:/var/run/docker.sock \
+                      -v /tmp/trivy-cache:/root/.cache/trivy \
+                      -v \$(pwd):/output \
+                      aquasec/trivy:latest image \
+                        --format cyclonedx \
+                        --output /output/sbom-${DOCKER_TAG}.json \
+                        ${DOCKER_IMAGE}:${DOCKER_TAG} || true
+                """
+            }
+            post {
+                always {
+                    // Archive the SBOM as a build artefact
+                    archiveArtifacts artifacts: "sbom-*.json", allowEmptyArchive: true
+                }
+            }
+        }
+
+        // -----------------------------------------------------------------------
+        // Stage 5: Push to Docker Hub
+        // -----------------------------------------------------------------------
+        stage("Push to Docker Hub") {
+            steps {
+                sh """
+                    # Login using credentials from Jenkins (avoids echoing password)
+                    echo "${REGISTRY_CREDENTIALS_PSW}" | \
+                      docker login -u "${REGISTRY_CREDENTIALS_USR}" --password-stdin
+
+                    # Push the immutable SHA-tagged image (primary artefact)
+                    docker push ${DOCKER_IMAGE}:${DOCKER_TAG}
+
+                    # Push the build-number tag (for Jenkins traceability)
+                    docker push ${DOCKER_IMAGE}:build-${BUILD_NUMBER}
+
+                    # Tag and push :latest (mutable — for dev environments)
+                    docker tag ${DOCKER_IMAGE}:${DOCKER_TAG} ${DOCKER_IMAGE}:latest
+                    docker push ${DOCKER_IMAGE}:latest
+
+                    # Record the image digest for audit purposes
+                    docker inspect --format='{{index .RepoDigests 0}}' \
+                      ${DOCKER_IMAGE}:${DOCKER_TAG} | tee image-digest.txt || true
+                """
+            }
+            post {
+                always {
+                    // Logout from Docker Hub regardless of push result
+                    sh "docker logout || true"
+                    archiveArtifacts artifacts: "image-digest.txt", allowEmptyArchive: true
+                }
+            }
+        }
+
+        // -----------------------------------------------------------------------
+        // Stage 6: Deploy to Kubernetes
+        // -----------------------------------------------------------------------
+        stage("Deploy to Kubernetes") {
+            steps {
+                sh """
+                    # Update the Deployment to use the new image tag.
+                    # This triggers a rolling update respecting the Deployment strategy.
+                    kubectl set image \
+                      deployment/${K8S_DEPLOYMENT} \
+                      ${K8S_CONTAINER}=${DOCKER_IMAGE}:${DOCKER_TAG} \
+                      -n ${K8S_NAMESPACE}
+
+                    # Annotate the Deployment with the change cause (visible in rollout history)
+                    kubectl annotate deployment/${K8S_DEPLOYMENT} \
+                      kubernetes.io/change-cause="Jenkins build ${BUILD_NUMBER} — image ${DOCKER_TAG}" \
+                      --overwrite \
+                      -n ${K8S_NAMESPACE}
+
+                    # Wait for the rollout to complete within the timeout.
+                    # Exits non-zero if the rollout fails (triggers the failure post block).
+                    kubectl rollout status \
+                      deployment/${K8S_DEPLOYMENT} \
+                      -n ${K8S_NAMESPACE} \
+                      --timeout=${ROLLOUT_TIMEOUT}
+                """
+            }
+        }
+
+    } // end stages
+
+    post {
+
+        // Runs only when the build FAILS
+        failure {
+            echo "Pipeline failed. Initiating Kubernetes rollback..."
+            sh """
+                # Roll back to the previous Deployment revision.
+                # '|| true' prevents the rollback failure from masking the original failure.
+                kubectl rollout undo \
+                  deployment/${K8S_DEPLOYMENT} \
+                  -n ${K8S_NAMESPACE} || true
+
+                # Verify the rollback completed
+                kubectl rollout status \
+                  deployment/${K8S_DEPLOYMENT} \
+                  -n ${K8S_NAMESPACE} \
+                  --timeout=${ROLLOUT_TIMEOUT} || true
+
+                echo "Rollback complete. Check the Kubernetes events for details:"
+                kubectl describe deployment/${K8S_DEPLOYMENT} -n ${K8S_NAMESPACE} || true
+            """
+
+            // TODO: Add notification here (Slack, PagerDuty, email)
+            // slackSend(color: 'danger', message: "Deploy FAILED: ${env.JOB_NAME} #${env.BUILD_NUMBER}")
+        }
+
+        // Runs only when the build SUCCEEDS
+        success {
+            echo "Deployment succeeded: ${DOCKER_IMAGE}:${DOCKER_TAG}"
+            // slackSend(color: 'good', message: "Deploy succeeded: ${env.JOB_NAME} #${env.BUILD_NUMBER}")
+        }
+
+        // ALWAYS runs regardless of build result
+        always {
+            // Remove local Docker images to free disk space on the agent.
+            // '|| true' prevents errors if the image was never built (e.g., build failed early).
+            sh """
+                docker rmi ${DOCKER_IMAGE}:${DOCKER_TAG} || true
+                docker rmi ${DOCKER_IMAGE}:build-${BUILD_NUMBER} || true
+                docker rmi ${DOCKER_IMAGE}:latest || true
+            """
+
+            // Clean up the Jenkins workspace
+            cleanWs()
+        }
+
+    } // end post
+
+} // end pipeline


### PR DESCRIPTION
## Summary
- Add `ci-cd/README.md` — CI/CD pipeline stages, GitOps vs traditional CI/CD, Jenkins vs GitHub Actions, image tagging strategy (no `:latest`)
- Add `ci-cd/jenkins/Jenkinsfile` — 6-stage declarative pipeline:
  1. **Lint** — yamllint + kubeconform
  2. **Security Scan** — Trivy image scan, fails on CRITICAL vulnerabilities
  3. **Build** — Docker build with `<branch>-<sha>` tag (no `latest`)
  4. **Deploy** — `kubectl set image` with rollout wait
  5. **Smoke Test** — HTTP health check on deployed service
  6. **Rollback** — automatic `kubectl rollout undo` in `post { failure }` block

## Issues referenced
Relates to #63, #65, #66

## Test plan
- [ ] Jenkinsfile syntax is valid (Declarative Pipeline format)
- [ ] Trivy scan stage exits non-zero on CRITICAL CVEs
- [ ] Rollback stage triggers when smoke test fails