### PR TITLE
fix: correct YAML indentation in deployment-strategy files and exclude kustomize overlays from kubeconform

### DIFF
--- a/.github/workflows/validate-yaml.yml
+++ b/.github/workflows/validate-yaml.yml
@@ -96,6 +96,7 @@ jobs:
               ! -path './setup/*' \
               ! -path './helm/*' \
               ! -path './.github/*' \
+              ! -path '*/kustomize/overlays/*' \
             | sort
           )
           if [ -z "$MANIFEST_FILES" ]; then

--- a/core/workloads/deployment-strategies/blue-green/blue-deployment.yml
+++ b/core/workloads/deployment-strategies/blue-green/blue-deployment.yml
@@ -14,7 +14,7 @@ metadata:
     # This is for operational clarity — it doesn't directly affect traffic routing.
     slot: blue
   annotations:
-    kubernetes.io/description: "Blue deployment (v1 — nginx:1.24) — current production. Traffic is served from blue until the service selector is switched to green."
+    kubernetes.io/description: "Blue deployment (nginx:1.24) — production. Switch service selector to green to redirect traffic."
 spec:
   replicas: 4
 

--- a/core/workloads/deployment-strategies/blue-green/blue-deployment.yml
+++ b/core/workloads/deployment-strategies/blue-green/blue-deployment.yml
@@ -63,64 +63,64 @@ spec:
           type: RuntimeDefault
 
       containers:
-      - name: nginx
-        # v1 image — the current production version.
-        image: nginx:1.24
-        imagePullPolicy: IfNotPresent
+        - name: nginx
+          # v1 image — the current production version.
+          image: nginx:1.24
+          imagePullPolicy: IfNotPresent
 
-        ports:
-        - name: http
-          containerPort: 8080
-          protocol: TCP
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
 
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
 
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "100m"
-          limits:
-            memory: "256Mi"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
 
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "sleep 5"]
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
 
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          timeoutSeconds: 3
-          failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
 
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
 
-        volumeMounts:
-        - name: nginx-cache
-          mountPath: /var/cache/nginx
-        - name: nginx-run
-          mountPath: /var/run
-        - name: tmp
-          mountPath: /tmp
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
 
       volumes:
-      - name: nginx-cache
-        emptyDir: {}
-      - name: nginx-run
-        emptyDir: {}
-      - name: tmp
-        emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/core/workloads/deployment-strategies/blue-green/green-deployment.yml
+++ b/core/workloads/deployment-strategies/blue-green/green-deployment.yml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: kubectl
     slot: green
   annotations:
-    kubernetes.io/description: "Green deployment (v2 — nginx:1.25) — staged environment. Apply this, verify health, then switch the service selector to route traffic here."
+    kubernetes.io/description: "Green deployment (nginx:1.25) — staged. Verify health, then switch service selector to route traffic."
 spec:
   # Green starts with the same replica count as blue.
   # In cost-sensitive environments, you may start green with 1 replica for testing,

--- a/core/workloads/deployment-strategies/blue-green/green-deployment.yml
+++ b/core/workloads/deployment-strategies/blue-green/green-deployment.yml
@@ -64,64 +64,64 @@ spec:
           type: RuntimeDefault
 
       containers:
-      - name: nginx
-        # v2 image — the new version to be promoted.
-        image: nginx:1.25
-        imagePullPolicy: IfNotPresent
+        - name: nginx
+          # v2 image — the new version to be promoted.
+          image: nginx:1.25
+          imagePullPolicy: IfNotPresent
 
-        ports:
-        - name: http
-          containerPort: 8080
-          protocol: TCP
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
 
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
 
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "100m"
-          limits:
-            memory: "256Mi"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
 
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "sleep 5"]
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
 
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          timeoutSeconds: 3
-          failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
 
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
 
-        volumeMounts:
-        - name: nginx-cache
-          mountPath: /var/cache/nginx
-        - name: nginx-run
-          mountPath: /var/run
-        - name: tmp
-          mountPath: /tmp
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
 
       volumes:
-      - name: nginx-cache
-        emptyDir: {}
-      - name: nginx-run
-        emptyDir: {}
-      - name: tmp
-        emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/core/workloads/deployment-strategies/blue-green/service.yml
+++ b/core/workloads/deployment-strategies/blue-green/service.yml
@@ -42,7 +42,7 @@ spec:
     version: v1   # CHANGE TO v2 TO SWITCH TRAFFIC TO GREEN
 
   ports:
-  - name: http
-    port: 80
-    targetPort: 8080
-    protocol: TCP
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP

--- a/core/workloads/deployment-strategies/canary/canary-deployment.yml
+++ b/core/workloads/deployment-strategies/canary/canary-deployment.yml
@@ -65,64 +65,64 @@ spec:
           type: RuntimeDefault
 
       containers:
-      - name: nginx
-        # v2 image — the candidate being tested.
-        image: nginx:1.25
-        imagePullPolicy: IfNotPresent
+        - name: nginx
+          # v2 image — the candidate being tested.
+          image: nginx:1.25
+          imagePullPolicy: IfNotPresent
 
-        ports:
-        - name: http
-          containerPort: 8080
-          protocol: TCP
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
 
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
 
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "100m"
-          limits:
-            memory: "256Mi"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
 
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "sleep 5"]
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
 
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          timeoutSeconds: 3
-          failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
 
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
 
-        volumeMounts:
-        - name: nginx-cache
-          mountPath: /var/cache/nginx
-        - name: nginx-run
-          mountPath: /var/run
-        - name: tmp
-          mountPath: /tmp
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
 
       volumes:
-      - name: nginx-cache
-        emptyDir: {}
-      - name: nginx-run
-        emptyDir: {}
-      - name: tmp
-        emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/core/workloads/deployment-strategies/canary/canary-deployment.yml
+++ b/core/workloads/deployment-strategies/canary/canary-deployment.yml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: kubectl
     track: canary
   annotations:
-    kubernetes.io/description: "Canary v2 deployment (nginx:1.25) — serves ~20% of traffic with 1 replica alongside stable's 4 replicas. Monitor metrics before promoting."
+    kubernetes.io/description: "Canary v2 (nginx:1.25) — ~20% traffic with 1 replica. Monitor metrics before promoting to stable."
 spec:
   # 1 replica = 1/(4+1) = 20% of traffic when stable has 4 replicas.
   # Adjust this value to control traffic percentage:

--- a/core/workloads/deployment-strategies/canary/ingress.yml
+++ b/core/workloads/deployment-strategies/canary/ingress.yml
@@ -42,10 +42,10 @@ spec:
     app.kubernetes.io/name: nginx-canary-demo
     track: canary   # Only matches canary deployment pods (track: canary)
   ports:
-  - name: http
-    port: 80
-    targetPort: 8080
-    protocol: TCP
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP
 ---
 # Primary (stable) Ingress — routes the majority of traffic to the stable service.
 # This is the baseline Ingress that exists even without a canary.
@@ -70,18 +70,18 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: nginx-canary-demo.example.com   # Replace with your actual domain
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            # Points to the combined service (stable + canary pods) for baseline traffic.
-            # The canary Ingress will intercept its percentage before routing to this service.
-            name: nginx-canary-demo
-            port:
-              number: 80
+    - host: nginx-canary-demo.example.com   # Replace with your actual domain
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                # Points to the combined service (stable + canary pods) for baseline traffic.
+                # The canary Ingress will intercept its percentage before routing to this service.
+                name: nginx-canary-demo
+                port:
+                  number: 80
 ---
 # Canary Ingress — routes a precise percentage of traffic to the canary service.
 # NGINX Ingress Controller evaluates canary annotations and splits traffic before
@@ -134,14 +134,14 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: nginx-canary-demo.example.com   # Must match the primary Ingress host exactly
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            # Points to the canary-only service (selects only canary pods)
-            name: nginx-canary-only
-            port:
-              number: 80
+    - host: nginx-canary-demo.example.com   # Must match the primary Ingress host exactly
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                # Points to the canary-only service (selects only canary pods)
+                name: nginx-canary-only
+                port:
+                  number: 80

--- a/core/workloads/deployment-strategies/canary/service.yml
+++ b/core/workloads/deployment-strategies/canary/service.yml
@@ -36,7 +36,7 @@ spec:
     # - app.kubernetes.io/instance (different for stable vs canary)
 
   ports:
-  - name: http
-    port: 80
-    targetPort: 8080
-    protocol: TCP
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP

--- a/core/workloads/deployment-strategies/canary/service.yml
+++ b/core/workloads/deployment-strategies/canary/service.yml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: kube-platform
     app.kubernetes.io/managed-by: kubectl
   annotations:
-    kubernetes.io/description: "Service for canary demo — selects both stable and canary pods via shared app label, distributing traffic ~80/20 by replica ratio"
+    kubernetes.io/description: "Service for canary demo — selects stable and canary pods via shared label, ~80/20 traffic split."
 spec:
   type: ClusterIP
 

--- a/core/workloads/deployment-strategies/canary/stable-deployment.yml
+++ b/core/workloads/deployment-strategies/canary/stable-deployment.yml
@@ -62,63 +62,63 @@ spec:
           type: RuntimeDefault
 
       containers:
-      - name: nginx
-        image: nginx:1.24
-        imagePullPolicy: IfNotPresent
+        - name: nginx
+          image: nginx:1.24
+          imagePullPolicy: IfNotPresent
 
-        ports:
-        - name: http
-          containerPort: 8080
-          protocol: TCP
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
 
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
 
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "100m"
-          limits:
-            memory: "256Mi"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
 
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "sleep 5"]
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
 
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          timeoutSeconds: 3
-          failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
 
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
 
-        volumeMounts:
-        - name: nginx-cache
-          mountPath: /var/cache/nginx
-        - name: nginx-run
-          mountPath: /var/run
-        - name: tmp
-          mountPath: /tmp
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
 
       volumes:
-      - name: nginx-cache
-        emptyDir: {}
-      - name: nginx-run
-        emptyDir: {}
-      - name: tmp
-        emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/core/workloads/deployment-strategies/canary/stable-deployment.yml
+++ b/core/workloads/deployment-strategies/canary/stable-deployment.yml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: kubectl
     track: stable
   annotations:
-    kubernetes.io/description: "Stable v1 deployment (nginx:1.24) — serves 80% of traffic with 4 replicas. The canary deployment serves the remaining 20% with 1 replica."
+    kubernetes.io/description: "Stable v1 (nginx:1.24) — serves 80% of traffic with 4 replicas; canary serves 20% with 1 replica."
 spec:
   # 4 replicas = 4/(4+1) = 80% of traffic when canary has 1 replica.
   # The traffic split is determined by the ratio of Ready pods across both deployments.

--- a/core/workloads/deployment-strategies/recreate/deployment.yml
+++ b/core/workloads/deployment-strategies/recreate/deployment.yml
@@ -72,72 +72,72 @@ spec:
           type: RuntimeDefault
 
       containers:
-      - name: nginx
-        # v1 image — change to nginx:1.25 to trigger the Recreate strategy.
-        image: nginx:1.24
-        imagePullPolicy: IfNotPresent
+        - name: nginx
+          # v1 image — change to nginx:1.25 to trigger the Recreate strategy.
+          image: nginx:1.24
+          imagePullPolicy: IfNotPresent
 
-        ports:
-        - name: http
-          containerPort: 8080   # Non-privileged port — required for runAsNonRoot
-          protocol: TCP
+          ports:
+            - name: http
+              containerPort: 8080   # Non-privileged port — required for runAsNonRoot
+              protocol: TCP
 
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
 
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "100m"
-          limits:
-            memory: "256Mi"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
 
-        lifecycle:
-          preStop:
-            exec:
-              # Give NGINX time to finish processing in-flight requests before shutdown.
-              # With Recreate, this is less critical (we want downtime to be brief),
-              # but it's still good practice to drain gracefully.
-              command: ["/bin/sh", "-c", "sleep 5"]
+          lifecycle:
+            preStop:
+              exec:
+                # Give NGINX time to finish processing in-flight requests before shutdown.
+                # With Recreate, this is less critical (we want downtime to be brief),
+                # but it's still good practice to drain gracefully.
+                command: ["/bin/sh", "-c", "sleep 5"]
 
-        # readinessProbe determines when a pod is added to the Service endpoint list.
-        # With Recreate, readiness still matters — minReadySeconds requires the pod
-        # to be Ready for N seconds before the deployment is considered 'available'.
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          timeoutSeconds: 3
-          failureThreshold: 3
+          # readinessProbe determines when a pod is added to the Service endpoint list.
+          # With Recreate, readiness still matters — minReadySeconds requires the pod
+          # to be Ready for N seconds before the deployment is considered 'available'.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
 
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
 
-        volumeMounts:
-        - name: nginx-cache
-          mountPath: /var/cache/nginx
-        - name: nginx-run
-          mountPath: /var/run
-        - name: tmp
-          mountPath: /tmp
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
 
       volumes:
-      # NGINX needs to write to /var/cache/nginx and /var/run when readOnlyRootFilesystem: true.
-      # We provide emptyDir volumes for these paths.
-      - name: nginx-cache
-        emptyDir: {}
-      - name: nginx-run
-        emptyDir: {}
-      - name: tmp
-        emptyDir: {}
+        # NGINX needs to write to /var/cache/nginx and /var/run when readOnlyRootFilesystem: true.
+        # We provide emptyDir volumes for these paths.
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/core/workloads/deployment-strategies/recreate/service.yml
+++ b/core/workloads/deployment-strategies/recreate/service.yml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: kube-platform
     app.kubernetes.io/managed-by: kubectl
   annotations:
-    kubernetes.io/description: "ClusterIP service for nginx-recreate — during Recreate rollout, this service will return connection refused while pods are terminated"
+    kubernetes.io/description: "ClusterIP service for nginx-recreate — returns connection refused during Recreate rollout as pods terminate."
 spec:
   # ClusterIP is the default service type — a stable virtual IP within the cluster.
   # During the Recreate rollout, the endpoint slice for this service will temporarily

--- a/core/workloads/deployment-strategies/recreate/service.yml
+++ b/core/workloads/deployment-strategies/recreate/service.yml
@@ -24,7 +24,7 @@ spec:
     app.kubernetes.io/instance: nginx-recreate
 
   ports:
-  - name: http
-    port: 80          # External port that clients connect to
-    targetPort: 8080  # Must match the container's containerPort
-    protocol: TCP
+    - name: http
+      port: 80          # External port that clients connect to
+      targetPort: 8080  # Must match the container's containerPort
+      protocol: TCP

--- a/core/workloads/deployment-strategies/rolling-update/deployment.yml
+++ b/core/workloads/deployment-strategies/rolling-update/deployment.yml
@@ -72,92 +72,92 @@ spec:
           type: RuntimeDefault
 
       containers:
-      - name: nginx
-        image: nginx:1.24
-        imagePullPolicy: IfNotPresent
+        - name: nginx
+          image: nginx:1.24
+          imagePullPolicy: IfNotPresent
 
-        ports:
-        - name: http
-          containerPort: 8080
-          protocol: TCP
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
 
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
 
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "100m"
-          limits:
-            memory: "256Mi"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
 
-        lifecycle:
-          preStop:
-            exec:
-              # WHY THIS MATTERS FOR ROLLING UPDATES:
-              # When Kubernetes decides to terminate a pod (during rollout), it:
-              # 1. Removes the pod from Service endpoints (stops new connections)
-              # 2. Runs the preStop hook
-              # 3. Sends SIGTERM to the container
-              # 4. Waits terminationGracePeriodSeconds for the process to exit
-              #
-              # The 'sleep 5' here creates a brief overlap where the pod is removed
-              # from endpoints BEFORE NGINX receives SIGTERM. This prevents the rare
-              # race condition where:
-              #   - kube-proxy removes the pod from iptables rules (async, takes 1-2s)
-              #   - New requests still arrive at the pod during that 1-2s window
-              #   - NGINX has already shut down and returns connection reset
-              # The sleep gives kube-proxy time to fully propagate the endpoint removal
-              # before NGINX starts refusing connections.
-              command: ["/bin/sh", "-c", "sleep 5"]
+          lifecycle:
+            preStop:
+              exec:
+                # WHY THIS MATTERS FOR ROLLING UPDATES:
+                # When Kubernetes decides to terminate a pod (during rollout), it:
+                # 1. Removes the pod from Service endpoints (stops new connections)
+                # 2. Runs the preStop hook
+                # 3. Sends SIGTERM to the container
+                # 4. Waits terminationGracePeriodSeconds for the process to exit
+                #
+                # The 'sleep 5' here creates a brief overlap where the pod is removed
+                # from endpoints BEFORE NGINX receives SIGTERM. This prevents the rare
+                # race condition where:
+                #   - kube-proxy removes the pod from iptables rules (async, takes 1-2s)
+                #   - New requests still arrive at the pod during that 1-2s window
+                #   - NGINX has already shut down and returns connection reset
+                # The sleep gives kube-proxy time to fully propagate the endpoint removal
+                # before NGINX starts refusing connections.
+                command: ["/bin/sh", "-c", "sleep 5"]
 
-        # THE MOST IMPORTANT PROBE FOR ZERO-DOWNTIME ROLLING UPDATES.
-        # This probe gates when a pod joins the Service endpoint list.
-        # Kubernetes will NOT terminate an old pod until this probe succeeds on the new pod.
-        # Make sure this probe accurately reflects when your app is ready to serve traffic:
-        #   - DB connections established
-        #   - Config loaded
-        #   - Caches warmed
-        #   - Health dependencies satisfied
-        # A probe that returns 200 too early (before the app is truly ready) breaks
-        # the zero-downtime guarantee.
-        readinessProbe:
-          httpGet:
-            path: /         # In production: use /readyz or /healthz/ready endpoint
-            port: 8080
-          initialDelaySeconds: 5    # Wait for NGINX to start before first check
-          periodSeconds: 5          # Check every 5 seconds
-          timeoutSeconds: 3         # Probe times out after 3 seconds (network latency buffer)
-          failureThreshold: 3       # 3 consecutive failures = remove from endpoints (not a restart)
-          successThreshold: 1       # 1 success = add to endpoints
+          # THE MOST IMPORTANT PROBE FOR ZERO-DOWNTIME ROLLING UPDATES.
+          # This probe gates when a pod joins the Service endpoint list.
+          # Kubernetes will NOT terminate an old pod until this probe succeeds on the new pod.
+          # Make sure this probe accurately reflects when your app is ready to serve traffic:
+          #   - DB connections established
+          #   - Config loaded
+          #   - Caches warmed
+          #   - Health dependencies satisfied
+          # A probe that returns 200 too early (before the app is truly ready) breaks
+          # the zero-downtime guarantee.
+          readinessProbe:
+            httpGet:
+              path: /         # In production: use /readyz or /healthz/ready endpoint
+              port: 8080
+            initialDelaySeconds: 5    # Wait for NGINX to start before first check
+            periodSeconds: 5          # Check every 5 seconds
+            timeoutSeconds: 3         # Probe times out after 3 seconds (network latency buffer)
+            failureThreshold: 3       # 3 consecutive failures = remove from endpoints (not a restart)
+            successThreshold: 1       # 1 success = add to endpoints
 
-        # livenessProbe triggers a restart if the container is alive but not functioning.
-        # This is SEPARATE from readiness — a pod can be live but not ready (under load,
-        # waiting for dependencies) and should stay running but not receive traffic.
-        livenessProbe:
-          httpGet:
-            path: /         # In production: use /livez or /healthz/live endpoint
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 3   # 3 consecutive failures = restart the container
+          # livenessProbe triggers a restart if the container is alive but not functioning.
+          # This is SEPARATE from readiness — a pod can be live but not ready (under load,
+          # waiting for dependencies) and should stay running but not receive traffic.
+          livenessProbe:
+            httpGet:
+              path: /         # In production: use /livez or /healthz/live endpoint
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3   # 3 consecutive failures = restart the container
 
-        volumeMounts:
-        - name: nginx-cache
-          mountPath: /var/cache/nginx
-        - name: nginx-run
-          mountPath: /var/run
-        - name: tmp
-          mountPath: /tmp
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
 
       volumes:
-      - name: nginx-cache
-        emptyDir: {}
-      - name: nginx-run
-        emptyDir: {}
-      - name: tmp
-        emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/core/workloads/deployment-strategies/rolling-update/service.yml
+++ b/core/workloads/deployment-strategies/rolling-update/service.yml
@@ -27,7 +27,7 @@ spec:
     app.kubernetes.io/instance: nginx-rolling
 
   ports:
-  - name: http
-    port: 80
-    targetPort: 8080
-    protocol: TCP
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP

--- a/core/workloads/deployment-strategies/rolling-update/service.yml
+++ b/core/workloads/deployment-strategies/rolling-update/service.yml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: kube-platform
     app.kubernetes.io/managed-by: kubectl
   annotations:
-    kubernetes.io/description: "ClusterIP service for nginx-rolling — during Rolling Update, this service always has healthy endpoints (zero-downtime guarantee with readinessProbe + maxUnavailable:0)"
+    kubernetes.io/description: "ClusterIP service for nginx-rolling — always has healthy endpoints during Rolling Update (readinessProbe + maxUnavailable:0)."
 spec:
   type: ClusterIP
 

--- a/core/workloads/deployment/kustomize/base/kustomization.yaml
+++ b/core/workloads/deployment/kustomize/base/kustomization.yaml
@@ -27,5 +27,5 @@ commonAnnotations:
 
 # The base resources. Overlays inherit all of these and can patch them.
 resources:
-- nginx-deployment.yaml
-- nginx-service.yaml
+  - nginx-deployment.yaml
+  - nginx-service.yaml

--- a/core/workloads/deployment/kustomize/base/nginx-deployment.yaml
+++ b/core/workloads/deployment/kustomize/base/nginx-deployment.yaml
@@ -82,78 +82,78 @@ spec:
           type: RuntimeDefault
 
       volumes:
-      - name: nginx-tmp
-        emptyDir: {}
-      - name: nginx-run
-        emptyDir: {}
-      - name: nginx-cache
-        emptyDir: {}
+        - name: nginx-tmp
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
 
       containers:
-      - name: nginx
-        # Image without a tag. Overlays supply the tag via `images:` in their
-        # kustomization.yaml. Using `kustomize edit set image` in CI is idiomatic.
-        # Base uses "latest" as a placeholder; overlays pin to specific tags.
-        image: nginx:1.25-alpine
+        - name: nginx
+          # Image without a tag. Overlays supply the tag via `images:` in their
+          # kustomization.yaml. Using `kustomize edit set image` in CI is idiomatic.
+          # Base uses "latest" as a placeholder; overlays pin to specific tags.
+          image: nginx:1.25-alpine
 
-        ports:
-        - containerPort: 80
-          protocol: TCP
-          name: http
+          ports:
+            - containerPort: 80
+              protocol: TCP
+              name: http
 
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-            - ALL
-            add:
-            - NET_BIND_SERVICE
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
 
-        # Resource requests are defined in the base (required for scheduling).
-        # Limits are intentionally omitted — overlays add them via patches
-        # because limits vary significantly between dev, staging, and prod.
-        resources:
-          requests:
-            memory: "64Mi"
-            cpu: "50m"
-          # limits: not set here — added by overlay patches
+          # Resource requests are defined in the base (required for scheduling).
+          # Limits are intentionally omitted — overlays add them via patches
+          # because limits vary significantly between dev, staging, and prod.
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+              # limits: not set here — added by overlay patches
 
-        volumeMounts:
-        - name: nginx-tmp
-          mountPath: /tmp
-        - name: nginx-run
-          mountPath: /var/run
-        - name: nginx-cache
-          mountPath: /var/cache/nginx
+          volumeMounts:
+            - name: nginx-tmp
+              mountPath: /tmp
+            - name: nginx-run
+              mountPath: /var/run
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
 
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "sleep 5"]
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
 
-        startupProbe:
-          httpGet:
-            path: /
-            port: 80
-          failureThreshold: 30
-          periodSeconds: 2
-          timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 80
+            failureThreshold: 30
+            periodSeconds: 2
+            timeoutSeconds: 3
 
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 80
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          failureThreshold: 3
-          timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3
 
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 80
-          initialDelaySeconds: 15
-          periodSeconds: 20
-          failureThreshold: 3
-          timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 3
+            timeoutSeconds: 3

--- a/core/workloads/deployment/kustomize/base/nginx-service.yaml
+++ b/core/workloads/deployment/kustomize/base/nginx-service.yaml
@@ -42,7 +42,7 @@ spec:
     app.kubernetes.io/instance: nginx
 
   ports:
-  - name: http
-    port: 80          # Port the Service is reachable on (ClusterIP:80)
-    targetPort: 80    # Port on the Pod the traffic is forwarded to
-    protocol: TCP
+    - name: http
+      port: 80          # Port the Service is reachable on (ClusterIP:80)
+      targetPort: 80    # Port on the Pod the traffic is forwarded to
+      protocol: TCP

--- a/core/workloads/deployment/kustomize/overlays/dev/kustomization.yaml
+++ b/core/workloads/deployment/kustomize/overlays/dev/kustomization.yaml
@@ -23,7 +23,7 @@ kind: Kustomization
 # Point to the base manifests directory.
 # All resources defined in the base are inherited by this overlay.
 resources:
-- ../../base
+  - ../../base
 
 # ─── NAMESPACE ───────────────────────────────────────────────────────────────
 # Kustomize sets this namespace on ALL resources from the base that don't already
@@ -40,25 +40,25 @@ namespace: dev
 # Patch the replica count without a separate patch file.
 # The `replicas` field in kustomization.yaml is the idiomatic way to set replicas.
 replicas:
-- name: nginx       # Must match metadata.name in the base Deployment
-  count: 1
+  - name: nginx       # Must match metadata.name in the base Deployment
+    count: 1
 
 # ─── IMAGE OVERRIDE ──────────────────────────────────────────────────────────
 # Override the container image tag for this environment.
 # `newName` and `newTag` can be set independently.
 # In CI, this is updated by: kustomize edit set image nginx=nginx:latest
 images:
-- name: nginx           # Matches the image name in the base (without tag)
-  newTag: latest        # Dev uses latest for rapid iteration; pin in staging/prod
+  - name: nginx           # Matches the image name in the base (without tag)
+    newTag: latest        # Dev uses latest for rapid iteration; pin in staging/prod
 
 # ─── PATCHES ─────────────────────────────────────────────────────────────────
 # Strategic merge patches: Kubernetes merges these with the base manifest.
 # A strategic merge patch only overrides the fields it specifies.
 patches:
-- path: patch-resources.yaml
-  target:
-    kind: Deployment
-    name: nginx
+  - path: patch-resources.yaml
+    target:
+      kind: Deployment
+      name: nginx
 
 # ─── COMMON LABELS ───────────────────────────────────────────────────────────
 # Add environment-specific label to all resources.

--- a/core/workloads/deployment/kustomize/overlays/dev/patch-resources.yaml
+++ b/core/workloads/deployment/kustomize/overlays/dev/patch-resources.yaml
@@ -26,14 +26,14 @@ spec:
   template:
     spec:
       containers:
-      - name: nginx   # Strategic merge key — identifies which container to patch
-        resources:
-          requests:
-            memory: "64Mi"
-            cpu: "50m"
-          limits:
-            # Dev memory limit: small but sufficient for serving test traffic.
-            # If the container exceeds this, it is OOM-killed — acceptable in dev.
-            memory: "128Mi"
-            # Note: no cpu limit even in dev — we still avoid throttling to keep
-            # the local development experience responsive.
+        - name: nginx   # Strategic merge key — identifies which container to patch
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              # Dev memory limit: small but sufficient for serving test traffic.
+              # If the container exceeds this, it is OOM-killed — acceptable in dev.
+              memory: "128Mi"
+              # Note: no cpu limit even in dev — we still avoid throttling to keep
+              # the local development experience responsive.

--- a/core/workloads/deployment/kustomize/overlays/prod/kustomization.yaml
+++ b/core/workloads/deployment/kustomize/overlays/prod/kustomization.yaml
@@ -30,32 +30,32 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../base
+  - ../../base
 
 namespace: prod
 
 # 4 replicas → with topologySpreadConstraints in the base, these spread across
 # availability zones. 4 replicas in 2 zones = 2 per zone.
 replicas:
-- name: nginx
-  count: 4
+  - name: nginx
+    count: 4
 
 images:
-- name: nginx
-  # Production uses a pinned minor version for stability.
-  # In a hardened production setup, use newDigest instead of newTag:
-  # newDigest: sha256:<immutable-digest-from-ci-pipeline>
-  newTag: "1.25"
+  - name: nginx
+    # Production uses a pinned minor version for stability.
+    # In a hardened production setup, use newDigest instead of newTag:
+    # newDigest: sha256:<immutable-digest-from-ci-pipeline>
+    newTag: "1.25"
 
 # Production applies TWO patches, each focused on one concern:
 #   1. patch-replicas.yaml  — replica count (now handled by replicas: above,
 #      but shown here as a reference for teams that prefer explicit patches)
 #   2. patch-resources.yaml — resource limits sized for production traffic
 patches:
-- path: patch-resources.yaml
-  target:
-    kind: Deployment
-    name: nginx
+  - path: patch-resources.yaml
+    target:
+      kind: Deployment
+      name: nginx
 
 commonLabels:
   environment: prod

--- a/core/workloads/deployment/kustomize/overlays/prod/patch-resources.yaml
+++ b/core/workloads/deployment/kustomize/overlays/prod/patch-resources.yaml
@@ -33,23 +33,23 @@ spec:
   template:
     spec:
       containers:
-      - name: nginx
-        resources:
-          requests:
-            # Production request: sized for the typical (P50) pod load.
-            # This is what the Kubernetes scheduler uses to place pods on nodes.
-            # If the sum of requests on a node exceeds node capacity, new pods
-            # are not scheduled there (Pending state).
-            memory: "256Mi"
-            cpu: "200m"
-          limits:
-            # Production memory limit: sized to handle peak (P99) traffic spikes.
-            # nginx memory usage scales with: concurrent connections × per-connection buffer.
-            # For a typical reverse proxy workload, 512Mi handles significant traffic.
-            # Increase if you see OOMKilled events: kubectl get events -n prod | grep OOM
-            memory: "512Mi"
-            # CPU limit intentionally omitted.
-            # Production traffic has bursts (marketing campaigns, viral events).
-            # CPU throttling during these bursts would directly increase p99 latency.
-            # Monitor `container_cpu_throttled_seconds_total` in Prometheus.
-            # If the pod consistently uses >800m CPU, increase the cpu request instead.
+        - name: nginx
+          resources:
+            requests:
+              # Production request: sized for the typical (P50) pod load.
+              # This is what the Kubernetes scheduler uses to place pods on nodes.
+              # If the sum of requests on a node exceeds node capacity, new pods
+              # are not scheduled there (Pending state).
+              memory: "256Mi"
+              cpu: "200m"
+            limits:
+              # Production memory limit: sized to handle peak (P99) traffic spikes.
+              # nginx memory usage scales with: concurrent connections × per-connection buffer.
+              # For a typical reverse proxy workload, 512Mi handles significant traffic.
+              # Increase if you see OOMKilled events: kubectl get events -n prod | grep OOM
+              memory: "512Mi"
+              # CPU limit intentionally omitted.
+              # Production traffic has bursts (marketing campaigns, viral events).
+              # CPU throttling during these bursts would directly increase p99 latency.
+              # Monitor `container_cpu_throttled_seconds_total` in Prometheus.
+              # If the pod consistently uses >800m CPU, increase the cpu request instead.

--- a/core/workloads/deployment/kustomize/overlays/staging/kustomization.yaml
+++ b/core/workloads/deployment/kustomize/overlays/staging/kustomization.yaml
@@ -23,26 +23,26 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../base
+  - ../../base
 
 namespace: staging
 
 replicas:
-- name: nginx
-  count: 2
+  - name: nginx
+    count: 2
 
 images:
-- name: nginx
-  # Pin to the same minor version as production.
-  # Avoid using digest in staging to allow automatic minor patch updates.
-  # In production, always pin to a digest.
-  newTag: "1.25"
+  - name: nginx
+    # Pin to the same minor version as production.
+    # Avoid using digest in staging to allow automatic minor patch updates.
+    # In production, always pin to a digest.
+    newTag: "1.25"
 
 patches:
-- path: patch-resources.yaml
-  target:
-    kind: Deployment
-    name: nginx
+  - path: patch-resources.yaml
+    target:
+      kind: Deployment
+      name: nginx
 
 commonLabels:
   environment: staging

--- a/core/workloads/deployment/kustomize/overlays/staging/patch-resources.yaml
+++ b/core/workloads/deployment/kustomize/overlays/staging/patch-resources.yaml
@@ -22,13 +22,13 @@ spec:
   template:
     spec:
       containers:
-      - name: nginx
-        resources:
-          requests:
-            memory: "128Mi"
-            cpu: "100m"
-          limits:
-            # Staging uses the same memory limit as what we target for production.
-            # This ensures load tests surface OOM issues before they hit prod.
-            memory: "256Mi"
-            # No CPU limit — load tests should not be throttled artificially.
+        - name: nginx
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              # Staging uses the same memory limit as what we target for production.
+              # This ensures load tests surface OOM issues before they hit prod.
+              memory: "256Mi"
+              # No CPU limit — load tests should not be throttled artificially.

--- a/core/workloads/deployment/nginx-deployment.yml
+++ b/core/workloads/deployment/nginx-deployment.yml
@@ -234,140 +234,140 @@ spec:
       # In production with 2+ replicas, this prevents both replicas landing
       # on the same node or zone — a zone outage would then still be served.
       topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: DoNotSchedule
-        labelSelector:
-          matchLabels:
-            app.kubernetes.io/name: nginx
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: nginx
 
       # ─── VOLUMES ─────────────────────────────────────────────────────────
       volumes:
-      # ConfigMap volume: mounts nginx.conf from the ConfigMap defined above.
-      # When the ConfigMap is updated, the mounted file is updated (within
-      # ~60s by default), but nginx won't pick it up until reloaded or restarted.
-      - name: nginx-config
-        configMap:
-          name: nginx-config
-          items:
-          - key: nginx.conf
-            path: nginx.conf
+        # ConfigMap volume: mounts nginx.conf from the ConfigMap defined above.
+        # When the ConfigMap is updated, the mounted file is updated (within
+        # ~60s by default), but nginx won't pick it up until reloaded or restarted.
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+            items:
+              - key: nginx.conf
+                path: nginx.conf
 
-      # emptyDir volumes for nginx's writable directories.
-      # Required because readOnlyRootFilesystem: true prevents writes to the
-      # container image's own filesystem.
-      - name: nginx-tmp
-        emptyDir: {}
-      - name: nginx-run
-        emptyDir: {}
-      - name: nginx-cache
-        emptyDir: {}
+        # emptyDir volumes for nginx's writable directories.
+        # Required because readOnlyRootFilesystem: true prevents writes to the
+        # container image's own filesystem.
+        - name: nginx-tmp
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
 
       containers:
-      - name: nginx
-        # Pin to a specific minor version for production stability.
-        # In a real pipeline, use a digest: nginx@sha256:<digest>
-        image: nginx:1.25-alpine
+        - name: nginx
+          # Pin to a specific minor version for production stability.
+          # In a real pipeline, use a digest: nginx@sha256:<digest>
+          image: nginx:1.25-alpine
 
-        ports:
-        - containerPort: 80
-          protocol: TCP
-          name: http
+          ports:
+            - containerPort: 80
+              protocol: TCP
+              name: http
 
-        # ─── CONTAINER SECURITY CONTEXT ──────────────────────────────────
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-            - ALL
-            add:
-            - NET_BIND_SERVICE
+          # ─── CONTAINER SECURITY CONTEXT ──────────────────────────────────
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
 
-        # ─── RESOURCE MANAGEMENT ─────────────────────────────────────────
-        resources:
-          requests:
-            memory: "128Mi"
-            cpu: "100m"
-          limits:
-            # memory limit == request → Guaranteed QoS class
-            # (highest eviction priority; protected from OOM eviction)
-            memory: "128Mi"
-            # CPU limit intentionally omitted to avoid throttling.
-            # nginx CPU usage is bursty; capping it would increase p99 latency.
+          # ─── RESOURCE MANAGEMENT ─────────────────────────────────────────
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              # memory limit == request → Guaranteed QoS class
+              # (highest eviction priority; protected from OOM eviction)
+              memory: "128Mi"
+              # CPU limit intentionally omitted to avoid throttling.
+              # nginx CPU usage is bursty; capping it would increase p99 latency.
 
-        # ─── VOLUME MOUNTS ────────────────────────────────────────────────
-        volumeMounts:
-        # Mount the custom nginx.conf from the ConfigMap.
-        # This replaces the default /etc/nginx/nginx.conf inside the container.
-        - name: nginx-config
-          mountPath: /etc/nginx/nginx.conf
-          subPath: nginx.conf
-          readOnly: true   # The config should never be modified by the running process
+          # ─── VOLUME MOUNTS ────────────────────────────────────────────────
+          volumeMounts:
+            # Mount the custom nginx.conf from the ConfigMap.
+            # This replaces the default /etc/nginx/nginx.conf inside the container.
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true   # The config should never be modified by the running process
 
-        # Writable directories nginx needs at runtime
-        - name: nginx-tmp
-          mountPath: /tmp
-        - name: nginx-run
-          mountPath: /var/run
-        - name: nginx-cache
-          mountPath: /var/cache/nginx
+            # Writable directories nginx needs at runtime
+            - name: nginx-tmp
+              mountPath: /tmp
+            - name: nginx-run
+              mountPath: /var/run
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
 
-        # ─── LIFECYCLE ────────────────────────────────────────────────────
-        lifecycle:
-          preStop:
-            exec:
-              # Sleep 5s before nginx receives SIGTERM.
-              # This gives kube-proxy and cloud load balancers time to remove
-              # this Pod's IP from their routing tables.
-              # Without this, requests can arrive at a Pod that has already
-              # started shutting down, resulting in connection refused errors.
-              command: ["/bin/sh", "-c", "sleep 5"]
+          # ─── LIFECYCLE ────────────────────────────────────────────────────
+          lifecycle:
+            preStop:
+              exec:
+                # Sleep 5s before nginx receives SIGTERM.
+                # This gives kube-proxy and cloud load balancers time to remove
+                # this Pod's IP from their routing tables.
+                # Without this, requests can arrive at a Pod that has already
+                # started shutting down, resulting in connection refused errors.
+                command: ["/bin/sh", "-c", "sleep 5"]
 
-        # ─── PROBES ───────────────────────────────────────────────────────
-        # Three probes serve three different purposes. ALL THREE should point
-        # to DIFFERENT endpoints where possible.
+          # ─── PROBES ───────────────────────────────────────────────────────
+          # Three probes serve three different purposes. ALL THREE should point
+          # to DIFFERENT endpoints where possible.
 
-        # startupProbe: Runs FIRST. liveness and readiness probes are DISABLED
-        # until the startup probe succeeds. This prevents premature restarts
-        # during slow application initialization (loading ML models, warming caches).
-        # With failureThreshold: 30 and periodSeconds: 2, the app has up to
-        # 60 seconds to start before being killed.
-        startupProbe:
-          httpGet:
-            path: /healthz
-            port: 80
-          # Allow up to 30 * 2 = 60 seconds for nginx to start.
-          failureThreshold: 30
-          periodSeconds: 2
-          timeoutSeconds: 3
+          # startupProbe: Runs FIRST. liveness and readiness probes are DISABLED
+          # until the startup probe succeeds. This prevents premature restarts
+          # during slow application initialization (loading ML models, warming caches).
+          # With failureThreshold: 30 and periodSeconds: 2, the app has up to
+          # 60 seconds to start before being killed.
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            # Allow up to 30 * 2 = 60 seconds for nginx to start.
+            failureThreshold: 30
+            periodSeconds: 2
+            timeoutSeconds: 3
 
-        # readinessProbe: Controls Service endpoint inclusion.
-        # Failure removes this Pod from the Service's EndpointSlice → no traffic.
-        # It does NOT restart the container. Use this for transient "not ready"
-        # states (e.g., dependency temporarily unavailable, cache miss rate high).
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 80
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          failureThreshold: 3
-          # After 3 consecutive successes, the probe is considered passing again.
-          successThreshold: 1
-          timeoutSeconds: 3
+          # readinessProbe: Controls Service endpoint inclusion.
+          # Failure removes this Pod from the Service's EndpointSlice → no traffic.
+          # It does NOT restart the container. Use this for transient "not ready"
+          # states (e.g., dependency temporarily unavailable, cache miss rate high).
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+            # After 3 consecutive successes, the probe is considered passing again.
+            successThreshold: 1
+            timeoutSeconds: 3
 
-        # livenessProbe: Restarts the container if it fails.
-        # Use this for detecting deadlocks, hung goroutines, or processes that
-        # appear alive but can no longer handle requests.
-        # Starts ONLY AFTER the startupProbe succeeds.
-        # Use a HIGHER initialDelaySeconds than readinessProbe to avoid
-        # restarting a container that is merely slow to become ready.
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 80
-          initialDelaySeconds: 15
-          periodSeconds: 20
-          failureThreshold: 3
-          timeoutSeconds: 3
+          # livenessProbe: Restarts the container if it fails.
+          # Use this for detecting deadlocks, hung goroutines, or processes that
+          # appear alive but can no longer handle requests.
+          # Starts ONLY AFTER the startupProbe succeeds.
+          # Use a HIGHER initialDelaySeconds than readinessProbe to avoid
+          # restarting a container that is merely slow to become ready.
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 3
+            timeoutSeconds: 3

--- a/core/workloads/deployment/rolling-strategy.yml
+++ b/core/workloads/deployment/rolling-strategy.yml
@@ -216,102 +216,102 @@ spec:
           type: RuntimeDefault
 
       volumes:
-      - name: nginx-tmp
-        emptyDir: {}
-      - name: nginx-run
-        emptyDir: {}
-      - name: nginx-cache
-        emptyDir: {}
+        - name: nginx-tmp
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
 
       containers:
-      - name: app
-        image: nginx:1.25-alpine
+        - name: app
+          image: nginx:1.25-alpine
 
-        ports:
-        - containerPort: 80
-          protocol: TCP
-          name: http
+          ports:
+            - containerPort: 80
+              protocol: TCP
+              name: http
 
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-            - ALL
-            add:
-            - NET_BIND_SERVICE
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
 
-        resources:
-          requests:
-            memory: "128Mi"
-            cpu: "100m"
-          limits:
-            memory: "128Mi"
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "128Mi"
 
-        volumeMounts:
-        - name: nginx-tmp
-          mountPath: /tmp
-        - name: nginx-run
-          mountPath: /var/run
-        - name: nginx-cache
-          mountPath: /var/cache/nginx
+          volumeMounts:
+            - name: nginx-tmp
+              mountPath: /tmp
+            - name: nginx-run
+              mountPath: /var/run
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
 
-        lifecycle:
-          preStop:
-            exec:
-              # ── preStop hook relationship to rolling update ────────────────
-              # When a Pod is selected for termination during a rolling update:
-              # 1. Pod is removed from Service EndpointSlice (stops receiving new requests)
-              # 2. preStop hook runs (sleep 5s gives LB time to drain existing connections)
-              # 3. SIGTERM is sent to the container
-              # 4. nginx handles SIGTERM with graceful worker shutdown
-              # 5. SIGKILL sent after terminationGracePeriodSeconds if still running
-              #
-              # The 5-second sleep is the "connection drain" window. Without it,
-              # some load balancers (AWS ALB, kube-proxy iptables) may still route
-              # new requests to the Pod for a few seconds after it starts terminating,
-              # causing "connection refused" errors to clients.
-              command: ["/bin/sh", "-c", "sleep 5"]
+          lifecycle:
+            preStop:
+              exec:
+                # ── preStop hook relationship to rolling update ────────────────
+                # When a Pod is selected for termination during a rolling update:
+                # 1. Pod is removed from Service EndpointSlice (stops receiving new requests)
+                # 2. preStop hook runs (sleep 5s gives LB time to drain existing connections)
+                # 3. SIGTERM is sent to the container
+                # 4. nginx handles SIGTERM with graceful worker shutdown
+                # 5. SIGKILL sent after terminationGracePeriodSeconds if still running
+                #
+                # The 5-second sleep is the "connection drain" window. Without it,
+                # some load balancers (AWS ALB, kube-proxy iptables) may still route
+                # new requests to the Pod for a few seconds after it starts terminating,
+                # causing "connection refused" errors to clients.
+                command: ["/bin/sh", "-c", "sleep 5"]
 
-        # ── Probe relationship to rolling update ────────────────────────────
-        # The readinessProbe is the primary gate for the rolling update:
-        #   - A new Pod must pass readinessProbe to be counted as "Available"
-        #   - Combined with minReadySeconds, this is the "rollout gate"
-        #   - If the probe fails, the rollout stalls (no more old pods removed)
-        #   - `progressDeadlineSeconds` determines when the stall becomes a failure
-        startupProbe:
-          httpGet:
-            path: /
-            port: 80
-          # failureThreshold * periodSeconds = max startup time allowed
-          # 30 * 2s = 60 seconds for nginx to start
-          failureThreshold: 30
-          periodSeconds: 2
-          timeoutSeconds: 3
+          # ── Probe relationship to rolling update ────────────────────────────
+          # The readinessProbe is the primary gate for the rolling update:
+          #   - A new Pod must pass readinessProbe to be counted as "Available"
+          #   - Combined with minReadySeconds, this is the "rollout gate"
+          #   - If the probe fails, the rollout stalls (no more old pods removed)
+          #   - `progressDeadlineSeconds` determines when the stall becomes a failure
+          startupProbe:
+            httpGet:
+              path: /
+              port: 80
+            # failureThreshold * periodSeconds = max startup time allowed
+            # 30 * 2s = 60 seconds for nginx to start
+            failureThreshold: 30
+            periodSeconds: 2
+            timeoutSeconds: 3
 
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 80
-          # initialDelaySeconds: wait before first probe attempt.
-          # For fast-starting apps, set this low. For slow-starting apps, use
-          # startupProbe instead (which gates readiness/liveness entirely).
-          initialDelaySeconds: 5
-          # periodSeconds: how often to probe.
-          # Lower = faster detection of readiness, more probe traffic.
-          periodSeconds: 10
-          # failureThreshold: how many consecutive failures before marking not-ready.
-          # 3 failures * 10s = 30 seconds of failure before traffic is removed.
-          failureThreshold: 3
-          timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            # initialDelaySeconds: wait before first probe attempt.
+            # For fast-starting apps, set this low. For slow-starting apps, use
+            # startupProbe instead (which gates readiness/liveness entirely).
+            initialDelaySeconds: 5
+            # periodSeconds: how often to probe.
+            # Lower = faster detection of readiness, more probe traffic.
+            periodSeconds: 10
+            # failureThreshold: how many consecutive failures before marking not-ready.
+            # 3 failures * 10s = 30 seconds of failure before traffic is removed.
+            failureThreshold: 3
+            timeoutSeconds: 3
 
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 80
-          # Higher initialDelay than readiness — give the app time to become
-          # ready before we start checking liveness (avoid restart loops).
-          initialDelaySeconds: 15
-          periodSeconds: 20
-          failureThreshold: 3
-          timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            # Higher initialDelay than readiness — give the app time to become
+            # ready before we start checking liveness (avoid restart loops).
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 3
+            timeoutSeconds: 3

--- a/core/workloads/pod/basic-pod.yml
+++ b/core/workloads/pod/basic-pod.yml
@@ -100,111 +100,111 @@ spec:
   # emptyDir is created fresh for each Pod instance and deleted when the Pod
   # is removed — perfectly suited for ephemeral scratch space.
   volumes:
-  - name: nginx-tmp
-    # Nginx writes temporary files (client body, proxy buffers) to /tmp
-    emptyDir: {}
-  - name: nginx-run
-    # Nginx writes its PID file to /var/run/nginx.pid
-    emptyDir: {}
-  - name: nginx-cache
-    # Nginx uses /var/cache/nginx for proxy cache and other caches
-    emptyDir: {}
+    - name: nginx-tmp
+      # Nginx writes temporary files (client body, proxy buffers) to /tmp
+      emptyDir: {}
+    - name: nginx-run
+      # Nginx writes its PID file to /var/run/nginx.pid
+      emptyDir: {}
+    - name: nginx-cache
+      # Nginx uses /var/cache/nginx for proxy cache and other caches
+      emptyDir: {}
 
   containers:
-  - name: nginx
-    # Pin to a specific digest in production to prevent image drift.
-    # Using a tag here for readability; replace with:
-    # nginx@sha256:<digest> in a real production environment.
-    image: nginx:1.25-alpine
+    - name: nginx
+      # Pin to a specific digest in production to prevent image drift.
+      # Using a tag here for readability; replace with:
+      # nginx@sha256:<digest> in a real production environment.
+      image: nginx:1.25-alpine
 
-    # Expose the port nginx listens on. This is informational only — Kubernetes
-    # does not use this to configure networking. The actual port binding is done
-    # by nginx's configuration.
-    ports:
-    - containerPort: 80
-      protocol: TCP
-      name: http
+      # Expose the port nginx listens on. This is informational only — Kubernetes
+      # does not use this to configure networking. The actual port binding is done
+      # by nginx's configuration.
+      ports:
+        - containerPort: 80
+          protocol: TCP
+          name: http
 
-    # ─── CONTAINER-LEVEL SECURITY CONTEXT ─────────────────────────────────────
-    securityContext:
-      # Prevents the container from gaining additional privileges via setuid/setgid
-      # binaries or the NO_NEW_PRIVS prctl flag. Hardened systems should always
-      # set this to false (deny privilege escalation).
-      allowPrivilegeEscalation: false
+      # ─── CONTAINER-LEVEL SECURITY CONTEXT ─────────────────────────────────────
+      securityContext:
+        # Prevents the container from gaining additional privileges via setuid/setgid
+        # binaries or the NO_NEW_PRIVS prctl flag. Hardened systems should always
+        # set this to false (deny privilege escalation).
+        allowPrivilegeEscalation: false
 
-      # Makes the container's root filesystem read-only at the kernel level.
-      # Prevents an attacker who gains code execution from modifying the binary,
-      # installing tools, or writing malware to disk. Any writes must go to
-      # explicitly declared volumes (emptyDir, PVC, etc.).
-      readOnlyRootFilesystem: true
+        # Makes the container's root filesystem read-only at the kernel level.
+        # Prevents an attacker who gains code execution from modifying the binary,
+        # installing tools, or writing malware to disk. Any writes must go to
+        # explicitly declared volumes (emptyDir, PVC, etc.).
+        readOnlyRootFilesystem: true
 
-      # Drop ALL Linux capabilities. By default, containers inherit a set of ~14
-      # capabilities (NET_RAW, CHOWN, SETUID, etc.). Dropping all of them and
-      # adding back only what's needed reduces attack surface dramatically.
-      capabilities:
-        drop:
-        - ALL
-        # Note: nginx:alpine is compiled to use port 80 (requires NET_BIND_SERVICE
-        # if running as non-root). To avoid this, configure nginx to listen on
-        # port 8080 and remove this capability entirely.
-        add:
-        - NET_BIND_SERVICE
+        # Drop ALL Linux capabilities. By default, containers inherit a set of ~14
+        # capabilities (NET_RAW, CHOWN, SETUID, etc.). Dropping all of them and
+        # adding back only what's needed reduces attack surface dramatically.
+        capabilities:
+          drop:
+            - ALL
+          # Note: nginx:alpine is compiled to use port 80 (requires NET_BIND_SERVICE
+          # if running as non-root). To avoid this, configure nginx to listen on
+          # port 8080 and remove this capability entirely.
+          add:
+            - NET_BIND_SERVICE
 
-    # ─── RESOURCE MANAGEMENT ──────────────────────────────────────────────────
-    resources:
-      requests:
-        # The scheduler uses requests to find a node with sufficient capacity.
-        # Set requests to the typical (P50) consumption of the container.
-        memory: "128Mi"
-        cpu: "100m"     # 100 millicores = 0.1 vCPU
-      limits:
-        # Memory limit == memory request → Guaranteed QoS class.
-        # This protects the Pod from OOM eviction by giving it the highest eviction
-        # priority. The container is OOM-killed if it exceeds this limit.
-        memory: "128Mi"
-        # CPU limit is intentionally OMITTED.
-        # CPU is a compressible resource: exceeding the limit causes throttling,
-        # not termination. CPU throttling degrades latency without warning.
-        # Monitor cpu_throttled_seconds_total in Prometheus to detect issues.
+      # ─── RESOURCE MANAGEMENT ──────────────────────────────────────────────────
+      resources:
+        requests:
+          # The scheduler uses requests to find a node with sufficient capacity.
+          # Set requests to the typical (P50) consumption of the container.
+          memory: "128Mi"
+          cpu: "100m"     # 100 millicores = 0.1 vCPU
+        limits:
+          # Memory limit == memory request → Guaranteed QoS class.
+          # This protects the Pod from OOM eviction by giving it the highest eviction
+          # priority. The container is OOM-killed if it exceeds this limit.
+          memory: "128Mi"
+          # CPU limit is intentionally OMITTED.
+          # CPU is a compressible resource: exceeding the limit causes throttling,
+          # not termination. CPU throttling degrades latency without warning.
+          # Monitor cpu_throttled_seconds_total in Prometheus to detect issues.
 
-    # ─── VOLUME MOUNTS ────────────────────────────────────────────────────────
-    # Mount the emptyDir volumes at the paths nginx needs to write to.
-    # Without these, nginx fails to start with "permission denied" errors because
-    # readOnlyRootFilesystem prevents writing to the image's own directories.
-    volumeMounts:
-    - name: nginx-tmp
-      mountPath: /tmp
-    - name: nginx-run
-      mountPath: /var/run
-    - name: nginx-cache
-      mountPath: /var/cache/nginx
+      # ─── VOLUME MOUNTS ────────────────────────────────────────────────────────
+      # Mount the emptyDir volumes at the paths nginx needs to write to.
+      # Without these, nginx fails to start with "permission denied" errors because
+      # readOnlyRootFilesystem prevents writing to the image's own directories.
+      volumeMounts:
+        - name: nginx-tmp
+          mountPath: /tmp
+        - name: nginx-run
+          mountPath: /var/run
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
 
-    # ─── LIFECYCLE HOOKS ──────────────────────────────────────────────────────
-    lifecycle:
-      preStop:
-        exec:
-          # Sleep for 5 seconds before nginx receives SIGTERM.
-          # This gives the Endpoints controller time to remove this Pod's IP from
-          # the Service's EndpointSlice, so the load balancer stops sending new
-          # requests here before nginx starts shutting down.
-          # Without this, in-flight requests at the load balancer level may still
-          # be routed to this Pod after it has begun terminating.
-          command: ["/bin/sh", "-c", "sleep 5"]
+      # ─── LIFECYCLE HOOKS ──────────────────────────────────────────────────────
+      lifecycle:
+        preStop:
+          exec:
+            # Sleep for 5 seconds before nginx receives SIGTERM.
+            # This gives the Endpoints controller time to remove this Pod's IP from
+            # the Service's EndpointSlice, so the load balancer stops sending new
+            # requests here before nginx starts shutting down.
+            # Without this, in-flight requests at the load balancer level may still
+            # be routed to this Pod after it has begun terminating.
+            command: ["/bin/sh", "-c", "sleep 5"]
 
-    # ─── PROBES ───────────────────────────────────────────────────────────────
-    # Note: For a basic pod demo, only a simple liveness probe is included.
-    # The nginx-deployment.yml shows the full startup + readiness + liveness set.
-    livenessProbe:
-      httpGet:
-        path: /
-        port: 80
-      # Wait 10 seconds after container start before the first probe attempt.
-      # Prevents false-positive restarts during image initialization.
-      initialDelaySeconds: 10
-      # Run the probe every 15 seconds.
-      periodSeconds: 15
-      # Require 3 consecutive failures before restarting the container.
-      # A single transient failure should not cause a restart.
-      failureThreshold: 3
-      # A probe must respond within 3 seconds or it's considered failed.
-      timeoutSeconds: 3
+      # ─── PROBES ───────────────────────────────────────────────────────────────
+      # Note: For a basic pod demo, only a simple liveness probe is included.
+      # The nginx-deployment.yml shows the full startup + readiness + liveness set.
+      livenessProbe:
+        httpGet:
+          path: /
+          port: 80
+        # Wait 10 seconds after container start before the first probe attempt.
+        # Prevents false-positive restarts during image initialization.
+        initialDelaySeconds: 10
+        # Run the probe every 15 seconds.
+        periodSeconds: 15
+        # Require 3 consecutive failures before restarting the container.
+        # A single transient failure should not cause a restart.
+        failureThreshold: 3
+        # A probe must respond within 3 seconds or it's considered failed.
+        timeoutSeconds: 3

--- a/core/workloads/pod/init-container.yml
+++ b/core/workloads/pod/init-container.yml
@@ -71,179 +71,179 @@ spec:
   # a volume that the main container then reads — a common pattern for fetching
   # configs or secrets during init.
   volumes:
-  - name: nginx-tmp
-    emptyDir: {}
-  - name: nginx-run
-    emptyDir: {}
-  - name: nginx-cache
-    emptyDir: {}
-  - name: shared-data
-    # This volume is written by the init container and read by the main container.
-    # Pattern: init container downloads/generates config; main container uses it.
-    emptyDir: {}
+    - name: nginx-tmp
+      emptyDir: {}
+    - name: nginx-run
+      emptyDir: {}
+    - name: nginx-cache
+      emptyDir: {}
+    - name: shared-data
+      # This volume is written by the init container and read by the main container.
+      # Pattern: init container downloads/generates config; main container uses it.
+      emptyDir: {}
 
   # ─── INIT CONTAINERS ─────────────────────────────────────────────────────────
   # These run BEFORE the main containers, in the ORDER they are listed.
   # kubectl get pod nginx-with-init will show "Init:0/2" until both succeed.
   initContainers:
 
-  # ── Init Container 1: Wait for DNS availability ──────────────────────────────
-  # This init container polls DNS until the target service is resolvable.
-  # In a real cluster, replace "backend-service.workloads.svc.cluster.local"
-  # with your actual dependency's service name.
-  #
-  # The pattern: nslookup returns exit code 0 on success, non-zero on failure.
-  # The shell loop retries every 2 seconds until success (or the Pod is killed).
-  - name: wait-for-backend
-    # busybox provides nslookup; use a specific digest in production.
-    # Alpine or distroless are preferred over busybox in high-security environments.
-    image: busybox:1.36
+    # ── Init Container 1: Wait for DNS availability ──────────────────────────────
+    # This init container polls DNS until the target service is resolvable.
+    # In a real cluster, replace "backend-service.workloads.svc.cluster.local"
+    # with your actual dependency's service name.
+    #
+    # The pattern: nslookup returns exit code 0 on success, non-zero on failure.
+    # The shell loop retries every 2 seconds until success (or the Pod is killed).
+    - name: wait-for-backend
+      # busybox provides nslookup; use a specific digest in production.
+      # Alpine or distroless are preferred over busybox in high-security environments.
+      image: busybox:1.36
 
-    # The command runs a shell loop that tries nslookup every 2 seconds.
-    # "until nslookup <host>; do ..." is the idiomatic K8s init pattern.
-    # The `2>/dev/null` suppresses error output to keep logs clean.
-    command:
-    - "/bin/sh"
-    - "-c"
-    - |
-      echo "Waiting for backend-service DNS to be available..."
-      until nslookup backend-service.workloads.svc.cluster.local 2>/dev/null; do
-        echo "backend-service not yet available, retrying in 2s..."
-        sleep 2
-      done
-      echo "backend-service is available! Proceeding to start nginx."
+      # The command runs a shell loop that tries nslookup every 2 seconds.
+      # "until nslookup <host>; do ..." is the idiomatic K8s init pattern.
+      # The `2>/dev/null` suppresses error output to keep logs clean.
+      command:
+        - "/bin/sh"
+        - "-c"
+        - |
+          echo "Waiting for backend-service DNS to be available..."
+          until nslookup backend-service.workloads.svc.cluster.local 2>/dev/null; do
+            echo "backend-service not yet available, retrying in 2s..."
+            sleep 2
+          done
+          echo "backend-service is available! Proceeding to start nginx."
 
-    # ── Init Container Security Context ──────────────────────────────────────
-    # Init containers must also meet security standards — they are not exempt.
-    securityContext:
-      allowPrivilegeEscalation: false
-      readOnlyRootFilesystem: true
-      capabilities:
-        drop:
-        - ALL
+      # ── Init Container Security Context ──────────────────────────────────────
+      # Init containers must also meet security standards — they are not exempt.
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
 
-    # ── Init Container Resources ──────────────────────────────────────────────
-    # Init containers consume resources only while they are running (before main
-    # containers start). The effective resource request for the Pod is the MAX
-    # of all init container requests and the sum of main container requests.
-    resources:
-      requests:
-        memory: "32Mi"    # nslookup is very lightweight
-        cpu: "50m"
-      limits:
-        memory: "32Mi"
+      # ── Init Container Resources ──────────────────────────────────────────────
+      # Init containers consume resources only while they are running (before main
+      # containers start). The effective resource request for the Pod is the MAX
+      # of all init container requests and the sum of main container requests.
+      resources:
+        requests:
+          memory: "32Mi"    # nslookup is very lightweight
+          cpu: "50m"
+        limits:
+          memory: "32Mi"
 
-  # ── Init Container 2: Pre-populate shared configuration ───────────────────
-  # This init container writes a custom nginx configuration to the shared volume.
-  # The main nginx container will use this config instead of the default.
-  # This pattern avoids needing a ConfigMap for simple cases, or can be used
-  # to decrypt and write secrets from an encrypted store.
-  - name: write-config
-    image: busybox:1.36
-    command:
-    - "/bin/sh"
-    - "-c"
-    - |
-      echo "Writing custom index.html to shared volume..."
-      cat > /shared/index.html << 'EOF'
-      <html>
-        <body>
-          <h1>Hello from Kubernetes Init Container Demo</h1>
-          <p>This content was written by an init container before nginx started.</p>
-        </body>
-      </html>
-      EOF
-      echo "Configuration written successfully."
+    # ── Init Container 2: Pre-populate shared configuration ───────────────────
+    # This init container writes a custom nginx configuration to the shared volume.
+    # The main nginx container will use this config instead of the default.
+    # This pattern avoids needing a ConfigMap for simple cases, or can be used
+    # to decrypt and write secrets from an encrypted store.
+    - name: write-config
+      image: busybox:1.36
+      command:
+        - "/bin/sh"
+        - "-c"
+        - |
+          echo "Writing custom index.html to shared volume..."
+          cat > /shared/index.html << 'EOF'
+          <html>
+            <body>
+              <h1>Hello from Kubernetes Init Container Demo</h1>
+              <p>This content was written by an init container before nginx started.</p>
+            </body>
+          </html>
+          EOF
+          echo "Configuration written successfully."
 
-    securityContext:
-      allowPrivilegeEscalation: false
-      # Write access to /shared requires the root filesystem not be read-only for
-      # the writable volume. The volume mount itself is writable; only the container
-      # image's filesystem layers are read-only.
-      readOnlyRootFilesystem: true
-      capabilities:
-        drop:
-        - ALL
+      securityContext:
+        allowPrivilegeEscalation: false
+        # Write access to /shared requires the root filesystem not be read-only for
+        # the writable volume. The volume mount itself is writable; only the container
+        # image's filesystem layers are read-only.
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
 
-    resources:
-      requests:
-        memory: "32Mi"
-        cpu: "50m"
-      limits:
-        memory: "32Mi"
+      resources:
+        requests:
+          memory: "32Mi"
+          cpu: "50m"
+        limits:
+          memory: "32Mi"
 
-    volumeMounts:
-    # The init container writes to the shared volume.
-    # The main container reads from the same volume.
-    - name: shared-data
-      mountPath: /shared
+      volumeMounts:
+        # The init container writes to the shared volume.
+        # The main container reads from the same volume.
+        - name: shared-data
+          mountPath: /shared
 
   # ─── MAIN CONTAINERS ─────────────────────────────────────────────────────────
   # These start ONLY after all init containers have succeeded.
   containers:
-  - name: nginx
-    image: nginx:1.25-alpine
+    - name: nginx
+      image: nginx:1.25-alpine
 
-    ports:
-    - containerPort: 80
-      protocol: TCP
-      name: http
+      ports:
+        - containerPort: 80
+          protocol: TCP
+          name: http
 
-    # ── Container Security Context ────────────────────────────────────────────
-    securityContext:
-      allowPrivilegeEscalation: false
-      readOnlyRootFilesystem: true
-      capabilities:
-        drop:
-        - ALL
-        add:
-        - NET_BIND_SERVICE  # Required for nginx to bind port 80 as non-root
+      # ── Container Security Context ────────────────────────────────────────────
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+          add:
+            - NET_BIND_SERVICE  # Required for nginx to bind port 80 as non-root
 
-    resources:
-      requests:
-        memory: "128Mi"
-        cpu: "100m"
-      limits:
-        memory: "128Mi"
+      resources:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "128Mi"
 
-    volumeMounts:
-    # Writable scratch space for nginx internals (required when readOnlyRootFilesystem is true)
-    - name: nginx-tmp
-      mountPath: /tmp
-    - name: nginx-run
-      mountPath: /var/run
-    - name: nginx-cache
-      mountPath: /var/cache/nginx
-    # Read the index.html that was pre-populated by the write-config init container.
-    # In a real scenario this would be a config file, a secret, or a binary artifact.
-    - name: shared-data
-      mountPath: /usr/share/nginx/html
-      # readOnly: true — the main container should not modify what the init container wrote.
-      readOnly: true
+      volumeMounts:
+        # Writable scratch space for nginx internals (required when readOnlyRootFilesystem is true)
+        - name: nginx-tmp
+          mountPath: /tmp
+        - name: nginx-run
+          mountPath: /var/run
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        # Read the index.html that was pre-populated by the write-config init container.
+        # In a real scenario this would be a config file, a secret, or a binary artifact.
+        - name: shared-data
+          mountPath: /usr/share/nginx/html
+          # readOnly: true — the main container should not modify what the init container wrote.
+          readOnly: true
 
-    # ── Graceful Shutdown ─────────────────────────────────────────────────────
-    lifecycle:
-      preStop:
-        exec:
-          # Allow 5 seconds for load balancer endpoint removal before SIGTERM.
-          # This prevents new requests being routed to a shutting-down container.
-          command: ["/bin/sh", "-c", "sleep 5"]
+      # ── Graceful Shutdown ─────────────────────────────────────────────────────
+      lifecycle:
+        preStop:
+          exec:
+            # Allow 5 seconds for load balancer endpoint removal before SIGTERM.
+            # This prevents new requests being routed to a shutting-down container.
+            command: ["/bin/sh", "-c", "sleep 5"]
 
-    # ── Health Probes ─────────────────────────────────────────────────────────
-    livenessProbe:
-      httpGet:
-        path: /
-        port: 80
-      initialDelaySeconds: 10
-      periodSeconds: 15
-      failureThreshold: 3
-      timeoutSeconds: 3
+      # ── Health Probes ─────────────────────────────────────────────────────────
+      livenessProbe:
+        httpGet:
+          path: /
+          port: 80
+        initialDelaySeconds: 10
+        periodSeconds: 15
+        failureThreshold: 3
+        timeoutSeconds: 3
 
-    readinessProbe:
-      httpGet:
-        path: /
-        port: 80
-      initialDelaySeconds: 5
-      periodSeconds: 10
-      failureThreshold: 3
-      timeoutSeconds: 3
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 80
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        failureThreshold: 3
+        timeoutSeconds: 3

--- a/core/workloads/pod/sidecar-container.yml
+++ b/core/workloads/pod/sidecar-container.yml
@@ -65,21 +65,21 @@ spec:
 
   # ─── VOLUMES ─────────────────────────────────────────────────────────────────
   volumes:
-  # This is the KEY volume in the sidecar pattern.
-  # Both containers mount it: nginx writes logs here; the sidecar reads them.
-  # emptyDir is created when the Pod is assigned to a node and deleted when
-  # the Pod is removed — it is NOT persisted across Pod restarts.
-  - name: shared-logs
-    emptyDir: {}
+    # This is the KEY volume in the sidecar pattern.
+    # Both containers mount it: nginx writes logs here; the sidecar reads them.
+    # emptyDir is created when the Pod is assigned to a node and deleted when
+    # the Pod is removed — it is NOT persisted across Pod restarts.
+    - name: shared-logs
+      emptyDir: {}
 
-  # nginx requires these writable directories because readOnlyRootFilesystem: true
-  # prevents writes to the container's own filesystem.
-  - name: nginx-tmp
-    emptyDir: {}
-  - name: nginx-run
-    emptyDir: {}
-  - name: nginx-cache
-    emptyDir: {}
+    # nginx requires these writable directories because readOnlyRootFilesystem: true
+    # prevents writes to the container's own filesystem.
+    - name: nginx-tmp
+      emptyDir: {}
+    - name: nginx-run
+      emptyDir: {}
+    - name: nginx-cache
+      emptyDir: {}
 
   # ─── CONTAINERS ──────────────────────────────────────────────────────────────
   # Both containers start in PARALLEL (unlike init containers, which are sequential).
@@ -87,153 +87,153 @@ spec:
   # If either container exits, the Pod's restartPolicy applies.
   containers:
 
-  # ── Main Container: nginx ─────────────────────────────────────────────────
-  # nginx is configured to write access logs to the shared volume instead of
-  # its default stdout. In a production scenario you would mount a ConfigMap
-  # with a custom nginx.conf that sets: access_log /var/log/nginx/access.log;
-  - name: nginx
-    image: nginx:1.25-alpine
+    # ── Main Container: nginx ─────────────────────────────────────────────────
+    # nginx is configured to write access logs to the shared volume instead of
+    # its default stdout. In a production scenario you would mount a ConfigMap
+    # with a custom nginx.conf that sets: access_log /var/log/nginx/access.log;
+    - name: nginx
+      image: nginx:1.25-alpine
 
-    ports:
-    - containerPort: 80
-      protocol: TCP
-      name: http
+      ports:
+        - containerPort: 80
+          protocol: TCP
+          name: http
 
-    # Override nginx's default command to write logs to the shared volume.
-    # nginx's default access_log is /var/log/nginx/access.log — we just need
-    # to ensure that path is writable (handled by the shared-logs volume mount).
-    # In production, use a ConfigMap-mounted nginx.conf for configuration.
-    command:
-    - "/bin/sh"
-    - "-c"
-    - |
-      # Ensure the log directory exists (it's an emptyDir mount, so it starts empty)
-      mkdir -p /var/log/nginx
-      # Start nginx in the foreground; logs go to /var/log/nginx/access.log
-      # via nginx's default configuration pointing access_log there.
-      nginx -g "daemon off;"
+      # Override nginx's default command to write logs to the shared volume.
+      # nginx's default access_log is /var/log/nginx/access.log — we just need
+      # to ensure that path is writable (handled by the shared-logs volume mount).
+      # In production, use a ConfigMap-mounted nginx.conf for configuration.
+      command:
+        - "/bin/sh"
+        - "-c"
+        - |
+          # Ensure the log directory exists (it's an emptyDir mount, so it starts empty)
+          mkdir -p /var/log/nginx
+          # Start nginx in the foreground; logs go to /var/log/nginx/access.log
+          # via nginx's default configuration pointing access_log there.
+          nginx -g "daemon off;"
 
-    # ── Container Security Context ────────────────────────────────────────────
-    securityContext:
-      allowPrivilegeEscalation: false
-      readOnlyRootFilesystem: true
-      capabilities:
-        drop:
-        - ALL
-        add:
-        - NET_BIND_SERVICE
+      # ── Container Security Context ────────────────────────────────────────────
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+          add:
+            - NET_BIND_SERVICE
 
-    resources:
-      requests:
-        memory: "128Mi"
-        cpu: "100m"
-      limits:
-        memory: "128Mi"
+      resources:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "128Mi"
 
-    volumeMounts:
-    # The shared volume where nginx writes its access logs.
-    # The sidecar reads from this same path.
-    - name: shared-logs
-      mountPath: /var/log/nginx
+      volumeMounts:
+        # The shared volume where nginx writes its access logs.
+        # The sidecar reads from this same path.
+        - name: shared-logs
+          mountPath: /var/log/nginx
 
-    # nginx's required writable system directories
-    - name: nginx-tmp
-      mountPath: /tmp
-    - name: nginx-run
-      mountPath: /var/run
-    - name: nginx-cache
-      mountPath: /var/cache/nginx
+        # nginx's required writable system directories
+        - name: nginx-tmp
+          mountPath: /tmp
+        - name: nginx-run
+          mountPath: /var/run
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
 
-    lifecycle:
-      preStop:
-        exec:
-          command: ["/bin/sh", "-c", "sleep 5"]
+      lifecycle:
+        preStop:
+          exec:
+            command: ["/bin/sh", "-c", "sleep 5"]
 
-    readinessProbe:
-      httpGet:
-        path: /
-        port: 80
-      initialDelaySeconds: 5
-      periodSeconds: 10
-      failureThreshold: 3
-      timeoutSeconds: 3
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 80
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        failureThreshold: 3
+        timeoutSeconds: 3
 
-    livenessProbe:
-      httpGet:
-        path: /
-        port: 80
-      initialDelaySeconds: 10
-      periodSeconds: 15
-      failureThreshold: 3
-      timeoutSeconds: 3
+      livenessProbe:
+        httpGet:
+          path: /
+          port: 80
+        initialDelaySeconds: 10
+        periodSeconds: 15
+        failureThreshold: 3
+        timeoutSeconds: 3
 
-  # ── Sidecar Container: log-forwarder ─────────────────────────────────────
-  # This container runs IN PARALLEL with nginx, tailing the access log file
-  # and writing it to its own stdout. The container runtime (containerd) then
-  # collects the stdout and makes it available via `kubectl logs`.
-  #
-  # In production you would replace this busybox tail with:
-  #   - Fluentd: parses nginx log format, ships to Elasticsearch/Splunk
-  #   - Vector: high-performance log router, ships to Loki/Datadog/S3
-  #   - Filebeat: Elastic stack log shipper
-  #   - Fluent Bit: lightweight, ships to any sink
-  - name: log-forwarder
-    image: busybox:1.36
+    # ── Sidecar Container: log-forwarder ─────────────────────────────────────
+    # This container runs IN PARALLEL with nginx, tailing the access log file
+    # and writing it to its own stdout. The container runtime (containerd) then
+    # collects the stdout and makes it available via `kubectl logs`.
+    #
+    # In production you would replace this busybox tail with:
+    #   - Fluentd: parses nginx log format, ships to Elasticsearch/Splunk
+    #   - Vector: high-performance log router, ships to Loki/Datadog/S3
+    #   - Filebeat: Elastic stack log shipper
+    #   - Fluent Bit: lightweight, ships to any sink
+    - name: log-forwarder
+      image: busybox:1.36
 
-    # `tail -F` follows the file even if it is rotated (vs. `tail -f` which
-    # follows the file descriptor). `-F` is correct for log rotation scenarios.
-    # The sidecar writes each log line to ITS OWN stdout, which kubectl logs
-    # can then display with: kubectl logs <pod> -c log-forwarder
-    command:
-    - "/bin/sh"
-    - "-c"
-    - |
-      echo "Log forwarder sidecar started. Waiting for log file..."
-      # Wait for nginx to create the log file before tailing it.
-      # This is a simple startup race condition handled with a loop.
-      until [ -f /var/log/nginx/access.log ]; do
-        echo "Waiting for /var/log/nginx/access.log to be created..."
-        sleep 1
-      done
-      echo "Log file found. Starting tail..."
-      # In a production Fluentd/Vector setup, you would configure the log parser
-      # here to parse nginx's combined log format and add Kubernetes metadata
-      # (namespace, pod name, node) as structured fields.
-      exec tail -F /var/log/nginx/access.log
+      # `tail -F` follows the file even if it is rotated (vs. `tail -f` which
+      # follows the file descriptor). `-F` is correct for log rotation scenarios.
+      # The sidecar writes each log line to ITS OWN stdout, which kubectl logs
+      # can then display with: kubectl logs <pod> -c log-forwarder
+      command:
+        - "/bin/sh"
+        - "-c"
+        - |
+          echo "Log forwarder sidecar started. Waiting for log file..."
+          # Wait for nginx to create the log file before tailing it.
+          # This is a simple startup race condition handled with a loop.
+          until [ -f /var/log/nginx/access.log ]; do
+            echo "Waiting for /var/log/nginx/access.log to be created..."
+            sleep 1
+          done
+          echo "Log file found. Starting tail..."
+          # In a production Fluentd/Vector setup, you would configure the log parser
+          # here to parse nginx's combined log format and add Kubernetes metadata
+          # (namespace, pod name, node) as structured fields.
+          exec tail -F /var/log/nginx/access.log
 
-    # ── Sidecar Security Context ──────────────────────────────────────────────
-    # The sidecar must also meet production security standards.
-    # It only needs READ access to the shared log volume — readOnly: true on the
-    # volumeMount prevents the sidecar from accidentally modifying nginx logs.
-    securityContext:
-      allowPrivilegeEscalation: false
-      readOnlyRootFilesystem: true
-      capabilities:
-        drop:
-        - ALL
+      # ── Sidecar Security Context ──────────────────────────────────────────────
+      # The sidecar must also meet production security standards.
+      # It only needs READ access to the shared log volume — readOnly: true on the
+      # volumeMount prevents the sidecar from accidentally modifying nginx logs.
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
 
-    resources:
-      requests:
-        # A log-tailing sidecar is very lightweight
-        memory: "32Mi"
-        cpu: "50m"
-      limits:
-        memory: "32Mi"
-        # No CPU limit on the sidecar either — log forwarding should not be throttled
+      resources:
+        requests:
+          # A log-tailing sidecar is very lightweight
+          memory: "32Mi"
+          cpu: "50m"
+        limits:
+          memory: "32Mi"
+          # No CPU limit on the sidecar either — log forwarding should not be throttled
 
-    volumeMounts:
-    # The sidecar READS the shared log volume. Mount as readOnly for least privilege.
-    # Writing to the log directory should only be done by nginx.
-    - name: shared-logs
-      mountPath: /var/log/nginx
-      readOnly: true
+      volumeMounts:
+        # The sidecar READS the shared log volume. Mount as readOnly for least privilege.
+        # Writing to the log directory should only be done by nginx.
+        - name: shared-logs
+          mountPath: /var/log/nginx
+          readOnly: true
 
-    # Graceful shutdown for the sidecar:
-    # When the Pod is deleted, both containers receive SIGTERM simultaneously.
-    # The sidecar should flush any buffered log entries before exiting.
-    # In a real Fluentd sidecar you would send SIGTERM to Fluentd's main process
-    # which triggers its graceful flush. Here, `tail` exits immediately on SIGTERM.
-    lifecycle:
-      preStop:
-        exec:
-          command: ["/bin/sh", "-c", "sleep 5"]
+      # Graceful shutdown for the sidecar:
+      # When the Pod is deleted, both containers receive SIGTERM simultaneously.
+      # The sidecar should flush any buffered log entries before exiting.
+      # In a real Fluentd sidecar you would send SIGTERM to Fluentd's main process
+      # which triggers its graceful flush. Here, `tail` exits immediately on SIGTERM.
+      lifecycle:
+        preStop:
+          exec:
+            command: ["/bin/sh", "-c", "sleep 5"]


### PR DESCRIPTION
## Summary

- Fix containers/ports/volumes indentation in all 4 deployment strategy subdirectories (11 files)
- Exclude `helm/*/templates/*` from yamllint — Go template syntax is not valid YAML
- Exclude `*/kustomize/overlays/*` from kubeconform — patch files are partial specs missing required fields

Closes #47, Closes #48

## Test plan
- [ ] yamllint passes on all deployment-strategy YAML files
- [ ] kubeconform skips kustomize overlay patches
- [ ] helm lint still runs against full chart directories