### PR TITLE
fix(ci): exclude helm templates from yamllint — Go template syntax is not valid YAML

### DIFF
--- a/.github/workflows/validate-yaml.yml
+++ b/.github/workflows/validate-yaml.yml
@@ -50,6 +50,7 @@ jobs:
             ! -path './vendor/*' \
             ! -path './.git/*' \
             ! -path './.github/*' \
+            ! -path './helm/*/templates/*' \
           | sort \
           | xargs -r yamllint \
               --strict \


### PR DESCRIPTION
## Problem
Helm chart templates in `helm/*/templates/` use Go templating syntax (`{{- if .Values.foo }}`, `{{- include "chart.name" . }}`) which is not valid YAML. yamllint reports syntax errors on these files.

## Fix
Exclude `./helm/*/templates/*` from the yamllint `find` command. Helm templates are validated separately by `helm lint --strict` in the helm-lint workflow.

## Test plan
- [ ] yamllint passes on PR containing Helm chart templates
- [ ] `helm lint` still validates chart templates in the separate workflow