### PR TITLE
feat(examples): nginx reference — intro and production-baseline with full security posture

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,214 @@
+# Examples
+
+This directory contains working, annotated Kubernetes manifests organised into learning
+progressions. Each sub-directory builds on the previous one, introducing new concepts
+and production requirements.
+
+---
+
+## Learning Paths
+
+### Path 1: Platform Engineer (recommended order)
+
+1. [`nginx-reference/01-intro/`](#1-nginx-intro) — Core Kubernetes objects: Pod, Deployment, Service
+2. [`nginx-reference/02-production-baseline/`](#2-nginx-production-baseline) — Production requirements: security contexts, probes, PDB, NetworkPolicy, HPA
+3. [`django-notes-app/`](#3-django-notes-app) — Full application: Dockerfile, multi-resource K8s deploy, Ingress, HPA
+
+### Path 2: Application Developer
+
+1. [`django-notes-app/`](#3-django-notes-app) — Deploy a real Django application to Kubernetes
+2. [`nginx-reference/02-production-baseline/`](#2-nginx-production-baseline) — Understand the production requirements your platform team enforces
+
+---
+
+## Prerequisites
+
+| Tool       | Version | Installation                             |
+|------------|---------|------------------------------------------|
+| kubectl    | >= 1.28 | https://kubernetes.io/docs/tasks/tools/ |
+| Helm       | >= 3.14 | https://helm.sh/docs/intro/install/     |
+| Docker     | >= 24   | https://docs.docker.com/get-docker/     |
+| minikube   | >= 1.32 | https://minikube.sigs.k8s.io/           |
+
+### Start a Local Cluster
+
+```bash
+# Using minikube
+minikube start --cpus=4 --memory=4g --driver=docker
+
+# Using kind (Kubernetes in Docker)
+kind create cluster --name kube-platform
+
+# Verify
+kubectl cluster-info
+kubectl get nodes
+```
+
+---
+
+## 1. Nginx Intro
+
+**Path:** `nginx-reference/01-intro/`
+
+**What you learn:**
+- What a Pod is and how to create one
+- What a Deployment is and why you should never run bare Pods in production
+- What a Service is and how traffic routing works
+
+**Files:**
+| File             | Description                                         |
+|------------------|-----------------------------------------------------|
+| `pod.yml`        | Minimal nginx Pod — learning only, not for prod     |
+| `deployment.yml` | Deployment with 1 replica — introductory            |
+| `service.yml`    | NodePort Service to expose the Deployment           |
+| `README.md`      | Step-by-step guide                                  |
+
+**Quick start:**
+
+```bash
+# Apply all intro files
+kubectl apply -f examples/nginx-reference/01-intro/
+
+# Verify
+kubectl get pods,svc
+
+# Access via minikube
+minikube service nginx-service
+
+# Clean up
+kubectl delete -f examples/nginx-reference/01-intro/
+```
+
+---
+
+## 2. Nginx Production Baseline
+
+**Path:** `nginx-reference/02-production-baseline/`
+
+**What you learn:**
+- Pod Security Standards (Restricted)
+- Security contexts (runAsNonRoot, readOnlyRootFilesystem, capabilities drop)
+- Resource requests and limits
+- Liveness, readiness, and startup probes
+- PodDisruptionBudget for HA during node drains
+- HorizontalPodAutoscaler for traffic-based scaling
+- NetworkPolicy for zero-trust networking
+
+**Files:**
+| File                 | Description                                             |
+|----------------------|---------------------------------------------------------|
+| `namespace.yml`      | Namespace with PSA labels enforcing Restricted policy   |
+| `deployment.yml`     | Full production Deployment — all security contexts      |
+| `service.yml`        | ClusterIP Service                                       |
+| `hpa.yml`            | HPA with CPU + memory metrics and behavior block        |
+| `pdb.yml`            | PodDisruptionBudget: minAvailable: 1                   |
+| `network-policy.yml` | Default deny-all + allow ingress controller egress      |
+| `README.md`          | Explanation of every field and why it exists            |
+
+**Quick start:**
+
+```bash
+kubectl apply -f examples/nginx-reference/02-production-baseline/
+
+# Monitor the HPA
+kubectl get hpa -n production-baseline -w
+
+# Test PDB (try to drain a node — should be blocked)
+kubectl drain <node-name> --dry-run=client
+
+# Clean up
+kubectl delete -f examples/nginx-reference/02-production-baseline/
+kubectl delete namespace production-baseline
+```
+
+---
+
+## 3. Django Notes App
+
+**Path:** `django-notes-app/`
+
+**What you learn:**
+- Multi-stage Dockerfile for Python applications
+- Complete Kubernetes deployment for a stateful web application
+- Ingress with TLS termination
+- HPA for a web application
+- ArgoCD GitOps integration
+
+**Files:**
+| File                  | Description                                              |
+|-----------------------|----------------------------------------------------------|
+| `Dockerfile`          | Multi-stage Python build (builder + runtime)             |
+| `README.md`           | Architecture, build, and deployment guide                |
+| `k8s/namespace.yml`   | notes-app namespace                                      |
+| `k8s/deployment.yml`  | Production Django Deployment                             |
+| `k8s/service.yml`     | ClusterIP Service                                        |
+| `k8s/hpa.yml`         | HPA                                                      |
+| `k8s/pdb.yml`         | PodDisruptionBudget                                      |
+| `k8s/ingress.yml`     | Ingress with TLS                                         |
+
+**Quick start:**
+
+```bash
+# Build the image locally (for minikube)
+eval $(minikube docker-env)
+docker build -t notes-app:local examples/django-notes-app/
+
+# Deploy
+kubectl apply -f examples/django-notes-app/k8s/
+
+# Access via port-forward
+kubectl port-forward svc/notes-app -n notes-app 8080:80
+
+# Clean up
+kubectl delete -f examples/django-notes-app/k8s/
+kubectl delete namespace notes-app
+```
+
+---
+
+## Conventions Used in These Examples
+
+### Label Standard
+
+All resources use the full `app.kubernetes.io/*` label set:
+
+```yaml
+labels:
+  app.kubernetes.io/name: nginx           # The application name
+  app.kubernetes.io/instance: nginx       # The release instance (unique per namespace)
+  app.kubernetes.io/version: "1.27"       # The application version
+  app.kubernetes.io/component: webserver  # The role of this resource
+  app.kubernetes.io/part-of: nginx        # The larger system this belongs to
+  app.kubernetes.io/managed-by: kubectl   # The tool managing this resource
+```
+
+### Security Baseline
+
+Every production example enforces:
+
+```yaml
+# Pod-level
+securityContext:
+  runAsNonRoot: true
+  runAsUser: <non-zero uid>
+  fsGroup: <non-zero gid>
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+```
+
+### Why No CPU Limits?
+
+CPU limits in Kubernetes cause CPU throttling — the process is artificially slowed even
+when physical CPU is available on the node. This causes latency spikes.
+
+The examples set CPU **requests** (for scheduling) but omit CPU **limits** (to avoid
+throttling). Memory limits are always set to prevent OOMKilled cascade failures.
+
+Reference: https://erickhun.com/posts/kubernetes-faster-services-no-cpu-limits/

--- a/examples/nginx-reference/01-intro/README.md
+++ b/examples/nginx-reference/01-intro/README.md
@@ -1,0 +1,165 @@
+# Intro — Core Kubernetes Objects
+
+This example introduces the three foundational Kubernetes objects:
+**Pod**, **Deployment**, and **Service**.
+
+---
+
+## What Each File Does
+
+### `pod.yml` — The Minimal Unit
+
+A Pod is a wrapper around one or more containers. This file creates a single nginx Pod.
+
+**Why you should never use bare Pods in production:**
+- If the Pod crashes, it is NOT automatically restarted (unlike a Deployment)
+- If the node the Pod runs on fails, the Pod is lost permanently
+- You cannot scale, update, or roll back bare Pods
+
+Use this to understand what a Pod is. In practice, always use a Deployment.
+
+### `deployment.yml` — Self-Healing, Scalable Pods
+
+A Deployment manages a ReplicaSet, which manages Pods. When a Pod crashes, the ReplicaSet
+controller creates a new one. When you update the Deployment spec, the rolling update
+controller replaces old Pods with new ones without downtime.
+
+Key Deployment fields explained:
+- `replicas: 1` — always maintain 1 running Pod
+- `selector.matchLabels` — the Deployment "owns" Pods with these labels (immutable)
+- `template` — the blueprint for every Pod this Deployment creates
+
+### `service.yml` — Stable Network Endpoint
+
+Pods get new IP addresses every time they restart. A Service gives you a stable DNS name
+and virtual IP that always routes to healthy Pods.
+
+This Service uses `NodePort` to expose nginx on port `30080` of every node in the cluster.
+This is the simplest way to access the app from outside the cluster during development.
+
+---
+
+## Step-by-Step Guide
+
+### 1. Apply all files
+
+```bash
+kubectl apply -f examples/nginx-reference/01-intro/
+```
+
+Expected output:
+```
+pod/nginx-pod created
+deployment.apps/nginx-deployment created
+service/nginx-service created
+```
+
+### 2. Verify the Pod is Running
+
+```bash
+kubectl get pods
+```
+
+Both the bare Pod and the Deployment's Pod should be Running:
+```
+NAME                                READY   STATUS    RESTARTS   AGE
+nginx-pod                           1/1     Running   0          10s
+nginx-deployment-6d84b876b5-abc12   1/1     Running   0          10s
+```
+
+### 3. Check the Deployment
+
+```bash
+kubectl get deployment nginx-deployment
+kubectl describe deployment nginx-deployment
+```
+
+### 4. Access the Application
+
+**Using minikube:**
+```bash
+minikube service nginx-service
+```
+
+**Using port-forward (works with any cluster):**
+```bash
+kubectl port-forward svc/nginx-service 8080:80
+# Open http://localhost:8080
+```
+
+**Direct NodePort (if you know your node IP):**
+```bash
+NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}')
+curl http://${NODE_IP}:30080
+```
+
+### 5. Scale the Deployment
+
+```bash
+# Scale to 3 replicas
+kubectl scale deployment nginx-deployment --replicas=3
+
+# Watch the new pods come up
+kubectl get pods -w
+```
+
+### 6. Simulate a Pod Crash
+
+```bash
+# Delete one of the Deployment's Pods
+POD=$(kubectl get pods -l app.kubernetes.io/name=nginx -o name | head -1)
+kubectl delete ${POD}
+
+# Watch the ReplicaSet immediately create a replacement
+kubectl get pods -w
+```
+
+Notice that the Deployment's Pod is immediately replaced. The bare Pod (`nginx-pod`)
+would NOT be replaced.
+
+### 7. Rolling Update
+
+```bash
+# Update the image version
+kubectl set image deployment/nginx-deployment nginx=nginx:1.27.1
+
+# Watch the rolling update
+kubectl rollout status deployment/nginx-deployment
+
+# View the rollout history
+kubectl rollout history deployment/nginx-deployment
+
+# Roll back to the previous version
+kubectl rollout undo deployment/nginx-deployment
+```
+
+### 8. Clean Up
+
+```bash
+kubectl delete -f examples/nginx-reference/01-intro/
+```
+
+---
+
+## Key Concepts Summary
+
+| Concept         | What It Does                                          | Production Use?   |
+|-----------------|-------------------------------------------------------|-------------------|
+| Pod             | Runs one or more containers                           | Never bare        |
+| ReplicaSet      | Maintains a desired number of Pod replicas            | Never directly    |
+| Deployment      | Manages ReplicaSets; handles updates and rollbacks    | Always            |
+| Service         | Stable network endpoint routing to Pods               | Always            |
+| NodePort        | Exposes Service on each node's IP                     | Dev/testing       |
+| ClusterIP       | Internal Service (use with Ingress for HTTP)          | Production        |
+
+---
+
+## Next Step
+
+Proceed to [`02-production-baseline/`](../02-production-baseline/README.md) to add:
+- Security contexts
+- Resource limits
+- Health probes
+- PodDisruptionBudget
+- NetworkPolicy
+- HorizontalPodAutoscaler

--- a/examples/nginx-reference/01-intro/deployment.yml
+++ b/examples/nginx-reference/01-intro/deployment.yml
@@ -1,0 +1,72 @@
+---
+# Deployment — Manages a ReplicaSet to ensure desired pod count
+# =============================================================
+# A Deployment:
+#   1. Creates a ReplicaSet (which creates and monitors Pods)
+#   2. Ensures the desired number of Pods is always running
+#   3. Handles rolling updates (replaces pods one at a time)
+#   4. Enables rollbacks to previous versions
+#
+# When to use a Deployment vs other controllers:
+#   Deployment     → Stateless applications (nginx, APIs, web apps)
+#   StatefulSet    → Stateful apps that need stable network IDs (databases, Kafka)
+#   DaemonSet      → One pod per node (log shippers, monitoring agents)
+#   Job/CronJob    → Batch tasks that run to completion
+#
+# Apply:    kubectl apply -f deployment.yml
+# Status:   kubectl rollout status deployment/nginx-deployment
+# History:  kubectl rollout history deployment/nginx-deployment
+# Rollback: kubectl rollout undo deployment/nginx-deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: nginx
+    app.kubernetes.io/version: "1.27"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: nginx
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "Intro nginx Deployment — 1 replica, basic settings for learning."
+spec:
+  # Number of identical pods to maintain.
+  # The ReplicaSet controller continuously reconciles the actual count to this number.
+  replicas: 1
+
+  # Selector — tells the Deployment which Pods it owns.
+  # IMMUTABLE after creation. Must match .spec.template.metadata.labels.
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx
+      app.kubernetes.io/instance: nginx
+
+  # Pod template — the blueprint for creating Pods.
+  # When you update this template, the Deployment rolls out new Pods.
+  template:
+    metadata:
+      # These labels MUST include all labels in selector.matchLabels above.
+      labels:
+        app.kubernetes.io/name: nginx
+        app.kubernetes.io/instance: nginx
+        app.kubernetes.io/version: "1.27"
+        app.kubernetes.io/component: webserver
+        app.kubernetes.io/part-of: nginx
+        app.kubernetes.io/managed-by: kubectl
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27
+
+          ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
+
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 64Mi

--- a/examples/nginx-reference/01-intro/pod.yml
+++ b/examples/nginx-reference/01-intro/pod.yml
@@ -1,0 +1,57 @@
+---
+# Pod — The smallest deployable unit in Kubernetes
+# =================================================
+# A Pod is a wrapper around one or more containers that share:
+#   - Network namespace (same IP address, share ports)
+#   - Storage volumes
+#   - Lifecycle (start/stop together)
+#
+# IMPORTANT: Do NOT run bare Pods in production.
+# If a Pod crashes or the node it runs on fails, it is NOT automatically
+# rescheduled. Use a Deployment instead.
+#
+# This file exists for LEARNING PURPOSES ONLY.
+#
+# Apply:   kubectl apply -f pod.yml
+# Delete:  kubectl delete -f pod.yml
+# Logs:    kubectl logs nginx-pod -c nginx
+# Shell:   kubectl exec -it nginx-pod -c nginx -- /bin/sh
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-pod
+  # Labels are key-value pairs attached to objects.
+  # They are used by selectors to find related resources (Services, HPA, etc.)
+  labels:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: nginx
+    app.kubernetes.io/version: "1.27"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: nginx
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "Intro nginx Pod — learning purposes only. Use a Deployment in production."
+spec:
+  containers:
+    - name: nginx
+      # Use a specific version tag, not :latest.
+      # :latest is a mutable tag — the image it points to can change without warning.
+      image: nginx:1.27
+
+      ports:
+        # Expose port 80 from the container.
+        # This is informational only — Kubernetes does not enforce port restrictions.
+        # The container must actually bind to this port for traffic to work.
+        - containerPort: 80
+          name: http
+          protocol: TCP
+
+      # Resource requests and limits
+      # Requests: what the scheduler uses to choose which node to place the pod on.
+      # Limits: hard upper bounds. Exceeding the memory limit = OOMKilled.
+      resources:
+        requests:
+          cpu: 50m       # 50 millicores = 0.05 vCPU
+          memory: 64Mi   # 64 mebibytes
+        limits:
+          memory: 64Mi   # No CPU limit — see examples/README.md for rationale

--- a/examples/nginx-reference/01-intro/service.yml
+++ b/examples/nginx-reference/01-intro/service.yml
@@ -1,0 +1,55 @@
+---
+# Service — Stable network endpoint for a set of Pods
+# =====================================================
+# Pods are ephemeral: they can be replaced at any time, getting new IP addresses.
+# A Service provides a stable virtual IP (ClusterIP) and DNS name that routes
+# traffic to matching Pods using a selector.
+#
+# Service types:
+#   ClusterIP    — Internal only (default). Accessible within the cluster only.
+#                  Use with Ingress for external HTTP/HTTPS traffic.
+#   NodePort     — Exposes a port on every cluster node (30000–32767 range).
+#                  Useful for development or non-HTTP protocols without a cloud LB.
+#   LoadBalancer — Provisions a cloud load balancer (AWS ELB, GCP LB, etc.).
+#                  Expensive for many services; prefer Ingress + ClusterIP.
+#   ExternalName — Maps the service to an external DNS name.
+#
+# This Service uses NodePort for easy local access with minikube.
+#
+# Apply:   kubectl apply -f service.yml
+# Access:  minikube service nginx-service
+# OR:      kubectl port-forward svc/nginx-service 8080:80
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  labels:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: nginx
+    app.kubernetes.io/version: "1.27"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: nginx
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "NodePort Service exposing the intro nginx Deployment."
+spec:
+  type: NodePort
+
+  ports:
+    # port: the port the Service itself listens on (within the cluster).
+    - port: 80
+      # targetPort: the port on the Pod the Service forwards traffic to.
+      # Must match the containerPort in the Pod/Deployment spec.
+      # Using the named port ("http") is preferred over hard-coding the number.
+      targetPort: http
+      protocol: TCP
+      name: http
+      # nodePort: optional. If omitted, Kubernetes assigns a random port (30000–32767).
+      # Fixed nodePort makes it predictable for scripts and bookmarks.
+      nodePort: 30080
+
+  # Selector — Service sends traffic to Pods with ALL of these labels.
+  # Must match the Pod template labels in the Deployment.
+  selector:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: nginx

--- a/examples/nginx-reference/02-production-baseline/README.md
+++ b/examples/nginx-reference/02-production-baseline/README.md
@@ -1,0 +1,224 @@
+# Production Baseline — nginx Reference
+
+This directory contains a complete, production-grade nginx deployment demonstrating
+all security and reliability requirements enforced on a hardened Kubernetes platform.
+
+Every setting is explained inline in the manifests. This README explains WHY each
+resource exists and how the pieces connect.
+
+---
+
+## Files and Why They Exist
+
+### `namespace.yml` — Security Boundary
+
+The Namespace does two things:
+
+1. **Isolation:** Resources in this namespace share a name space (pun intended) but
+   are isolated from resources in other namespaces by default.
+
+2. **Pod Security Admission (PSA):** The `pod-security.kubernetes.io/*` labels enforce
+   the **Restricted** Pod Security Standard. Any Pod that doesn't satisfy Restricted
+   requirements (non-root, no privilege escalation, seccomp, etc.) is **rejected**.
+
+```bash
+# See what PSA enforces in this namespace
+kubectl get namespace production-baseline -o yaml | grep pod-security
+```
+
+### `deployment.yml` — The Workload
+
+The Deployment is where most production requirements are implemented. Key decisions:
+
+#### Why `nginxinc/nginx-unprivileged`?
+
+Standard `nginx:1.27` listens on port 80. Binding to ports below 1024 requires the
+`NET_BIND_SERVICE` capability (or running as root). The Restricted PSS forbids both.
+
+`nginxinc/nginx-unprivileged:1.27` is the official nginx image configured to:
+- Run as UID 101 (not root)
+- Listen on port 8080 (not 80)
+- Drop all capabilities
+
+#### Why `readOnlyRootFilesystem: true`?
+
+Prevents an attacker who gains code execution from writing malicious files to the
+container's filesystem. Any legitimate writes must go to explicit volumes (emptyDir, PVC).
+
+nginx needs several writable directories:
+- `/tmp` — temp file storage
+- `/var/cache/nginx` — proxy and fastcgi cache
+- `/var/run` — PID file
+- `/var/log/nginx` — log files (redirected to stdout/stderr in prod)
+
+All four are backed by `emptyDir` volumes.
+
+#### Why no CPU limit?
+
+CPU limits in Kubernetes use Linux cgroups v1 CFS (Completely Fair Scheduler) quotas.
+When a container hits its CPU limit, the kernel throttles it — even if the node has
+spare CPU capacity.
+
+This causes **latency spikes** because the process is forced to wait for the next
+scheduler period (default: 100ms). For latency-sensitive services, this is harmful.
+
+The recommendation (widely adopted by production platforms): set CPU **requests** for
+scheduling, but omit CPU **limits**. Monitor actual CPU usage; if pods consistently
+approach the request value, increase the request.
+
+Reference: https://erickhun.com/posts/kubernetes-faster-services-no-cpu-limits/
+
+#### Why `preStop` sleep?
+
+When a pod is deleted:
+1. kube-proxy starts removing the pod's IP from iptables rules on all nodes
+2. The kubelet sends SIGTERM to the container
+3. Steps 1 and 2 happen **in parallel** — there is a race condition
+
+Without the sleep: the pod receives SIGTERM and stops, but kube-proxy hasn't finished
+propagating the endpoint removal. Requests arrive at a dead pod → 502 errors.
+
+With `sleep 5`: the pod waits 5 seconds before stopping, giving kube-proxy time to
+finish propagating. After the sleep, `nginx -s quit` gracefully drains in-flight requests.
+
+#### Why `minReadySeconds: 10`?
+
+After a pod passes its readiness probe, Kubernetes considers it "Ready." But "Ready"
+doesn't mean "fully warmed up." A pod might be ready after one successful health check
+but fail on the next request due to JIT compilation, cache warming, etc.
+
+`minReadySeconds: 10` requires the pod to remain continuously Ready for 10 seconds
+before the rolling update moves to the next pod. This prevents a flapping pod from
+being counted as Available prematurely.
+
+### `service.yml` — Stable Endpoint + ServiceAccount
+
+The **Service** provides a stable ClusterIP and DNS name (`nginx.production-baseline.svc.cluster.local`)
+that routes to healthy Pods. It also contains the **ServiceAccount** definition.
+
+Why a dedicated ServiceAccount?
+- Every namespace has a `default` ServiceAccount
+- Kubernetes auto-mounts a token for the `default` SA that has some permissions
+- By creating a dedicated SA with no permissions and `automountServiceAccountToken: false`,
+  we ensure that if the pod is compromised, the attacker gets no K8s API credentials
+
+### `hpa.yml` — Automatic Scaling
+
+The HPA watches CPU and memory utilisation and adjusts the replica count between 2 and 10.
+
+Key behavior decisions:
+- **Scale-up stabilization: 0s** — react immediately to traffic spikes
+- **Scale-down stabilization: 300s (5 min)** — wait 5 minutes before removing pods
+
+Why conservative scale-down? If you remove pods too quickly during a brief traffic dip,
+the next request spike catches you under-provisioned and you're scaling back up under
+load. The 5-minute window absorbs most traffic variance.
+
+### `pdb.yml` — High Availability During Maintenance
+
+The PDB says: "Never let more than 1 pod be unavailable at a time voluntarily."
+
+Without a PDB:
+- A cluster upgrade might drain 3 nodes simultaneously
+- Your 2-replica Deployment loses both pods → outage
+
+With `minAvailable: 1`:
+- The cluster must ensure 1 pod is Running and Ready before draining another node
+- Node drains happen sequentially, not in parallel
+- Rolling Deployment updates are also constrained by the PDB
+
+### `network-policy.yml` — Zero-Trust Networking
+
+Four policies work together:
+
+1. **`default-deny-all`** — blocks all ingress and egress by default
+2. **`allow-ingress-controller`** — allows the nginx Ingress controller to route to pods
+3. **`allow-dns-egress`** — allows pods to resolve service names via CoreDNS
+4. **`allow-prometheus-scrape`** — allows Prometheus to scrape metrics
+
+Without NetworkPolicies, any pod in any namespace can reach any other pod in the cluster.
+This violates the principle of least privilege for networking.
+
+---
+
+## Applying the Production Baseline
+
+```bash
+# Apply in order (namespace first)
+kubectl apply -f examples/nginx-reference/02-production-baseline/namespace.yml
+kubectl apply -f examples/nginx-reference/02-production-baseline/service.yml
+kubectl apply -f examples/nginx-reference/02-production-baseline/deployment.yml
+kubectl apply -f examples/nginx-reference/02-production-baseline/pdb.yml
+kubectl apply -f examples/nginx-reference/02-production-baseline/hpa.yml
+kubectl apply -f examples/nginx-reference/02-production-baseline/network-policy.yml
+
+# Or apply all at once (kubectl handles ordering)
+kubectl apply -f examples/nginx-reference/02-production-baseline/
+```
+
+## Verification
+
+```bash
+# All pods Running
+kubectl get pods -n production-baseline
+
+# Security contexts applied
+kubectl get pod -n production-baseline -o jsonpath='{.items[0].spec.securityContext}' | jq .
+
+# HPA status
+kubectl get hpa -n production-baseline
+
+# PDB status
+kubectl get pdb -n production-baseline
+
+# NetworkPolicies
+kubectl get networkpolicies -n production-baseline
+
+# Attempt to exec into pod — should work (for debugging)
+POD=$(kubectl get pods -n production-baseline -o name | head -1)
+kubectl exec -n production-baseline ${POD} -- id
+# Expected: uid=101(nginx) gid=101(nginx) groups=101(nginx)
+
+# Attempt to write to filesystem — should fail
+kubectl exec -n production-baseline ${POD} -- touch /test-file
+# Expected: touch: /test-file: Read-only file system
+```
+
+## Clean Up
+
+```bash
+kubectl delete -f examples/nginx-reference/02-production-baseline/
+kubectl delete namespace production-baseline
+```
+
+---
+
+## Production Checklist
+
+| Requirement                   | Implemented? | Where                              |
+|-------------------------------|--------------|------------------------------------|
+| Dedicated ServiceAccount      | Yes          | `service.yml`                      |
+| automountServiceAccountToken false | Yes     | `service.yml`, `deployment.yml`    |
+| runAsNonRoot                  | Yes          | `deployment.yml` podSecurityContext|
+| runAsUser (non-zero)          | Yes          | UID 101                            |
+| fsGroup                       | Yes          | GID 101                            |
+| seccompProfile: RuntimeDefault| Yes          | `deployment.yml` podSecurityContext|
+| allowPrivilegeEscalation: false | Yes        | container securityContext          |
+| readOnlyRootFilesystem: true  | Yes          | container securityContext          |
+| capabilities: drop ALL        | Yes          | container securityContext          |
+| Resource requests             | Yes          | CPU + memory                       |
+| Memory limits                 | Yes          | No CPU limit (by design)           |
+| Startup probe                 | Yes          | `deployment.yml`                   |
+| Liveness probe                | Yes          | `deployment.yml`                   |
+| Readiness probe               | Yes          | `deployment.yml`                   |
+| preStop lifecycle hook        | Yes          | `deployment.yml`                   |
+| terminationGracePeriodSeconds | Yes          | 60s                                |
+| Rolling update (maxUnavailable: 0) | Yes    | `deployment.yml`                   |
+| minReadySeconds               | Yes          | 10s                                |
+| revisionHistoryLimit          | Yes          | 5                                  |
+| Pod anti-affinity             | Yes          | `deployment.yml`                   |
+| PodDisruptionBudget           | Yes          | `pdb.yml`                          |
+| HorizontalPodAutoscaler       | Yes          | `hpa.yml`                          |
+| NetworkPolicy default-deny    | Yes          | `network-policy.yml`               |
+| Full app.kubernetes.io labels | Yes          | All resources                      |
+| PSA Restricted enforcement    | Yes          | `namespace.yml` labels             |

--- a/examples/nginx-reference/02-production-baseline/deployment.yml
+++ b/examples/nginx-reference/02-production-baseline/deployment.yml
@@ -1,0 +1,235 @@
+---
+# Production Baseline Deployment
+# ================================
+# This Deployment demonstrates ALL production security and reliability requirements:
+#
+# Security:
+#   - Pod Security Context: runAsNonRoot, runAsUser, fsGroup, seccompProfile
+#   - Container Security Context: allowPrivilegeEscalation: false,
+#     readOnlyRootFilesystem: true, capabilities drop ALL
+#
+# Reliability:
+#   - Resource requests and limits
+#   - Liveness, readiness, and startup probes
+#   - preStop lifecycle hook for graceful shutdown
+#   - Rolling update with maxUnavailable: 0 (zero-downtime)
+#   - Pod anti-affinity for multi-node HA
+#   - minReadySeconds to prevent premature traffic
+#
+# Labelling:
+#   - Full app.kubernetes.io/* label set on all resources
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: production-baseline
+  labels:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: nginx
+    app.kubernetes.io/version: "1.27"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: nginx
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "Production-grade nginx Deployment with full security and reliability configuration."
+spec:
+  replicas: 2   # >= 2 for HA; matches PDB minAvailable: 1
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx
+      app.kubernetes.io/instance: nginx
+
+  # Zero-downtime rolling update:
+  # maxUnavailable: 0 — no pods go down until a new pod is Ready
+  # maxSurge: 1       — one extra pod is created above replicas during the update
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+
+  # Retain 5 old ReplicaSets for rollback history
+  revisionHistoryLimit: 5
+
+  # Pod must be Ready for 10s before it counts as Available.
+  # Prevents premature routing during startup transients.
+  minReadySeconds: 10
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nginx
+        app.kubernetes.io/instance: nginx
+        app.kubernetes.io/version: "1.27"
+        app.kubernetes.io/component: webserver
+        app.kubernetes.io/part-of: nginx
+        app.kubernetes.io/managed-by: kubectl
+      annotations:
+        kubernetes.io/description: "Production nginx pod."
+        kubectl.kubernetes.io/default-container: nginx
+    spec:
+      # Dedicated ServiceAccount — never use the default SA
+      serviceAccountName: nginx
+      # Disable API token auto-mount — nginx doesn't need Kubernetes API access
+      automountServiceAccountToken: false
+
+      # -----------------------------------------------------------------------
+      # Pod Security Context — applies to ALL containers
+      # -----------------------------------------------------------------------
+      securityContext:
+        # Prevent any container from running as root (UID 0).
+        # Enforced before the container starts.
+        runAsNonRoot: true
+
+        # Run as UID 101 (the nginx user in the nginx:unprivileged image).
+        # This image is specifically built to run as non-root.
+        runAsUser: 101
+
+        # Set the owning GID for volume mounts.
+        fsGroup: 101
+
+        # Apply the RuntimeDefault seccomp profile.
+        # This allows common syscalls while blocking dangerous ones (e.g., ptrace, unshare).
+        seccompProfile:
+          type: RuntimeDefault
+
+      # Allow 60s for graceful shutdown before SIGKILL
+      terminationGracePeriodSeconds: 60
+
+      containers:
+        - name: nginx
+          # Use nginx:unprivileged — specifically built to run as non-root UID 101.
+          # Standard nginx:1.27 binds to port 80 which requires root (privileged port).
+          # The unprivileged variant listens on port 8080 instead.
+          image: nginxinc/nginx-unprivileged:1.27
+
+          # -----------------------------------------------------------------------
+          # Container Security Context
+          # -----------------------------------------------------------------------
+          securityContext:
+            # Prevent privilege escalation via setuid/setgid binaries or sudo.
+            allowPrivilegeEscalation: false
+
+            # Mount the container root filesystem as read-only.
+            # Any path the process writes to must be backed by an explicit volume.
+            # nginx needs: /tmp, /var/cache/nginx, /var/run, /var/log/nginx
+            readOnlyRootFilesystem: true
+
+            # Drop all Linux capabilities.
+            # The nginx unprivileged image doesn't need any capabilities.
+            capabilities:
+              drop: ["ALL"]
+
+          ports:
+            - name: http
+              # Port 8080 — the nginx unprivileged image listens here (not 80)
+              containerPort: 8080
+              protocol: TCP
+
+          # -----------------------------------------------------------------------
+          # Lifecycle — Graceful Shutdown
+          # -----------------------------------------------------------------------
+          lifecycle:
+            preStop:
+              exec:
+                # 1. Sleep 5s: gives kube-proxy time to remove this pod's endpoint
+                #    from the Service before nginx stops accepting connections.
+                #    Without this, some requests get routed to a pod that is shutting
+                #    down, causing 502 errors in clients.
+                # 2. nginx -s quit: sends a graceful shutdown signal — nginx finishes
+                #    processing in-flight requests before stopping.
+                command: ["/bin/sh", "-c", "sleep 5 && nginx -s quit"]
+
+          # -----------------------------------------------------------------------
+          # Probes
+          # -----------------------------------------------------------------------
+
+          # Startup probe: the container has (30 * 10 = 300s) to start before
+          # the liveness probe takes over. Prevents premature liveness kills.
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+
+          # Liveness probe: kills and restarts the container if nginx is hung.
+          # Must be fast and local — does not check external dependencies.
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            failureThreshold: 3
+            timeoutSeconds: 3
+
+          # Readiness probe: removes the pod from Service endpoints if it fails.
+          # Traffic is only sent to pods that pass this probe.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3
+
+          # -----------------------------------------------------------------------
+          # Resources
+          # -----------------------------------------------------------------------
+          resources:
+            requests:
+              cpu: 100m      # 0.1 vCPU — nginx is very efficient
+              memory: 128Mi
+            limits:
+              # CPU limit intentionally omitted to avoid CPU throttling.
+              memory: 128Mi
+
+          # -----------------------------------------------------------------------
+          # Volume Mounts — required by readOnlyRootFilesystem: true
+          # -----------------------------------------------------------------------
+          volumeMounts:
+            # nginx writes temp files here
+            - name: tmp
+              mountPath: /tmp
+            # nginx cache directory
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            # nginx PID file
+            - name: nginx-run
+              mountPath: /var/run
+            # nginx logs (stdout/stderr stream — captured by container runtime)
+            - name: nginx-logs
+              mountPath: /var/log/nginx
+
+      # -----------------------------------------------------------------------
+      # Volumes
+      # -----------------------------------------------------------------------
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: nginx-logs
+          emptyDir: {}
+
+      # -----------------------------------------------------------------------
+      # Affinity — Spread Pods Across Nodes
+      # -----------------------------------------------------------------------
+      affinity:
+        podAntiAffinity:
+          # preferredDuringScheduling: best-effort (won't block scheduling if impossible)
+          # For hard HA requirement, use requiredDuringSchedulingIgnoredDuringExecution
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: nginx
+                    app.kubernetes.io/instance: nginx
+                # Spread across different nodes (not just different availability zones)
+                topologyKey: kubernetes.io/hostname

--- a/examples/nginx-reference/02-production-baseline/hpa.yml
+++ b/examples/nginx-reference/02-production-baseline/hpa.yml
@@ -1,0 +1,108 @@
+---
+# HorizontalPodAutoscaler — Automatic scaling based on metrics
+# =============================================================
+# The HPA controller queries the Metrics Server for resource utilisation and
+# adjusts the Deployment replica count to maintain target utilisation.
+#
+# Requirements:
+#   - Metrics Server must be installed in the cluster
+#     `kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml`
+#   - Resource REQUESTS must be set on containers (HPA calculates % of requests, not limits)
+#
+# autoscaling/v2 API (GA since Kubernetes 1.23) supports:
+#   - Multiple metrics (CPU + memory + custom)
+#   - Behavior configuration (scale-up/down policies + stabilization windows)
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: nginx
+  namespace: production-baseline
+  labels:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: nginx
+    app.kubernetes.io/version: "1.27"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: nginx
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: >-
+      HPA for nginx. Scales between 2–10 replicas based on CPU (70%) and
+      memory (80%) utilisation with conservative scale-down behavior.
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx
+
+  # minReplicas must be >= the PDB minAvailable to avoid a deadlock where
+  # the PDB blocks pod evictions during scale-down.
+  minReplicas: 2
+
+  # maxReplicas should be set based on cluster capacity and cost budget.
+  # Monitor actual scaling events and adjust based on peak load patterns.
+  maxReplicas: 10
+
+  metrics:
+    # CPU utilisation — most common scaling metric.
+    # Scale out when average CPU across all pods exceeds 70% of their requests.
+    # The "70% of requests" threshold means pods have 30% headroom before scaling out.
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+
+    # Memory utilisation — scale out when average memory exceeds 80% of requests.
+    # Memory-based scaling is less reactive (memory doesn't release as quickly as CPU)
+    # but useful as a safety net for memory-hungry workloads.
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+
+  behavior:
+    # -----------------------------------------------------------------------
+    # Scale-Up Behavior — Aggressive (respond quickly to traffic spikes)
+    # -----------------------------------------------------------------------
+    scaleUp:
+      # No stabilization window for scale-up — react immediately.
+      # The metric must be above the threshold for at least this many seconds
+      # before scaling up. 0 = react on the first metric sample above threshold.
+      stabilizationWindowSeconds: 0
+
+      policies:
+        # Policy 1: Add up to 4 pods per 60 seconds.
+        - type: Pods
+          value: 4
+          periodSeconds: 60
+
+        # Policy 2: Double the pod count every 60 seconds.
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+
+      # selectPolicy: Max — use whichever policy allows more pods (most aggressive).
+      # Use Min for more conservative scale-up.
+      selectPolicy: Max
+
+    # -----------------------------------------------------------------------
+    # Scale-Down Behavior — Conservative (prevent oscillation/flapping)
+    # -----------------------------------------------------------------------
+    scaleDown:
+      # Stabilization window — the metric must be below the threshold continuously
+      # for this many seconds before scaling down. 300s = 5 minutes.
+      # Prevents removing pods during a brief traffic lull between spikes.
+      stabilizationWindowSeconds: 300
+
+      policies:
+        # Remove at most 1 pod per 60 seconds during scale-down.
+        # Conservative: gives pods time to gracefully finish requests.
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+
+      # selectPolicy: Min — use the most conservative policy during scale-down.
+      selectPolicy: Min

--- a/examples/nginx-reference/02-production-baseline/namespace.yml
+++ b/examples/nginx-reference/02-production-baseline/namespace.yml
@@ -1,0 +1,52 @@
+---
+# Namespace — Logical isolation boundary within a cluster
+# ========================================================
+# Namespaces provide:
+#   - Name uniqueness (resources share names only within a namespace)
+#   - Resource quota isolation (LimitRange, ResourceQuota)
+#   - RBAC scope (Roles apply within a namespace)
+#   - NetworkPolicy scope
+#
+# Pod Security Admission (PSA) — enforced by the pod-security.kubernetes.io labels:
+#   Labels: pod-security.kubernetes.io/{enforce,audit,warn}: {privileged,baseline,restricted}
+#
+#   Levels:
+#     privileged  — no restrictions (only for system namespaces like kube-system)
+#     baseline    — prevents known privilege escalations (minimum for production)
+#     restricted  — hardened policy: non-root, no host namespaces, seccomp, etc.
+#
+#   Modes:
+#     enforce — reject Pods that violate the policy (hard block)
+#     audit   — allow but log violations (use during migration)
+#     warn    — allow but warn the client (kubectl shows a warning)
+#
+# This namespace enforces the Restricted PSS policy — the highest security level.
+# All Pods in this namespace MUST satisfy all Restricted requirements.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: production-baseline
+  labels:
+    app.kubernetes.io/name: production-baseline
+    app.kubernetes.io/instance: production-baseline
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: platform
+    app.kubernetes.io/part-of: kube-platform
+    app.kubernetes.io/managed-by: kubectl
+
+    # Pod Security Admission — enforce Restricted policy
+    # Any Pod that doesn't meet Restricted requirements will be REJECTED.
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+
+    # Also audit and warn during migration to catch violations in child namespaces
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+
+  annotations:
+    kubernetes.io/description: >-
+      Production baseline namespace demonstrating full Restricted PSS enforcement.
+      All workloads must satisfy runAsNonRoot, readOnlyRootFilesystem, seccomp, and
+      capabilities drop ALL requirements.

--- a/examples/nginx-reference/02-production-baseline/network-policy.yml
+++ b/examples/nginx-reference/02-production-baseline/network-policy.yml
@@ -1,0 +1,186 @@
+---
+# NetworkPolicy — Default Deny All
+# ==================================
+# This policy denies ALL ingress and egress traffic to/from every pod in the
+# production-baseline namespace by default. This is the zero-trust networking
+# starting point.
+#
+# Once this policy exists, additional NetworkPolicies must explicitly ALLOW
+# each required traffic flow. The union of all matching policies is evaluated —
+# traffic is allowed if ANY matching policy permits it.
+#
+# Requirements:
+#   - A CNI plugin that enforces NetworkPolicies must be installed.
+#     Not all CNIs support NetworkPolicy. Examples that do:
+#       Calico, Cilium, Weave Net, Canal, Antrea
+#     Examples that do NOT:
+#       Flannel (alone), kubenet
+#
+# Verify your CNI supports NetworkPolicy:
+#   kubectl get pods -n kube-system | grep -E 'calico|cilium|weave'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: production-baseline
+  labels:
+    app.kubernetes.io/name: default-deny-all
+    app.kubernetes.io/instance: default-deny-all
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: network-policy
+    app.kubernetes.io/part-of: nginx
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: >-
+      Default-deny NetworkPolicy. Blocks all ingress and egress traffic in the
+      production-baseline namespace. Additional NetworkPolicies must explicitly
+      allow required flows.
+spec:
+  # Empty podSelector — matches ALL pods in this namespace
+  podSelector: {}
+
+  # Specifying both ingress and egress in policyTypes with no rules means:
+  # "apply an ingress policy to all pods (deny all ingress) and
+  #  apply an egress policy to all pods (deny all egress)"
+  policyTypes:
+    - Ingress
+    - Egress
+
+  # No ingress rules = deny all ingress
+  # No egress rules  = deny all egress
+
+---
+# NetworkPolicy — Allow Ingress from Ingress Controller
+# ======================================================
+# Allow the nginx ingress controller to reach the nginx pods on port 8080.
+# The ingress controller runs in the 'ingress-nginx' namespace and has the label
+# 'app.kubernetes.io/name: ingress-nginx'.
+#
+# This policy is combined with the default-deny policy above.
+# Traffic is allowed if any policy permits it.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-controller
+  namespace: production-baseline
+  labels:
+    app.kubernetes.io/name: allow-ingress-controller
+    app.kubernetes.io/instance: allow-ingress-controller
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: network-policy
+    app.kubernetes.io/part-of: nginx
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: >-
+      Allows ingress traffic from the nginx-ingress controller namespace to nginx pods
+      on port 8080. Required for Ingress routing to work.
+spec:
+  # Apply this policy to nginx pods
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: nginx
+      app.kubernetes.io/instance: nginx
+
+  policyTypes:
+    - Ingress
+
+  ingress:
+    - from:
+        # Allow from pods in the 'ingress-nginx' namespace only.
+        # This prevents other namespaces from directly accessing nginx.
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          # Additionally, only allow from pods with the ingress-nginx label.
+          # Both conditions must be true (AND logic — same item in the from list).
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 8080
+
+---
+# NetworkPolicy — Allow DNS Egress
+# ================================
+# Allow pods to query the CoreDNS / kube-dns service for name resolution.
+# Without this policy, pods in the default-deny namespace cannot resolve
+# service names (e.g., 'nginx.production-baseline.svc.cluster.local').
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: production-baseline
+  labels:
+    app.kubernetes.io/name: allow-dns-egress
+    app.kubernetes.io/instance: allow-dns-egress
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: network-policy
+    app.kubernetes.io/part-of: nginx
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: >-
+      Allows egress from all pods in this namespace to kube-dns on port 53 (UDP/TCP).
+      Required for service name resolution.
+spec:
+  podSelector: {}   # All pods in this namespace
+
+  policyTypes:
+    - Egress
+
+  egress:
+    - to:
+        # Allow to the kube-system namespace where CoreDNS runs
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+
+---
+# NetworkPolicy — Allow Metrics Scraping (Prometheus)
+# ====================================================
+# Allow the Prometheus server to scrape metrics from pods on port 8080.
+# The Prometheus server runs in the 'monitoring' namespace.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-scrape
+  namespace: production-baseline
+  labels:
+    app.kubernetes.io/name: allow-prometheus-scrape
+    app.kubernetes.io/instance: allow-prometheus-scrape
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: network-policy
+    app.kubernetes.io/part-of: nginx
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: >-
+      Allows ingress from the Prometheus server (monitoring namespace) to scrape
+      metrics from nginx pods.
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: nginx
+      app.kubernetes.io/instance: nginx
+
+  policyTypes:
+    - Ingress
+
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/examples/nginx-reference/02-production-baseline/pdb.yml
+++ b/examples/nginx-reference/02-production-baseline/pdb.yml
@@ -1,0 +1,51 @@
+---
+# PodDisruptionBudget — Availability during voluntary disruptions
+# ================================================================
+# A PDB limits how many pods can be simultaneously unavailable during
+# VOLUNTARY disruptions. Examples of voluntary disruptions:
+#   - Node drain (cluster upgrade, node maintenance, spot instance termination)
+#   - Rolling Deployment update
+#   - Horizontal scaling down
+#   - Manual pod deletion
+#
+# PDB does NOT protect against INVOLUNTARY disruptions:
+#   - Node hardware failure
+#   - Kernel panic
+#   - Network partition
+#   - OOMKill
+#
+# Without a PDB, a cluster upgrade could drain multiple nodes simultaneously,
+# taking all your pods offline at once.
+#
+# IMPORTANT: PDB + HPA interaction
+# If minReplicas (HPA) == minAvailable (PDB), the cluster cannot scale down
+# without violating the PDB. Always set: minReplicas > minAvailable.
+# With replicas: 2 and minAvailable: 1, scaling down to 1 is allowed.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: nginx
+  namespace: production-baseline
+  labels:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: nginx
+    app.kubernetes.io/version: "1.27"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: nginx
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: >-
+      PDB for nginx. Ensures at least 1 pod remains available during node drains
+      and rolling updates. With 2 replicas, at most 1 pod can be disrupted at a time.
+spec:
+  # minAvailable: at least 1 pod must remain available during a voluntary disruption.
+  # With replicas: 2, this allows draining 1 pod at a time.
+  #
+  # Alternative: use maxUnavailable instead of minAvailable.
+  # maxUnavailable: 1  — at most 1 pod can be down at a time (percentage also valid: "50%")
+  minAvailable: 1
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx
+      app.kubernetes.io/instance: nginx

--- a/examples/nginx-reference/02-production-baseline/service.yml
+++ b/examples/nginx-reference/02-production-baseline/service.yml
@@ -1,0 +1,58 @@
+---
+# ClusterIP Service — Internal traffic only
+# ==========================================
+# In production, use ClusterIP + Ingress rather than NodePort or LoadBalancer:
+#   - ClusterIP: one stable virtual IP per service (cheap, internal only)
+#   - Ingress: one L7 load balancer routes to many services by host/path (efficient)
+#   - NodePort: exposes a random high port on EVERY node (coarse-grained, not production)
+#   - LoadBalancer: one cloud LB per service (expensive at scale)
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: production-baseline
+  labels:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: nginx
+    app.kubernetes.io/version: "1.27"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: nginx
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "ClusterIP Service for the production nginx Deployment."
+spec:
+  type: ClusterIP
+
+  ports:
+    - port: 80           # Port the Service listens on (cluster-internal)
+      targetPort: http   # Named port on the pod (maps to containerPort 8080)
+      protocol: TCP
+      name: http
+
+  # Routes traffic to Pods with these labels
+  selector:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: nginx
+
+---
+# ServiceAccount — Dedicated identity for nginx pods
+# ====================================================
+# Every pod runs as a ServiceAccount. The 'default' ServiceAccount in each namespace
+# auto-mounts a token with some cluster permissions — never use it for workloads.
+# Create a dedicated SA with no permissions (unless the pod needs K8s API access).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx
+  namespace: production-baseline
+  labels:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: nginx
+    app.kubernetes.io/version: "1.27"
+    app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: nginx
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    kubernetes.io/description: "Dedicated ServiceAccount for nginx pods. No K8s API permissions required."
+# Disable token auto-mounting at the SA level (also set on the pod spec)
+automountServiceAccountToken: false


### PR DESCRIPTION
## Summary
Two-track nginx reference progression showing the delta between a learning-grade and production-grade manifest:

**01-intro**: minimal pod, 2-replica Deployment, NodePort service — designed for first `kubectl apply` experience

**02-production-baseline** (all 6 files):
- `namespace.yml` — with `enforce: baseline` PSS labels
- `deployment.yml` — full security context (non-root, `readOnlyRootFilesystem`, `seccompProfile: RuntimeDefault`, `capabilities.drop: [ALL]`), `topologySpreadConstraints`, `preStop: sleep 5`, separate startup/readiness/liveness probe endpoints
- `service.yml` — ClusterIP (Ingress handles external access)
- `hpa.yml` — CPU 60% + memory 70% with stabilization window
- `pdb.yml` — `minAvailable: 1`
- `network-policy.yml` — ingress from `ingress-nginx` namespace only; default-deny everything else

## Issues referenced
Relates to #69

## Test plan
- [ ] `kubectl apply -f examples/nginx-reference/01-intro/` — basic pod runs
- [ ] `kubectl apply -k examples/nginx-reference/02-production-baseline/` — all 6 resources deploy
- [ ] HPA targets appear in `kubectl get hpa` once metrics-server is running