### PR TITLE
docs: architecture, deployment strategies, and CI/CD concepts documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,483 @@
+# Kubernetes Architecture
+
+A deep-dive reference for engineers who need more than surface-level knowledge.
+This document covers how the control plane works, what runs on each node, the key
+API objects you'll touch every day, and the full end-to-end journey a Pod takes
+from `kubectl apply` to "Running".
+
+---
+
+## Table of Contents
+
+1. [The Big Picture](#the-big-picture)
+2. [Control Plane Components](#control-plane-components)
+   - [API Server](#api-server)
+   - [etcd](#etcd)
+   - [Scheduler](#scheduler)
+   - [Controller Manager](#controller-manager)
+   - [Cloud Controller Manager](#cloud-controller-manager)
+3. [Worker Node Components](#worker-node-components)
+   - [kubelet](#kubelet)
+   - [kube-proxy](#kube-proxy)
+   - [Container Runtime](#container-runtime)
+4. [Key API Objects](#key-api-objects)
+5. [How a Pod Gets Scheduled — End-to-End](#how-a-pod-gets-scheduled--end-to-end)
+6. [ASCII Architecture Diagram](#ascii-architecture-diagram)
+7. [Further Reading](#further-reading)
+
+---
+
+## The Big Picture
+
+Kubernetes is a **distributed system** that automates the deployment, scaling, and
+lifecycle management of containerized workloads. Think of it as an operating system
+for your data center: the control plane is the kernel, and the worker nodes are the
+hardware.
+
+Every interaction with Kubernetes goes through a single authoritative entry point —
+the **API Server**. Nothing communicates directly with etcd or with another component
+except through the API Server (with one exception: etcd itself communicates only
+with the API Server). This strict fan-out pattern keeps the system auditable and
+consistent.
+
+---
+
+## Control Plane Components
+
+The control plane is the "brain" of the cluster. In production it runs on dedicated
+nodes (often 3 or 5 for high availability) that are tainted so workloads cannot be
+scheduled there.
+
+### API Server
+
+**Real-world analogy:** The API Server is the front-desk receptionist at a large
+hospital. Every request — whether from a doctor (kubectl), a nurse (kubelet), or an
+automated system (controller) — must go through the receptionist. The receptionist
+checks your ID (authentication), verifies you have permission (authorization via
+RBAC), validates the paperwork (admission controllers), and then files it in the
+records room (etcd).
+
+**What it does:**
+
+- Exposes the Kubernetes REST API over HTTPS (default port 6443).
+- Performs **Authentication** — Who are you? (certificates, bearer tokens, OIDC)
+- Performs **Authorization** — Are you allowed? (RBAC, ABAC, Webhook)
+- Runs **Admission Controllers** — Should this request be allowed/mutated?
+  Examples: `LimitRanger`, `ResourceQuota`, `MutatingWebhookConfiguration`.
+- Serializes state to etcd. It is the **only** component that reads/writes etcd.
+- Implements **watch** semantics — clients subscribe to changes on any resource,
+  allowing controllers to react without polling.
+
+**Key insight:** The API Server is stateless. You can run multiple replicas behind a
+load balancer for HA. All state lives in etcd.
+
+---
+
+### etcd
+
+**Real-world analogy:** etcd is the hospital's medical records vault. It is the
+single source of truth. The receptionist (API Server) is the only one with the key.
+Records are replicated to multiple filing cabinets (etcd peers) using the Raft
+consensus algorithm so no single cabinet failure loses data.
+
+**What it does:**
+
+- A distributed, strongly-consistent key-value store.
+- Stores all cluster state: nodes, pods, secrets, configmaps, RBAC policies,
+  custom resources — everything.
+- Uses the **Raft consensus protocol** to elect a leader among peers and replicate
+  writes. A write is committed only after a quorum (majority) of peers acknowledges
+  it.
+- Supports **watch** on keys/prefixes, which is how the API Server delivers
+  change events to controllers.
+
+**Production considerations:**
+
+- Always run an odd number of etcd members (3 or 5) to maintain quorum during
+  a member failure. With 3 members, you tolerate 1 failure. With 5, you tolerate 2.
+- etcd is I/O sensitive — use SSDs with low write latency (< 10ms fsync).
+- Back up etcd snapshots regularly (`etcdctl snapshot save`). This is your
+  disaster-recovery lifeline.
+- Encrypt etcd at rest using the `EncryptionConfiguration` API to protect Secrets
+  stored in plaintext by default.
+
+---
+
+### Scheduler
+
+**Real-world analogy:** The Scheduler is the hospital's bed manager. When a new
+patient arrives (a Pod is created with no `nodeName`), the bed manager looks at all
+available rooms (nodes), checks their occupancy and required equipment (resource
+requests, node selectors, taints/tolerations, affinity rules), and assigns the
+patient to the best available room. The bed manager does **not** move the patient —
+it just writes the assignment down; the nurses (kubelets) on each floor handle the
+actual admission.
+
+**What it does:**
+
+- Watches for Pods in `Pending` state with no `spec.nodeName`.
+- Runs a two-phase algorithm:
+  1. **Filtering** — eliminates nodes that cannot run the Pod (insufficient CPU/RAM,
+     taint not tolerated, node affinity not satisfied, volume topology mismatch).
+  2. **Scoring** — ranks remaining nodes using plugins (least-requested resources,
+     image locality, inter-pod affinity spread, custom plugins).
+- Writes the chosen `nodeName` back to the Pod spec via the API Server.
+- The scheduler is **pluggable** — you can replace or extend it using the
+  Scheduling Framework.
+
+**Key scheduling concepts:**
+
+| Concept | What it does |
+|---|---|
+| `nodeSelector` | Simple key=value match against node labels |
+| `nodeAffinity` | Expressive rules (required vs. preferred) against node labels |
+| `podAffinity` / `podAntiAffinity` | Schedule near / away from other Pods |
+| `taints` + `tolerations` | Nodes repel Pods; Pods opt-in by tolerating |
+| `topologySpreadConstraints` | Spread Pods evenly across zones/nodes |
+| `priorityClass` | High-priority Pods can preempt lower-priority ones |
+
+---
+
+### Controller Manager
+
+**Real-world analogy:** The Controller Manager is the hospital's department of
+automated systems — the HVAC, fire suppression, elevator control, and supply
+ordering systems all rolled into one binary. Each sub-system (controller) watches
+a specific condition and continuously reconciles the actual state with the desired
+state. They don't know about each other; each controller only watches what it cares
+about.
+
+**What it does:**
+
+- Runs a collection of control loops (controllers), each responsible for one
+  resource type.
+- Each controller follows the **reconciliation loop** pattern:
+  1. Watch the API Server for the desired state of its resource.
+  2. Check the actual state (e.g., how many Pods exist).
+  3. Take action to close the gap (create, delete, update).
+  4. Repeat.
+
+**Important controllers:**
+
+| Controller | Responsibility |
+|---|---|
+| Deployment Controller | Creates/updates ReplicaSets to match Deployment spec |
+| ReplicaSet Controller | Creates/deletes Pods to match `replicas` count |
+| StatefulSet Controller | Manages ordered, stable-identity Pod sets |
+| DaemonSet Controller | Ensures one Pod per node (or per matching node) |
+| Job Controller | Runs Pods to completion, retries on failure |
+| CronJob Controller | Creates Jobs on a cron schedule |
+| Namespace Controller | Cleans up resources when a Namespace is deleted |
+| Node Controller | Monitors node heartbeats, marks nodes `NotReady`, evicts Pods |
+| Service Account Controller | Creates default ServiceAccounts in new Namespaces |
+| Endpoints Controller | Populates Endpoints objects from Service + Pod selectors |
+
+---
+
+### Cloud Controller Manager
+
+**Real-world analogy:** The Cloud Controller Manager is the hospital's liaison with
+external vendors — the laundry service, food delivery, and security company. It
+speaks the language of the outside world (AWS, GCP, Azure APIs) so that the internal
+hospital staff (core controllers) don't have to.
+
+**What it does:**
+
+- Separates cloud-provider-specific logic from the core controller manager.
+- Manages cloud infrastructure that Kubernetes needs to function:
+  - **Node Controller** — Syncs node metadata from the cloud provider (instance ID,
+    zone, instance type) and removes nodes from the cluster when cloud instances
+    are terminated.
+  - **Route Controller** — Programs cloud network routes so nodes can reach each
+    other (GCP, older AWS setups).
+  - **Service Controller** — Provisions cloud load balancers when a Service of
+    type `LoadBalancer` is created.
+- Each major cloud provider ships its own CCM binary (e.g., `cloud-provider-aws`,
+  `cloud-provider-gcp`).
+
+---
+
+## Worker Node Components
+
+Worker nodes run the actual application workloads. Each node runs three mandatory
+components.
+
+### kubelet
+
+**Real-world analogy:** The kubelet is the charge nurse on a hospital floor. It
+receives patient assignments (PodSpecs) from the bed manager (Scheduler), admits
+the patient (pulls the container image, creates the container), monitors the
+patient's vitals (liveness/readiness probes), reports status back to the receptionist
+(API Server), and escalates if a patient deteriorates (restarts failed containers).
+
+**What it does:**
+
+- The primary node agent, running on every worker node.
+- Watches the API Server for Pods assigned to its node.
+- Calls the Container Runtime Interface (CRI) to pull images and start containers.
+- Mounts volumes (PVs, ConfigMaps, Secrets, projected tokens) into the Pod.
+- Executes **startup**, **liveness**, and **readiness** probes.
+  - `startupProbe` — Prevents liveness/readiness checks until the app has started.
+  - `livenessProbe` — Restarts a container that is stuck or deadlocked.
+  - `readinessProbe` — Controls whether the Pod receives traffic via Services.
+- Reports Pod status, node conditions, and resource usage (CPU, memory) to the
+  API Server.
+- Enforces resource limits via cgroups.
+- Does **not** manage containers not created by Kubernetes (unlike Docker daemon).
+
+---
+
+### kube-proxy
+
+**Real-world analogy:** kube-proxy is the hospital's telephone switchboard operator.
+When someone calls the hospital's main number asking for "cardiology" (a Service),
+the switchboard looks up which extension (Pod IP) to connect them to, applying
+load balancing across all cardiologists currently on duty.
+
+**What it does:**
+
+- Runs on every node; implements the Service networking abstraction.
+- Watches the API Server for Service and EndpointSlice changes.
+- Programs the node's networking layer to forward traffic sent to a Service's
+  ClusterIP:Port to a healthy backend Pod IP:Port.
+- Supports three modes:
+  - **iptables** (default on most clusters) — Installs iptables `DNAT` rules.
+    Performant for most clusters; rules are programmed in O(n) with number of
+    endpoints — can become slow at 10,000+ endpoints.
+  - **ipvs** — Uses Linux IPVS (IP Virtual Server) for O(1) lookups and more
+    sophisticated load-balancing algorithms (round-robin, least-connection, etc.).
+    Preferred for large clusters.
+  - **nftables** (Kubernetes 1.31+, beta) — Modern replacement for iptables.
+  - **eBPF** — Used by CNI plugins like Cilium to bypass kube-proxy entirely,
+    implementing Service routing at the kernel level for superior performance.
+
+---
+
+### Container Runtime
+
+**Real-world analogy:** The container runtime is the hospital's operating room
+equipment — the ventilators, monitors, and surgical tools that actually keep the
+patient alive. kubelet tells it what to do; it does the low-level work.
+
+**What it does:**
+
+- The software that actually runs containers on the node.
+- kubelet communicates with the runtime via the **CRI** (Container Runtime Interface),
+  a gRPC API. This abstraction allows different runtimes to be swapped without
+  changing kubelet.
+- Responsibilities: pulling images, managing image layers, creating/deleting
+  container namespaces (PID, network, mount, UTS, IPC), enforcing cgroup limits.
+
+**Common runtimes:**
+
+| Runtime | Notes |
+|---|---|
+| **containerd** | Most common; extracted from Docker; used by GKE, EKS, AKS |
+| **CRI-O** | Lightweight; designed for Kubernetes; used by OpenShift |
+| **Docker Engine** | Removed as a direct runtime in K8s 1.24 (dockershim removed) |
+| **gVisor (runsc)** | Sandboxed runtime from Google; adds syscall interception layer |
+| **Kata Containers** | VM-level isolation; each Pod runs in a lightweight VM |
+
+---
+
+## Key API Objects
+
+| Object | What it represents |
+|---|---|
+| **Pod** | The smallest deployable unit. One or more containers sharing a network namespace and storage volumes. Pods are ephemeral — treat them as cattle, not pets. |
+| **Deployment** | Declares the desired state of a set of identical Pods. Manages rollouts, rollbacks, and scaling via ReplicaSets. |
+| **ReplicaSet** | Ensures N replicas of a Pod template are running. Rarely used directly — Deployments manage them. |
+| **StatefulSet** | Like a Deployment, but Pods have stable names (pod-0, pod-1), stable network identities, and ordered, graceful scaling/updates. For databases, queues. |
+| **DaemonSet** | Ensures one Pod runs on every (or every matching) node. For node-level agents: log collectors, monitoring exporters, CNI plugins. |
+| **Job** | Runs one or more Pods to completion. For batch workloads. |
+| **CronJob** | Creates Jobs on a cron schedule. |
+| **Service** | A stable virtual IP (ClusterIP) + DNS name in front of a set of Pods. Decouples consumers from the ephemeral Pod IPs. Types: ClusterIP, NodePort, LoadBalancer, ExternalName. |
+| **Ingress** | Layer-7 HTTP/HTTPS routing rules. Routes external traffic to Services based on hostname and path. Requires an Ingress Controller (nginx, Traefik, AWS ALB). |
+| **ConfigMap** | Stores non-sensitive configuration as key-value pairs. Mounted as files or injected as environment variables. |
+| **Secret** | Stores sensitive data (passwords, tokens, certs). Base64-encoded at rest by default — always enable encryption at rest and use an external secrets operator in production. |
+| **Namespace** | A virtual cluster within the physical cluster. Provides scope for names, RBAC, resource quotas, and network policies. |
+| **PersistentVolume (PV)** | A piece of storage provisioned by an admin or dynamically by a StorageClass. |
+| **PersistentVolumeClaim (PVC)** | A user's request for storage. Kubernetes binds a PVC to a suitable PV. |
+| **ServiceAccount** | An identity for processes running in a Pod. Used with RBAC to grant Pods permission to call the Kubernetes API. |
+| **NetworkPolicy** | Firewall rules for Pods. Controls ingress/egress traffic between Pods and external endpoints. Requires a CNI plugin that enforces policies (Calico, Cilium). |
+| **HorizontalPodAutoscaler** | Automatically scales Deployment/StatefulSet replicas based on CPU, memory, or custom metrics. |
+
+---
+
+## How a Pod Gets Scheduled — End-to-End
+
+Below is the complete sequence of events from `kubectl apply` to the Pod reaching
+`Running` state. Understanding this flow is essential for diagnosing scheduling
+failures and optimizing startup time.
+
+```
+Step 1: kubectl apply -f pod.yaml
+        └─> kubectl serializes the manifest to JSON
+        └─> HTTPS POST to kube-apiserver:6443/api/v1/namespaces/default/pods
+
+Step 2: API Server — Authentication
+        └─> Validates the client certificate / bearer token / OIDC token
+        └─> Determines the user identity (e.g., system:admin)
+
+Step 3: API Server — Authorization (RBAC)
+        └─> Checks: can this identity CREATE pods in this namespace?
+        └─> Denied → 403 Forbidden
+
+Step 4: API Server — Admission Controllers (in order)
+        └─> MutatingAdmissionWebhook: may inject sidecars, set defaults
+        └─> LimitRanger: applies default requests/limits if omitted
+        └─> ResourceQuota: checks namespace quota isn't exceeded
+        └─> ValidatingAdmissionWebhook: policy checks (OPA/Gatekeeper, Kyverno)
+        └─> PodSecurity: enforces PodSecurity standards (restricted/baseline)
+
+Step 5: API Server writes Pod to etcd
+        └─> Pod is now in Pending state, spec.nodeName = ""
+        └─> API Server sends watch event to all watchers
+
+Step 6: Scheduler receives watch event (Pod with no nodeName)
+        └─> Filtering phase: eliminates nodes that can't run this Pod
+            ├─ Insufficient CPU or memory
+            ├─ Taint not tolerated
+            ├─ Node affinity not satisfied
+            ├─ Pod affinity/anti-affinity not satisfied
+            ├─ Volume topology mismatch
+            └─ Node not Ready
+        └─> Scoring phase: ranks remaining nodes (0-100 per plugin)
+            ├─ LeastAllocated: prefers nodes with more free resources
+            ├─ ImageLocality: prefers nodes that already have the image
+            ├─ NodeAffinity: bonus for preferred affinity matches
+            └─> NodeResourcesFit, InterPodAffinity, etc.
+        └─> Scheduler writes spec.nodeName = "node-42" via API Server
+        └─> Binding object created (another etcd write)
+
+Step 7: kubelet on node-42 receives watch event
+        └─> Sees a Pod assigned to it with phase=Pending
+
+Step 8: kubelet — Image Pull
+        └─> Calls CRI (containerd) to pull the image
+        └─> containerd pulls layers from registry (if not cached)
+        └─> imagePullPolicy: IfNotPresent skips pull if digest matches
+
+Step 9: kubelet — Pod Setup
+        └─> Creates the "pause" (infra) container to hold the network namespace
+        └─> CNI plugin invoked: assigns Pod IP, programs routes
+        └─> Creates volumes: mounts ConfigMaps, Secrets, PVCs, emptyDirs
+        └─> Starts init containers in order (each must exit 0 before next starts)
+
+Step 10: kubelet — Main Container Start
+         └─> Calls CRI to create and start main containers
+         └─> Applies cgroup limits (CPU, memory)
+         └─> Injects environment variables (from ConfigMap/Secret refs)
+
+Step 11: kubelet — startupProbe (if configured)
+         └─> Probes repeatedly until success or failureThreshold exceeded
+         └─> liveness and readiness probes are GATED until startup succeeds
+         └─> Prevents premature restarts of slow-starting apps
+
+Step 12: kubelet — readinessProbe
+         └─> On success: kubelet marks the Pod condition Ready=True
+         └─> Endpoints controller adds the Pod IP to the Service's EndpointSlice
+         └─> kube-proxy/CNI programs traffic rules to include this Pod
+         └─> Pod starts receiving traffic
+
+Step 13: kubelet — livenessProbe (ongoing)
+         └─> If probe fails consecutively (failureThreshold times):
+             └─> kubelet sends SIGTERM to the container
+             └─> preStop hook runs (e.g., sleep 5 for graceful drain)
+             └─> terminationGracePeriodSeconds countdown starts
+             └─> Container exits; kubelet restarts it (respecting restartPolicy)
+
+Step 14: Pod is now Running and receiving traffic.
+```
+
+---
+
+## ASCII Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        CONTROL PLANE                                │
+│                                                                     │
+│  ┌──────────────────────────────────────────────────────────────┐  │
+│  │                     kube-apiserver                           │  │
+│  │      (AuthN → AuthZ → Admission → etcd read/write)          │  │
+│  └──────────────┬───────────────────────┬───────────────────────┘  │
+│                 │                       │                           │
+│         ┌───────┴──────┐       ┌────────┴────────┐                 │
+│         │     etcd     │       │   kube-scheduler │                │
+│         │  (cluster    │       │  (filter+score   │                │
+│         │   state)     │       │   → bind)        │                │
+│         └──────────────┘       └─────────────────┘                 │
+│                                                                     │
+│         ┌───────────────────┐  ┌─────────────────────────────┐     │
+│         │  kube-controller  │  │  cloud-controller-manager   │     │
+│         │  -manager         │  │  (node, route, service LB)  │     │
+│         │  (reconcile loops)│  │                             │     │
+│         └───────────────────┘  └─────────────────────────────┘     │
+└─────────────────────────────────────────────────────────────────────┘
+                │  HTTPS (watch/list/update)
+                │
+┌───────────────▼───────────────────────────────────────────────────────┐
+│                        WORKER NODE                                    │
+│                                                                       │
+│  ┌──────────────────────────────────────────────────────────────┐    │
+│  │  kubelet                                                      │    │
+│  │  ├─ Watches API Server for assigned Pods                      │    │
+│  │  ├─ Calls CRI to pull images, start/stop containers          │    │
+│  │  ├─ Mounts volumes (ConfigMap, Secret, PVC, emptyDir)        │    │
+│  │  ├─ Runs startup/liveness/readiness probes                   │    │
+│  │  └─ Reports node/pod status to API Server                    │    │
+│  └──────────────────────────────────────────────────────────────┘    │
+│                                                                       │
+│  ┌─────────────────────┐    ┌────────────────────────────────────┐   │
+│  │  kube-proxy         │    │  Container Runtime (containerd)    │   │
+│  │  (iptables/ipvs     │    │  ├─ Pulls OCI images               │   │
+│  │   rules for Service │    │  ├─ Manages container lifecycle     │   │
+│  │   ClusterIP → Pod)  │    │  └─ CRI gRPC API                   │   │
+│  └─────────────────────┘    └────────────────────────────────────┘   │
+│                                                                       │
+│  ┌─────────────────────────────────────────────────────────────────┐ │
+│  │  Pods (share node kernel, isolated via namespaces + cgroups)   │ │
+│  │                                                                 │ │
+│  │  ┌───────────────────────────────────────────────────────┐     │ │
+│  │  │ Pod A                                                 │     │ │
+│  │  │  ┌──────────────┐  ┌──────────────┐  shared:         │     │ │
+│  │  │  │ init-ctr     │→ │ main-ctr     │  - network ns    │     │ │
+│  │  │  │ (exits 0)    │  │ (nginx)      │  - volumes       │     │ │
+│  │  │  └──────────────┘  └──────────────┘  - IPC ns        │     │ │
+│  │  │                     ┌──────────────┐                  │     │ │
+│  │  │                     │ sidecar-ctr  │                  │     │ │
+│  │  │                     │ (log-fwd)    │                  │     │ │
+│  │  │                     └──────────────┘                  │     │ │
+│  │  └───────────────────────────────────────────────────────┘     │ │
+│  └─────────────────────────────────────────────────────────────────┘ │
+└───────────────────────────────────────────────────────────────────────┘
+
+Traffic flow for a Service request:
+  Client → kube-proxy DNAT rule → Pod IP:containerPort
+  (Service ClusterIP is a virtual IP; packets are rewritten at the node)
+```
+
+---
+
+## Further Reading
+
+**Official Kubernetes Documentation**
+- [Kubernetes Components](https://kubernetes.io/docs/concepts/overview/components/)
+- [The Kubernetes API](https://kubernetes.io/docs/concepts/overview/kubernetes-api/)
+- [Scheduling, Preemption and Eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/)
+- [Container Lifecycle Hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/)
+- [Configure Liveness, Readiness and Startup Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+
+**Deep Dives**
+- [etcd FAQ](https://etcd.io/docs/latest/faq/)
+- [Raft Consensus Visualized](https://raft.github.io/)
+- [The Scheduler Framework](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/)
+- [A Deep Dive into Kubernetes Controllers](https://engineering.bitnami.com/articles/a-deep-dive-into-kubernetes-controllers.html)
+- [Life of a Packet (CNCF)](https://www.youtube.com/watch?v=0Omvgd7Hg1I)
+
+**Security**
+- [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+- [Encrypting Secret Data at Rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)
+- [RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [NSA/CISA Kubernetes Hardening Guide](https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF)

--- a/docs/ci-cd-concepts.md
+++ b/docs/ci-cd-concepts.md
@@ -1,0 +1,464 @@
+# CI/CD with Kubernetes
+
+A practical guide to Continuous Integration, Continuous Delivery, and Continuous
+Deployment in the context of Kubernetes. This document covers the definitions,
+how Kubernetes fits into each stage, the GitOps paradigm, and a concrete pipeline
+flow you can adapt for your team.
+
+---
+
+## Table of Contents
+
+1. [Definitions: CI vs CD vs Continuous Deployment](#definitions)
+2. [How Kubernetes Fits Into the Pipeline](#how-kubernetes-fits-into-the-pipeline)
+3. [Push-Based vs GitOps (Pull-Based) Deployment](#push-based-vs-gitops-pull-based-deployment)
+4. [A Typical Pipeline Flow](#a-typical-pipeline-flow)
+5. [Tooling Landscape](#tooling-landscape)
+6. [Related Files in This Repository](#related-files-in-this-repository)
+7. [Further Reading](#further-reading)
+
+---
+
+## Definitions
+
+### Continuous Integration (CI)
+
+**The practice of merging developer code changes into a shared repository frequently
+(multiple times per day), with each merge triggering an automated build and test suite.**
+
+CI is about eliminating "integration hell" — the pain that accumulates when long-lived
+feature branches diverge from main and are merged all at once. By integrating
+continuously, problems are discovered when the change set is small and the context
+is fresh.
+
+Core CI activities:
+- **Source Control Trigger** — A push or pull request to a branch triggers the pipeline.
+- **Build** — Compile code (or build a Docker image via `docker build`).
+- **Unit Tests** — Fast, isolated tests that run in milliseconds. No external services.
+- **Static Analysis / Linting** — Code style, complexity, security scanning
+  (e.g., `golangci-lint`, `eslint`, `bandit` for Python).
+- **Container Image Build** — Build the OCI image; tag it with the Git commit SHA.
+- **Image Scanning** — Scan for known CVEs in the image layers (Trivy, Snyk, Grype).
+- **Artifact Publication** — Push the vetted image to a container registry (ECR, GCR,
+  Docker Hub, Harbor).
+
+**CI is complete when a versioned, tested, scanned artifact exists in a registry.**
+
+---
+
+### Continuous Delivery (CD)
+
+**The practice of ensuring that code is always in a deployable state, and that
+deploying to production is a low-risk, repeatable, push-button action.**
+
+CD extends CI by automating the deployment pipeline all the way to a production-like
+environment. The key distinction from Continuous Deployment:
+
+- **Continuous Delivery** — The pipeline runs automatically through staging/pre-prod,
+  but a **human approves** the final step to production. Production deployment is
+  possible at any time but is not automatic.
+- The approval gate exists because of business/regulatory reasons, not technical ones.
+  Any approved build should be deployable within minutes.
+
+CD activities:
+- **Deploy to staging** — Apply manifests (or run Helm/Kustomize) against a staging
+  cluster. Automated.
+- **Integration tests** — Test the service against its real dependencies in staging.
+- **Performance/load tests** — Run Gatling, k6, or Locust to detect regressions.
+- **Security/compliance scan** — DAST (Dynamic Application Security Testing).
+- **Human approval gate** — A Slack message, PagerDuty alert, or CI/CD UI button.
+- **Deploy to production** — Triggered by the approver.
+
+---
+
+### Continuous Deployment
+
+**Every code change that passes all automated gates is deployed to production
+automatically, with no human approval step.**
+
+This is the "gold standard" for teams with mature testing, observability, and
+rollback capabilities. Netflix, Google, Amazon, and Facebook all practice Continuous
+Deployment for many of their services.
+
+Requirements for safe Continuous Deployment:
+- Comprehensive test coverage (unit, integration, contract, E2E).
+- Automated canary analysis with data-driven promotion.
+- Feature flags to decouple deployment from feature release.
+- Instant rollback capability (Blue-Green or canary abort).
+- Robust monitoring and alerting (SLO-based error budgets).
+- Post-deployment smoke tests that run within seconds.
+
+The difference between Continuous Delivery and Continuous Deployment is **one
+approval gate**. Removing it requires building confidence in your automation.
+
+---
+
+### Summary Table
+
+| Concept | Automation Level | Human Gate | Goal |
+|---|---|---|---|
+| Continuous Integration | Build + Test + Publish | None | Catch bugs at merge time |
+| Continuous Delivery | CI + Deploy to staging + E2E tests | Approval before prod | Always have a deployable artifact |
+| Continuous Deployment | CI + all the way to prod | None | Release continuously, safely |
+
+---
+
+## How Kubernetes Fits Into the Pipeline
+
+Kubernetes is the **deployment target**, not the CI system. It plays several distinct
+roles across the pipeline:
+
+### 1. CI Build Environment (optional but common)
+
+Modern CI systems (GitHub Actions, GitLab CI, Tekton, Argo Workflows) run CI jobs
+**inside Kubernetes Pods**. Benefits:
+- Ephemeral build environments — each job gets a fresh Pod.
+- Horizontal scaling — Kubernetes schedules more Pods as the queue grows.
+- Resource governance — Jobs cannot starve each other via resource quotas.
+- Secrets management — K8s Secrets or external vaults inject credentials.
+
+```yaml
+# Example GitHub Actions self-hosted runner on Kubernetes
+# Or Tekton PipelineRun that builds images inside a Pod
+```
+
+### 2. Staging / Pre-Production Cluster
+
+The staging Kubernetes cluster receives every merged change automatically. Your CI
+pipeline runs `kubectl apply -k overlays/staging` (or `helm upgrade`) after
+publishing the new image. Integration tests run against this cluster.
+
+### 3. Production Deployment Target
+
+The final stage deploys to the production cluster using one of the strategies covered
+in `deployment-strategies.md`:
+- Rolling Update (most common, via `kubectl apply` or Helm)
+- Canary (via Argo Rollouts or Flagger)
+- Blue-Green (via Argo Rollouts or manual selector patch)
+
+### 4. Kubernetes Primitives Used by CD Systems
+
+| Kubernetes Feature | CD Usage |
+|---|---|
+| Namespaces | Isolate dev/staging/prod within one cluster |
+| RBAC | CI service accounts have `deploy` permission only to their namespace |
+| Readiness Probes | CD system waits for `rollout status` before marking success |
+| PodDisruptionBudget | Prevents CD from taking down too many replicas at once |
+| Horizontal Pod Autoscaler | Production scales automatically after deployment |
+| Secrets | Registry credentials, database passwords injected into Pods |
+| ConfigMaps | Environment-specific configuration without re-building images |
+
+### 5. Health and Rollback
+
+```bash
+# CD system checks rollout health:
+kubectl rollout status deployment/myapp --timeout=5m
+
+# If rollout fails, CD triggers rollback:
+kubectl rollout undo deployment/myapp
+```
+
+---
+
+## Push-Based vs GitOps (Pull-Based) Deployment
+
+This is the most important architectural decision in your CD pipeline. The two
+models have fundamentally different trust and security properties.
+
+### Push-Based Deployment
+
+```
+Developer → Git commit → CI pipeline runs → CI pipeline pushes to Kubernetes
+                                              (kubectl apply / helm upgrade)
+```
+
+**How it works:**
+The CI/CD system (Jenkins, GitHub Actions, GitLab CI) has credentials to the
+Kubernetes cluster. After tests pass, the pipeline directly calls `kubectl apply`
+or `helm upgrade` to update the cluster.
+
+**Trust model:** The CI/CD system is trusted with cluster credentials. The cluster
+is pushed to; it does not pull.
+
+**Pros:**
+- Simple to understand and implement.
+- Works with any CI system.
+- Immediate feedback — the CI job reports success/failure synchronously.
+- Familiar to teams coming from VM-based deployments.
+
+**Cons:**
+- CI/CD system holds powerful cluster credentials — a security risk. If the CI
+  system is compromised, the attacker has cluster access.
+- Credentials must be rotated and distributed to every CI worker.
+- Drift is possible — someone can `kubectl apply` directly to production and the
+  Git repo won't reflect that.
+- The cluster state is only as fresh as the last CI run. No automatic re-sync.
+- Multi-cluster deployments require credentials for each cluster in the CI system.
+
+---
+
+### GitOps (Pull-Based) Deployment
+
+```
+Developer → Git commit (to config repo) → GitOps operator in cluster detects diff
+                                          → operator applies changes from inside cluster
+```
+
+**How it works:**
+A GitOps operator (Argo CD, Flux) runs **inside** the cluster and continuously
+watches a Git repository (the "desired state"). When the operator detects a diff
+between the Git state and the cluster state, it pulls and applies the changes.
+The cluster reaches out to Git; nothing pushes into the cluster.
+
+**Key principle:** **Git is the single source of truth.** Every cluster state change
+must go through Git. `kubectl apply` directly to production is prohibited.
+
+**Trust model:** The cluster needs read access to Git, not the other way around.
+Cluster credentials never leave the cluster. Audit trail is 100% in Git history.
+
+**Pros:**
+- **Security** — No cluster credentials in the CI system. The operator has minimal
+  RBAC to apply only what it manages.
+- **Drift detection** — The operator continuously compares desired (Git) vs. actual
+  (cluster). Manual changes are detected and can be auto-corrected.
+- **Self-healing** — If someone deletes a Deployment manually, the GitOps operator
+  re-creates it within seconds.
+- **Auditability** — Every cluster change is a Git commit with author, timestamp,
+  and diff. `git log` is your audit log.
+- **Multi-cluster** — Deploy to many clusters by pointing each cluster's operator
+  at the same (or different) Git repo.
+- **Disaster recovery** — Rebuild a cluster from scratch by pointing a new operator
+  at the Git repo.
+
+**Cons:**
+- **Complexity** — Requires learning Argo CD or Flux, structuring a config repo.
+- **Asynchronous** — The CI pipeline cannot directly verify if the deployment
+  succeeded. You need to poll Argo CD's API or use sync hooks.
+- **Secrets management** — Secrets cannot be stored in Git in plaintext.
+  Requires Sealed Secrets, SOPS, or an external vault (Vault, AWS Secrets Manager).
+- **Image update automation** — Automatically updating the image tag in Git when
+  a new image is published requires an additional component (Argo CD Image Updater,
+  Flux Image Reflector).
+
+---
+
+### Comparison Table
+
+| Dimension | Push-Based | GitOps (Pull-Based) |
+|---|---|---|
+| Cluster credentials location | CI/CD system | Inside the cluster (operator) |
+| Source of truth | CI pipeline | Git repository |
+| Drift detection | None | Continuous |
+| Self-healing | None | Yes (auto-sync) |
+| Audit trail | CI logs | Git history |
+| Secret management | Simpler | Requires Sealed Secrets / SOPS / Vault |
+| Multi-cluster | Requires creds per cluster | Each cluster has its own operator |
+| Feedback latency | Synchronous | Asynchronous (poll Argo CD API) |
+| Team learning curve | Low | Medium |
+| Industry adoption trend | Declining | Growing (CNCF standard practice) |
+
+**Recommendation:** For new Kubernetes projects, **start with GitOps**. Argo CD has
+become the de facto standard. The security and auditability benefits are not
+theoretical — they address real incidents (see: CircleCI breach 2023, where CI
+system credentials were compromised).
+
+---
+
+## A Typical Pipeline Flow
+
+Below is a production-grade pipeline combining CI (push-based) with GitOps
+(pull-based) deployment. This "CI pushes image, GitOps deploys" hybrid is the
+most common pattern in mature engineering organizations.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  DEVELOPER WORKSTATION                                              │
+│                                                                     │
+│  git commit -m "feat: add user caching"                            │
+│  git push origin feature/user-caching                              │
+└───────────────────────────┬─────────────────────────────────────────┘
+                            │ webhook
+                            ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  STAGE 1: CI — CODE VALIDATION (GitHub Actions / GitLab CI)        │
+│                                                                     │
+│  ├─ Lint (eslint, golangci-lint, flake8)                           │
+│  ├─ Unit tests (go test, pytest, jest) — parallel matrix           │
+│  ├─ Security scan (Semgrep, Bandit, gosec)                         │
+│  ├─ Dependency vulnerability scan (npm audit, Snyk, Dependabot)    │
+│  └─ Build Docker image: myapp:$GIT_COMMIT_SHA                      │
+│                                                                     │
+│  [GATE] All checks green → proceed                                 │
+└───────────────────────────┬─────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  STAGE 2: IMAGE PUBLICATION                                        │
+│                                                                     │
+│  ├─ Container image vulnerability scan (Trivy, Grype)              │
+│  │   └─ CRITICAL CVEs → BLOCK publish                              │
+│  ├─ Sign image with Cosign (supply chain security)                 │
+│  ├─ Push to registry: ecr.aws/myorg/myapp:abc1234                  │
+│  └─ Push immutable tag: ecr.aws/myorg/myapp:1.7.3                  │
+└───────────────────────────┬─────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  STAGE 3: CONFIG REPO UPDATE (CI writes to GitOps repo)            │
+│                                                                     │
+│  CI job updates the image tag in the GitOps config repo:           │
+│  ├─ git clone git@github.com/myorg/k8s-config                      │
+│  ├─ cd overlays/staging && kustomize edit set image myapp:abc1234  │
+│  ├─ git commit -m "chore: bump myapp to abc1234 [staging]"         │
+│  └─ git push → triggers Argo CD sync                               │
+└───────────────────────────┬─────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  STAGE 4: STAGING DEPLOYMENT (Argo CD — GitOps pull)               │
+│                                                                     │
+│  Argo CD operator (running in staging cluster):                    │
+│  ├─ Detects config repo change                                     │
+│  ├─ Runs kustomize build → computes desired manifests              │
+│  ├─ Diffs against current cluster state                            │
+│  ├─ Applies changes: kubectl apply -f ...                          │
+│  ├─ Waits for rollout: kubectl rollout status                      │
+│  └─ Reports sync status: Healthy / Degraded                        │
+└───────────────────────────┬─────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  STAGE 5: AUTOMATED TESTING IN STAGING                             │
+│                                                                     │
+│  ├─ Integration tests (real DB, real queue, real downstream APIs)  │
+│  ├─ Contract tests (Pact, consumer-driven)                         │
+│  ├─ Performance tests (k6 with SLO thresholds: p99 < 200ms)       │
+│  ├─ Smoke tests (critical user journeys: login, checkout, etc.)    │
+│  └─ Security DAST scan (OWASP ZAP, Burp Suite)                    │
+│                                                                     │
+│  [GATE] All tests pass → proceed                                   │
+│  [GATE for Continuous Delivery] Human approval in Argo CD / Slack  │
+└───────────────────────────┬─────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  STAGE 6: PRODUCTION DEPLOYMENT (Argo CD — GitOps pull)            │
+│                                                                     │
+│  CI job (or human) updates config repo:                            │
+│  ├─ kustomize edit set image myapp:abc1234 (overlays/prod)         │
+│  ├─ git commit + push                                              │
+│                                                                     │
+│  Argo CD (production cluster):                                     │
+│  ├─ Detects change → applies Canary rollout (Argo Rollouts)        │
+│  ├─ 5% traffic → monitor for 30 min                               │
+│  ├─ Analysis: error rate < 1%, p99 < 150ms                        │
+│  ├─ 20% → 50% → 100% (automated promotion)                        │
+│  └─ OR abort + roll back to previous stable image tag             │
+└───────────────────────────┬─────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  STAGE 7: POST-DEPLOYMENT                                          │
+│                                                                     │
+│  ├─ Smoke tests run against production                             │
+│  ├─ Slack notification: "myapp 1.7.3 deployed to prod ✓"          │
+│  ├─ PagerDuty event: deployment marker (for alert correlation)     │
+│  ├─ Datadog / Grafana deployment annotation (for dashboards)       │
+│  └─ Rollback trigger: alert → Argo CD manual sync to prev revision │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Tooling Landscape
+
+### CI Systems
+
+| Tool | Notes |
+|---|---|
+| **GitHub Actions** | Tight GitHub integration; large marketplace; hosted runners |
+| **GitLab CI/CD** | Built-in to GitLab; strong Kubernetes integration; free self-hosted |
+| **Tekton** | Kubernetes-native CI; runs pipelines as Kubernetes CRDs; CNCF project |
+| **Argo Workflows** | Kubernetes-native workflow engine; used for both CI and data pipelines |
+| **Jenkins** | Mature; highly customizable; heavy operational overhead |
+| **CircleCI** | Hosted; fast; docker-layer caching |
+
+### GitOps / CD Systems
+
+| Tool | Notes |
+|---|---|
+| **Argo CD** | Most popular GitOps tool; rich UI; multi-cluster; ApplicationSets |
+| **Flux v2** | CNCF project; lightweight; strong Helm/Kustomize support; GitRepository CRD |
+| **Argo Rollouts** | Advanced deployment strategies (Canary, Blue-Green) with analysis |
+| **Flagger** | Progressive delivery; integrates with Istio, Linkerd, App Mesh |
+| **Spinnaker** | Enterprise-grade; multi-cloud; Blue-Green native; complex to operate |
+| **Helm** | Package manager for Kubernetes; not a CD tool but used within CD pipelines |
+
+### Secret Management in GitOps
+
+| Tool | Approach |
+|---|---|
+| **Sealed Secrets** | Encrypt secrets with a cluster public key; safe to commit to Git |
+| **SOPS** | Mozilla tool; encrypts YAML/JSON with AWS KMS, GCP KMS, Age |
+| **External Secrets Operator** | Syncs secrets from AWS SSM, Vault, Azure Key Vault into K8s Secrets |
+| **HashiCorp Vault** | Full-featured secret management; sidecar or CSI driver injection |
+| **AWS Secrets Manager + ASCP** | AWS-native; CSI driver mounts secrets into pods as files |
+
+---
+
+## Related Files in This Repository
+
+This document is part of a broader reference collection:
+
+```
+/
+├── docs/
+│   ├── architecture.md          ← Kubernetes control plane deep dive
+│   ├── deployment-strategies.md ← Recreate / Rolling / Blue-Green / Canary
+│   └── ci-cd-concepts.md        ← This file
+│
+├── core/
+│   └── workloads/
+│       ├── pod/
+│       │   ├── README.md
+│       │   ├── basic-pod.yml
+│       │   ├── init-container.yml
+│       │   └── sidecar-container.yml
+│       └── deployment/
+│           ├── README.md
+│           ├── nginx-deployment.yml    ← production deployment with probes
+│           ├── rolling-strategy.yml    ← rolling update fields annotated
+│           └── kustomize/
+│               ├── base/              ← shared base manifests
+│               └── overlays/
+│                   ├── dev/           ← small resources, nginx:latest
+│                   ├── staging/       ← 2 replicas, nginx:1.25
+│                   └── prod/          ← 4 replicas, larger limits
+```
+
+The Kustomize overlays in `core/workloads/deployment/kustomize/` directly implement
+the environment promotion model described in the pipeline above: a single base
+manifest is patched per environment without duplicating YAML.
+
+---
+
+## Further Reading
+
+**GitOps**
+- [Argo CD Getting Started](https://argo-cd.readthedocs.io/en/stable/getting_started/)
+- [Flux Documentation](https://fluxcd.io/flux/)
+- [OpenGitOps Principles](https://opengitops.dev/)
+- [CNCF GitOps Working Group](https://github.com/cncf/tag-app-delivery/tree/main/gitops-wg)
+- [GitOps Tech — What is GitOps?](https://www.gitops.tech/)
+
+**CI/CD Patterns**
+- [Google — Testing on the Toilet: Change Detector Tests Considered Harmful](https://testing.googleblog.com/2015/01/testing-on-toilet-change-detector-tests.html)
+- [Martin Fowler — Continuous Delivery](https://martinfowler.com/books/continuousDelivery.html)
+- [The Twelve-Factor App — Build, Release, Run](https://12factor.net/build-release-run)
+- [DORA State of DevOps Report](https://dora.dev/research/)
+
+**Security in the Pipeline**
+- [SLSA — Supply Chain Levels for Software Artifacts](https://slsa.dev/)
+- [Sigstore / Cosign — Container Image Signing](https://docs.sigstore.dev/)
+- [CNCF Security Whitepaper](https://github.com/cncf/tag-security/blob/main/security-whitepaper/CNCF_cloud-native-security-whitepaper-May2022-v2.pdf)
+- [CircleCI Breach Post-Mortem — Why CI Credentials Are High-Value Targets](https://circleci.com/blog/jan-4-2023-incident-report/)

--- a/docs/deployment-strategies.md
+++ b/docs/deployment-strategies.md
@@ -1,0 +1,499 @@
+# Kubernetes Deployment Strategies
+
+A comprehensive comparison of the four primary deployment strategies used in
+production Kubernetes environments. Each strategy makes different trade-offs between
+downtime risk, resource consumption, rollback speed, and operational complexity.
+Choosing the right strategy depends on your service's SLA, traffic patterns, and
+team maturity.
+
+---
+
+## Table of Contents
+
+1. [Strategy Overview](#strategy-overview)
+2. [Recreate](#1-recreate)
+3. [Rolling Update](#2-rolling-update)
+4. [Blue-Green](#3-blue-green)
+5. [Canary](#4-canary)
+6. [Decision Matrix](#decision-matrix)
+7. [When to Use Each in Production](#when-to-use-each-in-production)
+8. [Industry Examples](#industry-examples)
+9. [Further Reading](#further-reading)
+
+---
+
+## Strategy Overview
+
+```
+STRATEGY         DOWNTIME?   EXTRA RESOURCES   ROLLBACK SPEED   RISK      COMPLEXITY
+─────────────────────────────────────────────────────────────────────────────────────
+Recreate         Yes         None              Fast (redeploy)  High      Low
+Rolling Update   No*         ~1 pod extra      Medium           Medium    Low
+Blue-Green       No          2x (full copy)    Instant          Low       Medium
+Canary           No          Partial (%)       Fast             Very Low  High
+```
+
+---
+
+## 1. Recreate
+
+### What It Is
+
+The Recreate strategy terminates **all existing Pods first**, then starts the new
+version. The cluster is intentionally empty between the two generations.
+
+### How It Works in Kubernetes
+
+```yaml
+strategy:
+  type: Recreate
+```
+
+Kubernetes's Deployment controller:
+1. Scales the existing ReplicaSet to 0 (all old Pods receive SIGTERM).
+2. Waits for all old Pods to be terminated.
+3. Creates a new ReplicaSet with the new template and scales it to the desired count.
+
+### Timeline
+
+```
+Time ──────────────────────────────────────────────────────────►
+
+[v1 Pods running]
+        │  kubectl apply (new version)
+        ▼
+[ALL v1 Pods terminated]  ← DOWNTIME WINDOW BEGINS
+        │
+        ▼
+[ALL v2 Pods starting]    ← DOWNTIME WINDOW ENDS when v2 is Ready
+        │
+        ▼
+[v2 Pods running] ── traffic resumes
+```
+
+### Pros
+
+- **Simplicity** — No version co-existence; zero risk of mixed-version traffic.
+- **No resource overhead** — No extra nodes or Pods needed.
+- **Predictable** — Easy to reason about; useful for stateful apps where two
+  versions cannot run simultaneously (e.g., database schema is not backward-compatible).
+- **Clean state** — Every instance starts fresh; no lingering v1 connections.
+
+### Cons
+
+- **Guaranteed downtime** — The window between old termination and new readiness is
+  a hard outage. For slow-starting applications this can be significant.
+- **No gradual validation** — The new version is "all or nothing". If v2 crashes,
+  all traffic is impacted.
+- **Poor for SLA-sensitive services** — Any service with an uptime SLA > 99% cannot
+  afford planned downtime per deployment.
+
+### When to Use Recreate
+
+- Development environments where downtime is acceptable.
+- Batch processing jobs or workers with no live traffic.
+- Database schema migrations where you cannot run v1 and v2 simultaneously.
+- Internal tooling with low-traffic windows (deploy at 2 AM).
+- Legacy monoliths being containerized for the first time.
+
+---
+
+## 2. Rolling Update
+
+### What It Is
+
+Rolling Update gradually replaces old Pods with new ones, ensuring that some
+capacity is always available. It is the **default Kubernetes strategy** for good
+reason: zero downtime with minimal resource overhead.
+
+### How It Works in Kubernetes
+
+```yaml
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1        # How many extra Pods can exist above the desired count
+    maxUnavailable: 0  # How many Pods can be unavailable during the update
+```
+
+With `replicas: 4`, `maxSurge: 1`, `maxUnavailable: 0`:
+1. Create 1 extra new Pod (total: 5) — wait for it to be Ready.
+2. Terminate 1 old Pod (total: 4, but 1 is new).
+3. Create 1 more new Pod (total: 5), wait for Ready.
+4. Terminate 1 more old Pod... repeat until all 4 are new.
+
+### Timeline
+
+```
+Time ──────────────────────────────────────────────────────────►
+
+Pods:  [v1][v1][v1][v1]
+                     │ kubectl apply
+                     ▼
+       [v1][v1][v1][v1][v2]  ← surge: +1 new (wait for Ready)
+       [v1][v1][v1]   [v2]   ← remove 1 old
+       [v1][v1][v1][v2][v2]  ← surge: +1 new (wait for Ready)
+       [v1][v1]   [v2][v2]   ← remove 1 old
+       ... (continues until all v1 replaced)
+       [v2][v2][v2][v2]      ← rollout complete
+```
+
+### Key Fields
+
+| Field | Effect |
+|---|---|
+| `maxSurge: 1` | At most 1 extra Pod above `replicas` at any time |
+| `maxSurge: 25%` | Can be a percentage of `replicas` |
+| `maxUnavailable: 0` | Never go below desired replica count (zero-downtime) |
+| `maxUnavailable: 1` | Allow 1 Pod to be unavailable (faster rollout) |
+| `minReadySeconds: 10` | A new Pod must be Ready for 10s before being considered available |
+| `progressDeadlineSeconds: 600` | Rollout is marked Failed if not complete in 10 min |
+
+### Pros
+
+- **Zero downtime** (with `maxUnavailable: 0`).
+- **Minimal resource overhead** — only `maxSurge` extra Pods at any time.
+- **Built-in health gating** — `readinessProbe` failures halt the rollout.
+- **Easy rollback** — `kubectl rollout undo deployment/<name>`.
+- **Simple** — Native Kubernetes; no extra tooling required.
+
+### Cons
+
+- **Two versions run simultaneously** — Requests may be served by v1 or v2 during
+  the rollout. APIs must be backward-compatible.
+- **Slow for large fleets** — With `maxSurge: 1` and 100 replicas, you cycle through
+  100 iterations. Increase `maxSurge` (e.g., 25%) to speed up.
+- **No traffic weighting** — You can't send 5% of traffic to the new version;
+  it's proportional to the number of ready Pods.
+- **Stateful apps** — Rolling updates of StatefulSets are ordered and slower.
+
+### Rollback
+
+```bash
+# Check rollout status
+kubectl rollout status deployment/nginx
+
+# View rollout history
+kubectl rollout history deployment/nginx
+
+# Rollback to previous revision
+kubectl rollout undo deployment/nginx
+
+# Rollback to a specific revision
+kubectl rollout undo deployment/nginx --to-revision=3
+```
+
+---
+
+## 3. Blue-Green
+
+### What It Is
+
+Blue-Green maintains **two identical production environments** (Blue = current,
+Green = new). Traffic is switched atomically from Blue to Green using a Service
+selector update. Rollback is instant — just flip the selector back.
+
+### How It Works in Kubernetes
+
+Kubernetes does not have a native Blue-Green resource. It is implemented using:
+- Two Deployments: one labeled `slot: blue`, one labeled `slot: green`.
+- One Service whose `selector` points to either `slot: blue` or `slot: green`.
+
+```yaml
+# Blue Deployment (currently live)
+metadata:
+  name: myapp-blue
+spec:
+  template:
+    metadata:
+      labels:
+        app: myapp
+        slot: blue  # Service selector targets this
+
+# Green Deployment (new version, being validated)
+metadata:
+  name: myapp-green
+spec:
+  template:
+    metadata:
+      labels:
+        app: myapp
+        slot: green  # Service selector does NOT target this yet
+```
+
+Traffic switch (zero-downtime):
+```bash
+kubectl patch service myapp -p '{"spec":{"selector":{"slot":"green"}}}'
+```
+
+Rollback (instant):
+```bash
+kubectl patch service myapp -p '{"spec":{"selector":{"slot":"blue"}}}'
+```
+
+### Timeline
+
+```
+Time ──────────────────────────────────────────────────────────►
+
+[BLUE: v1 running — 100% traffic]
+
+         Deploy GREEN (v2), run smoke tests — NO traffic yet
+         GREEN validated ✓
+
+         kubectl patch service → selector: green
+         ↓
+[BLUE: v1 idle]     [GREEN: v2 — 100% traffic]
+
+         Issue detected → kubectl patch service → selector: blue (INSTANT)
+
+[BLUE: v1 — 100% traffic]  ← full rollback in seconds
+```
+
+### Pros
+
+- **Instant rollback** — A single `kubectl patch` reverts all traffic immediately.
+- **Full pre-production validation** — Green can be smoke-tested with real
+  infrastructure (databases, service mesh) before receiving traffic.
+- **No mixed versions** — Traffic is served by exactly one version at all times.
+- **Clean swap** — No gradual exposure means no need for v1/v2 API compatibility
+  (assuming the switch is fast relative to in-flight requests).
+
+### Cons
+
+- **2x resource cost** — You maintain a full second copy of every Pod. This doubles
+  your compute bill during deployments.
+- **Database migrations** — If v2 requires a DB schema change, you must migrate the
+  schema before the switch (making it additive/backward-compatible) or accept a
+  brief compatibility window.
+- **State / sticky sessions** — In-flight sessions on Blue may be dropped when
+  traffic switches to Green. Use session draining or sticky sessions carefully.
+- **Operational overhead** — Requires automation to manage two environments;
+  easy to forget to scale down the idle slot (wasting money).
+- **Not built-in** — Requires discipline in label/selector naming conventions.
+
+### Implementation Notes
+
+Tools that automate Blue-Green in Kubernetes:
+- **Argo Rollouts** — `strategy: blueGreen` with automatic analysis and promotion.
+- **Flux Flagger** — Progressive delivery controller with Blue-Green support.
+- **Spinnaker** — Pipeline-based delivery platform with Blue-Green stages.
+
+---
+
+## 4. Canary
+
+### What It Is
+
+Canary releases gradually shift a **small percentage of traffic** to the new version,
+monitor it for errors and latency regressions, and progressively increase the
+percentage until the new version handles 100% of traffic (or the release is aborted).
+
+The name comes from the "canary in a coal mine" — a small, controlled exposure that
+detects danger before it affects everyone.
+
+### How It Works in Kubernetes
+
+**Native Kubernetes (approximate traffic splitting via replica ratio):**
+
+```
+10 replicas v1, 1 replica v2 → ~9% canary traffic
+↓ promote (metrics look good)
+9 replicas v1, 2 replicas v2  → ~18% canary traffic
+...continue until v2 = 10
+```
+
+This is coarse-grained (limited by replica count) and requires API compatibility
+between versions. For precise traffic splitting (e.g., exactly 5%), you need:
+
+**Precise traffic splitting options:**
+- **Argo Rollouts + Istio/Gateway API** — Weight-based traffic split at the service
+  mesh level (completely independent of replica count).
+- **Nginx Ingress** — `nginx.ingress.kubernetes.io/canary-weight: "10"` annotation.
+- **Flagger** — Automated canary analysis with Prometheus metrics gates.
+
+### Timeline
+
+```
+Time ──────────────────────────────────────────────────────────────────►
+
+v1: [●][●][●][●][●][●][●][●][●][●]   100%
+                    ↓ deploy canary
+v1: [●][●][●][●][●][●][●][●][●]  90%
+v2: [●]                            10%  ← monitor error rate, p99 latency
+
+(metrics OK after 30 min)
+v1: [●][●][●][●][●][●][●][●]      80%
+v2: [●][●]                         20%
+
+(metrics OK after 1 hour)
+v1: [●][●][●][●][●]               50%
+v2: [●][●][●][●][●]               50%
+
+(metrics OK)
+v1: []                              0%
+v2: [●][●][●][●][●][●][●][●][●][●] 100% ← full promotion
+
+OR:
+(ERROR RATE SPIKE at any stage → abort, route all traffic back to v1)
+```
+
+### Key Metrics to Monitor During Canary
+
+| Signal | Typical Threshold |
+|---|---|
+| HTTP 5xx error rate | < 1% of requests |
+| p99 latency | < 1.5x baseline |
+| p50 latency | < 1.2x baseline |
+| Pod restart count | 0 restarts in window |
+| Custom business metrics | Conversion rate, checkout success, etc. |
+
+### Pros
+
+- **Lowest blast radius** — Only a small fraction of users experience a bad release.
+- **Real production validation** — Canary traffic is real users, real load, real data.
+  Catches issues that staging never surfaces.
+- **Data-driven promotion** — Automated analysis (Argo Rollouts `AnalysisTemplate`)
+  gates promotion on actual metrics.
+- **Gradual confidence building** — Engineers gain confidence progressively, not
+  all at once.
+
+### Cons
+
+- **Highest operational complexity** — Requires a service mesh or advanced Ingress,
+  metrics pipeline, and automated analysis setup.
+- **Two versions in production simultaneously** — All the API compatibility concerns
+  of Rolling Update apply, but for a longer, intentional window.
+- **Debugging is harder** — "Why do 10% of users see errors?" is a harder
+  conversation than "the new version is broken".
+- **Slow for low-traffic services** — Statistical significance requires enough
+  requests. A service with 10 RPM may take hours to accumulate sufficient data.
+
+---
+
+## Decision Matrix
+
+| | **Recreate** | **Rolling Update** | **Blue-Green** | **Canary** |
+|---|:---:|:---:|:---:|:---:|
+| **Downtime** | Yes | No* | No | No |
+| **Resource Overhead** | None | ~1 Pod extra | 2x full copy | Partial (canary %) |
+| **Rollback Speed** | Slow (redeploy) | Medium (undo) | Instant (selector patch) | Fast (abort + reroute) |
+| **Traffic Control Precision** | N/A | Coarse (by replica %) | All-or-nothing | Fine-grained (%) |
+| **Production Risk** | High | Medium | Low | Very Low |
+| **API Compatibility Required** | No | Yes (during rollout) | No (atomic switch) | Yes (during canary) |
+| **Infrastructure Complexity** | Low | Low | Medium | High |
+| **Suitable for Stateful Apps** | Sometimes | With care | Better | With care |
+| **Cost During Deployment** | Lowest | Low | 2x | Low–Medium |
+| **Best For** | Dev / batch | Most production workloads | High-stakes releases | High-volume, risk-averse teams |
+
+\* Zero downtime with `maxUnavailable: 0` and working `readinessProbe`.
+
+---
+
+## When to Use Each in Production
+
+### Use Recreate When:
+- The workload is a **batch job** or background worker with no live HTTP traffic.
+- Running **database schema migrations** where v1 and v2 are incompatible.
+- You are in a **development or CI environment** and downtime is acceptable.
+- The application explicitly **cannot** run two versions concurrently (e.g., it holds
+  an exclusive lock or distributed lease).
+
+### Use Rolling Update When:
+- You have a standard, stateless web service or API.
+- Your API is **backward-compatible** between versions.
+- You want **zero-downtime** with **minimal resource cost** and **no extra tooling**.
+- You are deploying **frequently** (multiple times per day) and need a fast,
+  simple default.
+- This is the **right default** for 80%+ of Kubernetes workloads.
+
+### Use Blue-Green When:
+- You need **guaranteed instant rollback** (e.g., payment processing, order systems).
+- You want to **validate the new version** against real infrastructure before it
+  receives any traffic.
+- You have **budget** for 2x resources during deployments.
+- Your service has **long-lived connections** (WebSocket, gRPC streaming) that cannot
+  be gracefully migrated mid-deployment.
+- You are doing a **major version upgrade** that changes external contracts.
+
+### Use Canary When:
+- You deploy a **high-volume service** (>1000 RPM) where statistical significance
+  for canary analysis is achievable quickly.
+- You have a **mature observability stack** (Prometheus, Grafana, distributed tracing).
+- You have a **risk-averse culture** or a history of regressions in production.
+- You are running **A/B tests** or **feature flags** alongside deployment.
+- You have invested in a **service mesh** (Istio, Linkerd) or **Argo Rollouts**.
+
+---
+
+## Industry Examples
+
+### Google — Canary
+
+Google has used canary releases as a core deployment primitive for over a decade,
+described in the SRE Book as "canarying." Their internal deployment system
+(Borg/Kubernetes) supports automatic canary analysis, rolling out changes to 1% of
+traffic, then 5%, 10%, 50%, before full promotion. Every change to a high-visibility
+service like Search or Gmail goes through this process. The key insight Google
+operationalized: **production is the only environment that matters for validation**.
+Their error budget framework (SLI/SLO/error budget) directly drives whether a canary
+can proceed.
+
+Reference: [Google SRE Book, Chapter 8 — Release Engineering](https://sre.google/sre-book/release-engineering/)
+
+### Netflix — Blue-Green
+
+Netflix pioneered Blue-Green deployment (along with Chaos Engineering) as a
+core reliability pattern. Their Spinnaker deployment platform, which they open-sourced
+in 2015, has Blue-Green as a first-class deployment stage. Netflix runs multiple
+AWS regions and uses Blue-Green to deploy their streaming backend, enabling instant
+rollback without affecting the 200M+ subscribers watching at any given moment.
+Their philosophy: **"Always be ready to roll back instantly."** Spinnaker's automated
+canary analysis (Kayenta) was a later addition that combines both strategies.
+
+Reference: [Netflix Tech Blog — Automated Canary Analysis at Netflix](https://netflixtechblog.com/automated-canary-analysis-at-netflix-with-kayenta-3260bc7acc69)
+
+### Amazon — Rolling Updates (with Canary for high-risk changes)
+
+Amazon uses Rolling Updates as the default for most of their microservices on ECS
+and EKS, relying on health check gating to prevent bad versions from fully rolling out.
+For high-risk changes (new algorithms, infrastructure changes affecting all customers),
+they use weighted routing via AWS Route 53 or Application Load Balancer to implement
+canary-style deployments at the infrastructure layer. Their one-way door vs. two-way
+door framework maps directly to deployment strategy selection: reversible decisions
+(two-way doors) use Rolling Updates; irreversible decisions use Canary or Blue-Green.
+
+### GitLab — Canary with Feature Flags
+
+GitLab deploys GitLab.com (running on Kubernetes) using Canary deployments combined
+with feature flags. Their "deploy to a canary stage first" model means every
+deployment first reaches their internal users (GitLab employees use GitLab.com) and
+a small percentage of external users before full rollout. They use LaunchDarkly-style
+feature flags to decouple deployment from feature release.
+
+Reference: [GitLab's Deployment Strategy](https://about.gitlab.com/blog/2021/02/05/ci-deployment-and-environments/)
+
+### Uber — Canary with Automated Gates
+
+Uber's deployment platform (Peloton/internally developed) enforces canary deployments
+for all production services. Automated gates check:
+- Error rate delta vs. baseline
+- p99 latency delta
+- Custom business metrics (trip requests, driver availability)
+
+If any gate fails, the deployment is automatically rolled back without human
+intervention. Uber's scale (millions of trips per day) means canary data accumulates
+within minutes, making statistical analysis fast and reliable.
+
+---
+
+## Further Reading
+
+- [Kubernetes Deployment Strategies (Argo Rollouts)](https://argoproj.github.io/argo-rollouts/concepts/)
+- [Flagger Progressive Delivery](https://flagger.app/)
+- [Martin Fowler — BlueGreenDeployment](https://martinfowler.com/bliki/BlueGreenDeployment.html)
+- [Martin Fowler — CanaryRelease](https://martinfowler.com/bliki/CanaryRelease.html)
+- [Google SRE Book — Chapter 8: Release Engineering](https://sre.google/sre-book/release-engineering/)
+- [Netflix Spinnaker](https://spinnaker.io/)
+- [Kayenta: Automated Canary Analysis](https://netflixtechblog.com/automated-canary-analysis-at-netflix-with-kayenta-3260bc7acc69)
+- [Kubernetes Rolling Update docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment)


### PR DESCRIPTION
## Summary
- Add `docs/architecture.md` — control plane components (kube-apiserver, etcd, scheduler, controller-manager), data plane components (kubelet, kube-proxy, CRI), request lifecycle when `kubectl apply` is run, component interaction diagram
- Add `docs/deployment-strategies.md` — detailed comparison of all 4 strategies with decision flowchart, traffic pattern diagrams, and rollback procedures for each
- Add `docs/ci-cd-concepts.md` — pipeline stage definitions (lint → scan → build → test → deploy → verify), GitOps pull-based model vs push-based CI, image tagging strategy, and canary release metrics

## Issues referenced
Closes #75, #76, #98, relates to #74, #77, #78, #83, #90, #96

## Test plan
- [ ] All internal links to `/core/`, `/platform/`, `/examples/` directories resolve
- [ ] Mermaid diagrams render in GitHub Markdown preview
- [ ] Deployment strategy decision flowchart correctly routes to all 4 strategies