### PR TITLE
fix(ci): disable yamllint document-start rule for Kubernetes multi-document YAML

### DIFF
--- a/.github/workflows/validate-yaml.yml
+++ b/.github/workflows/validate-yaml.yml
@@ -59,7 +59,7 @@ jobs:
                   line-length: {max: 160, level: warning},
                   truthy: {allowed-values: ["true", "false"]},
                   comments: {min-spaces-from-content: 1},
-                  document-start: {present: false}
+                  document-start: disable
                 }
               }'
 


### PR DESCRIPTION
## Problem
yamllint `document-start: {present: false}` forbids `---` markers. Kubernetes YAML files commonly use `---` as multi-document separators (e.g., ConfigMap + Deployment in one file, multi-policy Kyverno files). This would cause yamllint CI failures on all PRs containing multi-document YAML.

## Fix
Change `document-start: {present: false}` → `document-start: disable` so the rule is not enforced in either direction. This is the correct setting for a Kubernetes YAML repository.

## Test plan
- [ ] PRs with multi-document YAML pass yamllint