### PR TITLE
fix: resolve all CI failures — yamllint, kubeconform, and helm lint

### DIFF
--- a/.github/workflows/validate-yaml.yml
+++ b/.github/workflows/validate-yaml.yml
@@ -60,6 +60,7 @@ jobs:
                   line-length: {max: 160, level: warning},
                   truthy: {allowed-values: ["true", "false"]},
                   comments: {min-spaces-from-content: 1},
+                  comments-indentation: disable,
                   document-start: disable
                 }
               }'
@@ -97,6 +98,7 @@ jobs:
               ! -path './helm/*' \
               ! -path './.github/*' \
               ! -path '*/kustomize/overlays/*' \
+              ! -path './platform/observability/prometheus-grafana/values-*.yaml' \
             | sort
           )
           if [ -z "$MANIFEST_FILES" ]; then

--- a/core/storage/storageclass-local.yml
+++ b/core/storage/storageclass-local.yml
@@ -47,51 +47,50 @@ metadata:
     # marked as default per cluster to avoid ambiguity.
     # storageclass.kubernetes.io/is-default-class: "true"
 
-spec:
-  # provisioner: kubernetes.io/no-provisioner disables dynamic provisioning.
-  # When a PVC is created that matches this StorageClass, Kubernetes will
-  # NOT call any provisioner to create a PV. Instead, it waits for a manually
-  # pre-created PV with the matching StorageClass name to become available.
-  provisioner: kubernetes.io/no-provisioner
+# provisioner: kubernetes.io/no-provisioner disables dynamic provisioning.
+# When a PVC is created that matches this StorageClass, Kubernetes will
+# NOT call any provisioner to create a PV. Instead, it waits for a manually
+# pre-created PV with the matching StorageClass name to become available.
+provisioner: kubernetes.io/no-provisioner
 
-  # volumeBindingMode: WaitForFirstConsumer
-  # ─────────────────────────────────────────
-  # This is the CRITICAL setting for local storage.
-  #
-  # WITHOUT this (using Immediate binding, the old default):
-  #   The PVC is immediately bound to the first available matching PV, before
-  #   any pod is scheduled. If the PV's node is different from where the pod
-  #   eventually schedules (due to resource constraints, nodeSelector, etc.),
-  #   the pod CANNOT START — it is stuck waiting for a volume that is on
-  #   the wrong node. This creates a deadlock with no obvious error message.
-  #
-  # WITH WaitForFirstConsumer:
-  #   The PVC remains in Pending state until a pod that references it is
-  #   actually being scheduled. At that point, the scheduler knows which node
-  #   the pod will run on, and THEN binds the PVC to a PV on that specific node.
-  #   This guarantees pod and volume co-location.
-  #
-  # Always use WaitForFirstConsumer for:
-  #   - local-storage (mandatory)
-  #   - topology-aware cloud storage (e.g., EBS in multi-AZ clusters)
-  #   - any storage type that is zone or node-constrained
-  volumeBindingMode: WaitForFirstConsumer
+# volumeBindingMode: WaitForFirstConsumer
+# ─────────────────────────────────────────
+# This is the CRITICAL setting for local storage.
+#
+# WITHOUT this (using Immediate binding, the old default):
+#   The PVC is immediately bound to the first available matching PV, before
+#   any pod is scheduled. If the PV's node is different from where the pod
+#   eventually schedules (due to resource constraints, nodeSelector, etc.),
+#   the pod CANNOT START — it is stuck waiting for a volume that is on
+#   the wrong node. This creates a deadlock with no obvious error message.
+#
+# WITH WaitForFirstConsumer:
+#   The PVC remains in Pending state until a pod that references it is
+#   actually being scheduled. At that point, the scheduler knows which node
+#   the pod will run on, and THEN binds the PVC to a PV on that specific node.
+#   This guarantees pod and volume co-location.
+#
+# Always use WaitForFirstConsumer for:
+#   - local-storage (mandatory)
+#   - topology-aware cloud storage (e.g., EBS in multi-AZ clusters)
+#   - any storage type that is zone or node-constrained
+volumeBindingMode: WaitForFirstConsumer
 
-  # reclaimPolicy: Retain preserves the PV and its data when the PVC is deleted.
-  # This is essential for local development where you want data to persist
-  # between test runs. For local storage, Retain is safer than Delete because
-  # there is no automated cleanup process — data stays on the node's disk.
-  #
-  # After the PVC is deleted, the PV transitions to Released state. To reuse it:
-  #   1. Delete the PV object.
-  #   2. Manually clean up /data/k8s-pv-1 on the node.
-  #   3. Recreate the PV (or apply persistent-volume.yml again).
-  reclaimPolicy: Retain
+# reclaimPolicy: Retain preserves the PV and its data when the PVC is deleted.
+# This is essential for local development where you want data to persist
+# between test runs. For local storage, Retain is safer than Delete because
+# there is no automated cleanup process — data stays on the node's disk.
+#
+# After the PVC is deleted, the PV transitions to Released state. To reuse it:
+#   1. Delete the PV object.
+#   2. Manually clean up /data/k8s-pv-1 on the node.
+#   3. Recreate the PV (or apply persistent-volume.yml again).
+reclaimPolicy: Retain
 
-  # allowVolumeExpansion: true allows PVCs to request more storage after
-  # creation by editing the PVC's spec.resources.requests.storage field.
-  # The underlying storage must support expansion (local hostPath does NOT
-  # support this; cloud block storage generally does). Include it here as a
-  # best practice for StorageClass definitions, even if not currently used.
-  allowVolumeExpansion: false   # hostPath/local volumes do not support expansion.
-                                # Set to true for cloud StorageClasses.
+# allowVolumeExpansion: true allows PVCs to request more storage after
+# creation by editing the PVC's spec.resources.requests.storage field.
+# The underlying storage must support expansion (local hostPath does NOT
+# support this; cloud block storage generally does). Include it here as a
+# best practice for StorageClass definitions, even if not currently used.
+# Set to true for cloud StorageClasses (e.g., EBS, GCE-PD).
+allowVolumeExpansion: false  # hostPath/local volumes do not support expansion.

--- a/core/workloads/daemonset/daemonset.yml
+++ b/core/workloads/daemonset/daemonset.yml
@@ -97,119 +97,119 @@ spec:
       # Tolerations allow the DaemonSet to be scheduled on nodes that have matching taints.
       # Without these tolerations, the pods would not be scheduled on control-plane nodes.
       tolerations:
-      # Tolerate the control-plane taint so the log collector runs on control-plane nodes too.
-      # This is necessary for complete log coverage (e.g., kube-apiserver audit logs, etcd logs).
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-      # Also tolerate the 'master' taint for compatibility with older Kubernetes versions
-      # that used 'master' instead of 'control-plane'.
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      # Tolerate nodes that are not yet ready — ensures the log collector starts collecting
-      # immediately when a node joins, before it is fully Ready. Useful for capturing
-      # startup logs and node initialization events.
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-        effect: NoSchedule
-      - key: node.kubernetes.io/unreachable
-        operator: Exists
-        effect: NoSchedule
+        # Tolerate the control-plane taint so the log collector runs on control-plane nodes too.
+        # This is necessary for complete log coverage (e.g., kube-apiserver audit logs, etcd logs).
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        # Also tolerate the 'master' taint for compatibility with older Kubernetes versions
+        # that used 'master' instead of 'control-plane'.
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        # Tolerate nodes that are not yet ready — ensures the log collector starts collecting
+        # immediately when a node joins, before it is fully Ready. Useful for capturing
+        # startup logs and node initialization events.
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoSchedule
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoSchedule
 
       containers:
-      - name: log-collector
-        # In production, replace busybox with Fluent Bit (fluent/fluent-bit),
-        # Filebeat (docker.elastic.co/beats/filebeat), or Fluentd (fluent/fluentd).
-        # busybox is used here to demonstrate the DaemonSet pattern without
-        # requiring external image pulls or complex configuration.
-        image: busybox:1.36
-        imagePullPolicy: IfNotPresent
+        - name: log-collector
+          # In production, replace busybox with Fluent Bit (fluent/fluent-bit),
+          # Filebeat (docker.elastic.co/beats/filebeat), or Fluentd (fluent/fluentd).
+          # busybox is used here to demonstrate the DaemonSet pattern without
+          # requiring external image pulls or complex configuration.
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
 
-        command:
-        - /bin/sh
-        - -c
-        - |
-          echo "Log collector starting on node: ${NODE_NAME}"
-          echo "Watching /var/log/host for new log files..."
-          # In production, this would be replaced by the log collector's entrypoint.
-          # For demonstration: tail all log files and echo to stdout.
-          # The kubelet captures stdout and makes it available via 'kubectl logs'.
-          while true; do
-            echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [log-collector] Heartbeat — node=${NODE_NAME}"
-            # A real log collector (Fluent Bit) would:
-            # 1. Watch /var/log/host/containers/*.log for container logs
-            # 2. Parse, enrich (add node name, namespace, pod name labels)
-            # 3. Forward to Elasticsearch, Loki, CloudWatch, etc.
-            sleep 30
-          done
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Log collector starting on node: ${NODE_NAME}"
+              echo "Watching /var/log/host for new log files..."
+              # In production, this would be replaced by the log collector's entrypoint.
+              # For demonstration: tail all log files and echo to stdout.
+              # The kubelet captures stdout and makes it available via 'kubectl logs'.
+              while true; do
+                echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [log-collector] Heartbeat — node=${NODE_NAME}"
+                # A real log collector (Fluent Bit) would:
+                # 1. Watch /var/log/host/containers/*.log for container logs
+                # 2. Parse, enrich (add node name, namespace, pod name labels)
+                # 3. Forward to Elasticsearch, Loki, CloudWatch, etc.
+                sleep 30
+              done
 
-        securityContext:
-          allowPrivilegeEscalation: false
-          # readOnlyRootFilesystem: true is safe here because the log collector
-          # only reads from hostPath volumes, not the container's own filesystem.
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            # readOnlyRootFilesystem: true is safe here because the log collector
+            # only reads from hostPath volumes, not the container's own filesystem.
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
 
-        resources:
-          requests:
-            memory: "64Mi"
-            cpu: "100m"
-          limits:
-            memory: "128Mi"
-            # CPU limit is set here because log collectors should be 'best effort'
-            # for CPU — they should not starve application pods on busy nodes.
-            # If the log collector gets CPU-throttled under load, logs may be delayed
-            # but this is preferable to impacting application latency.
-            cpu: "200m"
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "128Mi"
+              # CPU limit is set here because log collectors should be 'best effort'
+              # for CPU — they should not starve application pods on busy nodes.
+              # If the log collector gets CPU-throttled under load, logs may be delayed
+              # but this is preferable to impacting application latency.
+              cpu: "200m"
 
-        env:
-        # Expose the node name to the container via the Downward API.
-        # This allows the log collector to label logs with the source node name —
-        # critical for log routing and filtering in multi-node clusters.
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        # Similarly expose pod name and namespace for self-identification in logs.
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          env:
+            # Expose the node name to the container via the Downward API.
+            # This allows the log collector to label logs with the source node name —
+            # critical for log routing and filtering in multi-node clusters.
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Similarly expose pod name and namespace for self-identification in logs.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
 
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log/host   # Mount host logs at a distinct path to avoid confusion
-          readOnly: true             # Log collectors need READ access only — never write to host logs
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true             # Container log files in JSON format (Docker/containerd runtime)
-        - name: tmp
-          mountPath: /tmp            # Writable temp space for the collector's own use
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log/host   # Mount host logs at a distinct path to avoid confusion
+              readOnly: true             # Log collectors need READ access only — never write to host logs
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true             # Container log files in JSON format (Docker/containerd runtime)
+            - name: tmp
+              mountPath: /tmp            # Writable temp space for the collector's own use
 
       volumes:
-      # hostPath mounts a directory from the HOST NODE's filesystem into the pod.
-      # This is how the log collector accesses logs written by other pods and the OS.
-      # Security note: This gives the container visibility into host filesystem paths.
-      # Always use readOnly: true in the volumeMount when write access is not required.
-      - name: varlog
-        hostPath:
-          path: /var/log
-          # 'Directory' type ensures the path must already exist on the host.
-          # If the path doesn't exist, the pod will fail with a clear error.
-          # Other types: File, Socket, CharDevice, BlockDevice, DirectoryOrCreate, FileOrCreate
-          type: Directory
+        # hostPath mounts a directory from the HOST NODE's filesystem into the pod.
+        # This is how the log collector accesses logs written by other pods and the OS.
+        # Security note: This gives the container visibility into host filesystem paths.
+        # Always use readOnly: true in the volumeMount when write access is not required.
+        - name: varlog
+          hostPath:
+            path: /var/log
+            # 'Directory' type ensures the path must already exist on the host.
+            # If the path doesn't exist, the pod will fail with a clear error.
+            # Other types: File, Socket, CharDevice, BlockDevice, DirectoryOrCreate, FileOrCreate
+            type: Directory
 
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-          type: DirectoryOrCreate    # Creates the directory if it doesn't exist (for non-Docker runtimes)
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+            type: DirectoryOrCreate    # Creates the directory if it doesn't exist (for non-Docker runtimes)
 
-      # emptyDir for the collector's own temporary buffer files.
-      - name: tmp
-        emptyDir: {}
+        # emptyDir for the collector's own temporary buffer files.
+        - name: tmp
+          emptyDir: {}

--- a/core/workloads/jobs/cronjob.yml
+++ b/core/workloads/jobs/cronjob.yml
@@ -93,119 +93,119 @@ spec:
           restartPolicy: Never
 
           containers:
-          - name: backup
-            # In production, replace with your backup tool's image:
-            # e.g., amazon/aws-cli for S3 backups, google/cloud-sdk for GCS,
-            # or a purpose-built image with mysqldump/pg_dump + cloud storage CLI.
-            image: busybox:1.36
-            imagePullPolicy: IfNotPresent
+            - name: backup
+              # In production, replace with your backup tool's image:
+              # e.g., amazon/aws-cli for S3 backups, google/cloud-sdk for GCS,
+              # or a purpose-built image with mysqldump/pg_dump + cloud storage CLI.
+              image: busybox:1.36
+              imagePullPolicy: IfNotPresent
 
-            command:
-            - /bin/sh
-            - -c
-            - |
-              set -e
-              set -u
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  set -u
 
-              BACKUP_DATE=$(date -u +%Y-%m-%d)
-              BACKUP_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-              BACKUP_FILE="/backup/data-${BACKUP_DATE}.tar.gz"
+                  BACKUP_DATE=$(date -u +%Y-%m-%d)
+                  BACKUP_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                  BACKUP_FILE="/backup/data-${BACKUP_DATE}.tar.gz"
 
-              echo "=== Data Backup Started ==="
-              echo "Date: ${BACKUP_TIME}"
-              echo "Target: ${BACKUP_FILE}"
-              echo "Pod: ${POD_NAME}"
+                  echo "=== Data Backup Started ==="
+                  echo "Date: ${BACKUP_TIME}"
+                  echo "Target: ${BACKUP_FILE}"
+                  echo "Pod: ${POD_NAME}"
 
-              # Step 1: Pre-backup checks
-              echo "Checking available disk space..."
-              df -h /backup
-              # In production: check if enough space exists before starting.
+                  # Step 1: Pre-backup checks
+                  echo "Checking available disk space..."
+                  df -h /backup
+                  # In production: check if enough space exists before starting.
 
-              # Step 2: Create backup
-              echo "Creating backup archive..."
-              # Production example (database dump):
-              # mysqldump -h "${DB_HOST}" -u root -p"${DB_PASSWORD}" --all-databases \
-              #   | gzip > "${BACKUP_FILE}"
-              #
-              # Production example (filesystem backup):
-              # tar -czf "${BACKUP_FILE}" /data/
-              #
-              # Production example (S3 upload):
-              # aws s3 cp "${BACKUP_FILE}" "s3://${BACKUP_BUCKET}/$(date +%Y/%m/%d)/"
-              echo "[SIMULATED] Backup archive created at ${BACKUP_FILE}"
+                  # Step 2: Create backup
+                  echo "Creating backup archive..."
+                  # Production example (database dump):
+                  # mysqldump -h "${DB_HOST}" -u root -p"${DB_PASSWORD}" --all-databases \
+                  #   | gzip > "${BACKUP_FILE}"
+                  #
+                  # Production example (filesystem backup):
+                  # tar -czf "${BACKUP_FILE}" /data/
+                  #
+                  # Production example (S3 upload):
+                  # aws s3 cp "${BACKUP_FILE}" "s3://${BACKUP_BUCKET}/$(date +%Y/%m/%d)/"
+                  echo "[SIMULATED] Backup archive created at ${BACKUP_FILE}"
 
-              # Step 3: Verify backup integrity
-              echo "Verifying backup..."
-              # Production: check archive integrity and non-zero size
-              # tar -tzf "${BACKUP_FILE}" > /dev/null && echo "Archive is valid"
-              echo "[SIMULATED] Backup integrity verified."
+                  # Step 3: Verify backup integrity
+                  echo "Verifying backup..."
+                  # Production: check archive integrity and non-zero size
+                  # tar -tzf "${BACKUP_FILE}" > /dev/null && echo "Archive is valid"
+                  echo "[SIMULATED] Backup integrity verified."
 
-              # Step 4: Rotate old backups (keep last 7 days)
-              echo "Rotating old backups..."
-              # find /backup -name "data-*.tar.gz" -mtime +7 -delete
-              echo "[SIMULATED] Old backups rotated."
+                  # Step 4: Rotate old backups (keep last 7 days)
+                  echo "Rotating old backups..."
+                  # find /backup -name "data-*.tar.gz" -mtime +7 -delete
+                  echo "[SIMULATED] Old backups rotated."
 
-              echo "=== Data Backup Completed Successfully ==="
-              echo "File: ${BACKUP_FILE}"
-              echo "Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  echo "=== Data Backup Completed Successfully ==="
+                  echo "File: ${BACKUP_FILE}"
+                  echo "Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities:
-                drop: ["ALL"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
 
-            resources:
-              requests:
-                memory: "256Mi"
-                cpu: "100m"
-              limits:
-                memory: "256Mi"
-                cpu: "500m"   # Allow burst CPU for compression
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "256Mi"
+                  cpu: "500m"   # Allow burst CPU for compression
 
-            env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            # In production, add credentials from secrets:
-            # - name: DB_HOST
-            #   valueFrom:
-            #     configMapKeyRef:
-            #       name: db-config
-            #       key: host
-            # - name: DB_PASSWORD
-            #   valueFrom:
-            #     secretKeyRef:
-            #       name: db-secret
-            #       key: password
-            # - name: BACKUP_BUCKET
-            #   valueFrom:
-            #     configMapKeyRef:
-            #       name: backup-config
-            #       key: bucket_name
+              env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              # In production, add credentials from secrets:
+              # - name: DB_HOST
+              #   valueFrom:
+              #     configMapKeyRef:
+              #       name: db-config
+              #       key: host
+              # - name: DB_PASSWORD
+              #   valueFrom:
+              #     secretKeyRef:
+              #       name: db-secret
+              #       key: password
+              # - name: BACKUP_BUCKET
+              #   valueFrom:
+              #     configMapKeyRef:
+              #       name: backup-config
+              #       key: bucket_name
 
-            volumeMounts:
-            - name: backup-storage
-              mountPath: /backup   # Where backup files are written
-            - name: tmp
-              mountPath: /tmp      # Temp space for compression staging
+              volumeMounts:
+                - name: backup-storage
+                  mountPath: /backup   # Where backup files are written
+                - name: tmp
+                  mountPath: /tmp      # Temp space for compression staging
 
           volumes:
-          # hostPath backup target — simulates a NAS or local backup volume.
-          # In production, replace this with:
-          #   a) A PVC pointing to NFS or object-storage-backed storage class
-          #   b) No volume at all (upload directly to S3/GCS from the container)
-          #   c) A PVC with ReadWriteMany for shared access
-          - name: backup-storage
-            hostPath:
-              path: /var/backups/kubernetes
-              # DirectoryOrCreate: create the directory if it doesn't exist.
-              # In production with a PVC, this volume definition is replaced entirely.
-              type: DirectoryOrCreate
-          - name: tmp
-            emptyDir: {}
+            # hostPath backup target — simulates a NAS or local backup volume.
+            # In production, replace this with:
+            #   a) A PVC pointing to NFS or object-storage-backed storage class
+            #   b) No volume at all (upload directly to S3/GCS from the container)
+            #   c) A PVC with ReadWriteMany for shared access
+            - name: backup-storage
+              hostPath:
+                path: /var/backups/kubernetes
+                # DirectoryOrCreate: create the directory if it doesn't exist.
+                # In production with a PVC, this volume definition is replaced entirely.
+                type: DirectoryOrCreate
+            - name: tmp
+              emptyDir: {}

--- a/core/workloads/jobs/job.yml
+++ b/core/workloads/jobs/job.yml
@@ -93,93 +93,93 @@ spec:
       restartPolicy: Never
 
       containers:
-      - name: db-migration
-        # In production, this would be your application's migration image:
-        # e.g., myapp:v2.3.1 with 'migrate' as the command, or
-        # ghcr.io/golang-migrate/migrate for Go projects,
-        # or your own image containing Flyway/Liquibase.
-        # busybox is used here to simulate the pattern.
-        image: busybox:1.36
-        imagePullPolicy: IfNotPresent
+        - name: db-migration
+          # In production, this would be your application's migration image:
+          # e.g., myapp:v2.3.1 with 'migrate' as the command, or
+          # ghcr.io/golang-migrate/migrate for Go projects,
+          # or your own image containing Flyway/Liquibase.
+          # busybox is used here to simulate the pattern.
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
 
-        command:
-        - /bin/sh
-        - -c
-        - |
-          set -e  # Exit immediately on any error (critical for migrations!)
-          set -u  # Treat unset variables as errors
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e  # Exit immediately on any error (critical for migrations!)
+              set -u  # Treat unset variables as errors
 
-          echo "=== Database Migration Started ==="
-          echo "Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          echo "Pod: ${POD_NAME}"
-          echo "Namespace: ${POD_NAMESPACE}"
+              echo "=== Database Migration Started ==="
+              echo "Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              echo "Pod: ${POD_NAME}"
+              echo "Namespace: ${POD_NAMESPACE}"
 
-          # Step 1: Wait for the database to be reachable.
-          # In production, replace this with an actual connectivity check:
-          # until mysql -h "${DB_HOST}" -u root -p"${DB_PASSWORD}" -e "SELECT 1" 2>/dev/null; do
-          echo "Checking database connectivity..."
-          echo "[SIMULATED] Database is reachable."
+              # Step 1: Wait for the database to be reachable.
+              # In production, replace this with an actual connectivity check:
+              # until mysql -h "${DB_HOST}" -u root -p"${DB_PASSWORD}" -e "SELECT 1" 2>/dev/null; do
+              echo "Checking database connectivity..."
+              echo "[SIMULATED] Database is reachable."
 
-          # Step 2: Run migrations in order.
-          # Production pattern using a migration tool:
-          # migrate -path /app/migrations -database "${DATABASE_URL}" up
-          echo "Running migration 001_create_users_table.sql..."
-          echo "[SIMULATED] CREATE TABLE IF NOT EXISTS users (id INT PRIMARY KEY, ...);"
+              # Step 2: Run migrations in order.
+              # Production pattern using a migration tool:
+              # migrate -path /app/migrations -database "${DATABASE_URL}" up
+              echo "Running migration 001_create_users_table.sql..."
+              echo "[SIMULATED] CREATE TABLE IF NOT EXISTS users (id INT PRIMARY KEY, ...);"
 
-          echo "Running migration 002_add_email_index.sql..."
-          echo "[SIMULATED] CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);"
+              echo "Running migration 002_add_email_index.sql..."
+              echo "[SIMULATED] CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);"
 
-          echo "Running migration 003_add_created_at.sql..."
-          echo "[SIMULATED] ALTER TABLE users ADD COLUMN IF NOT EXISTS created_at TIMESTAMP;"
+              echo "Running migration 003_add_created_at.sql..."
+              echo "[SIMULATED] ALTER TABLE users ADD COLUMN IF NOT EXISTS created_at TIMESTAMP;"
 
-          # Step 3: Verify the migration completed successfully.
-          echo "Verifying schema version..."
-          echo "[SIMULATED] Schema is at version 003 — migration complete."
+              # Step 3: Verify the migration completed successfully.
+              echo "Verifying schema version..."
+              echo "[SIMULATED] Schema is at version 003 — migration complete."
 
-          echo "=== Database Migration Completed Successfully ==="
-          echo "Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              echo "=== Database Migration Completed Successfully ==="
+              echo "Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
 
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "100m"
-          limits:
-            memory: "256Mi"
-            # CPU limit is acceptable for batch Jobs — throttling a migration is
-            # less harmful than throttling a live serving workload.
-            cpu: "200m"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              # CPU limit is acceptable for batch Jobs — throttling a migration is
+              # less harmful than throttling a live serving workload.
+              cpu: "200m"
 
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        # In production, database credentials would come from a Secret:
-        # - name: DB_HOST
-        #   valueFrom:
-        #     configMapKeyRef:
-        #       name: db-config
-        #       key: DB_HOST
-        # - name: DB_PASSWORD
-        #   valueFrom:
-        #     secretKeyRef:
-        #       name: db-secret
-        #       key: DB_PASSWORD
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          # In production, database credentials would come from a Secret:
+          # - name: DB_HOST
+          #   valueFrom:
+          #     configMapKeyRef:
+          #       name: db-config
+          #       key: DB_HOST
+          # - name: DB_PASSWORD
+          #   valueFrom:
+          #     secretKeyRef:
+          #       name: db-secret
+          #       key: DB_PASSWORD
 
-        volumeMounts:
-        - name: tmp
-          mountPath: /tmp   # Migration tools often need to write temp files
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp   # Migration tools often need to write temp files
 
       volumes:
-      - name: tmp
-        emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/core/workloads/statefulset/mysql-service-clusterip.yml
+++ b/core/workloads/statefulset/mysql-service-clusterip.yml
@@ -39,10 +39,10 @@ spec:
     app.kubernetes.io/instance: mysql
 
   ports:
-  - name: mysql
-    port: 3306
-    targetPort: 3306
-    protocol: TCP
+    - name: mysql
+      port: 3306
+      targetPort: 3306
+      protocol: TCP
 
   # sessionAffinity: ClientIP makes kube-proxy route all requests from the same client IP
   # to the same backend pod. Useful for connection pooling — ensures a client's persistent

--- a/core/workloads/statefulset/mysql-service-headless.yml
+++ b/core/workloads/statefulset/mysql-service-headless.yml
@@ -43,10 +43,10 @@ spec:
     app.kubernetes.io/instance: mysql
 
   ports:
-  - name: mysql
-    port: 3306
-    targetPort: 3306
-    protocol: TCP
+    - name: mysql
+      port: 3306
+      targetPort: 3306
+      protocol: TCP
 
   # publishNotReadyAddresses: false (default) means DNS entries are only created
   # for pods that have passed their readiness probe. This prevents replication traffic

--- a/core/workloads/statefulset/mysql-statefulset.yml
+++ b/core/workloads/statefulset/mysql-statefulset.yml
@@ -36,8 +36,7 @@ spec:
   # 'Delete' would destroy your data when the StatefulSet is deleted or scaled down —
   # a catastrophic and irreversible operation.
   persistentVolumeClaimRetentionPolicy:
-    whenDeleted: Retain     # PVCs survive StatefulSet deletion
-    whenScaledDown: Retain  # PVCs survive scale-down (so scaling back up reattaches the same data)
+    whenDeleted: Retain     # PVCs survive StatefulSet deletion (scaling back up reattaches same data)
 
   updateStrategy:
     type: RollingUpdate
@@ -99,214 +98,214 @@ spec:
       # They are ideal for setup tasks: copying config, running migrations, waiting for
       # dependencies. They share the same volumes as the main container.
       initContainers:
-      - name: mysql-init-config
-        # Use the same image as the main container for consistency — avoids tool version mismatches.
-        image: mysql:8.0
-        imagePullPolicy: IfNotPresent
-        command:
-        - /bin/sh
-        - -c
-        - |
-          set -e
-          echo "[mysqld]" > /mnt/mysql-config/my.cnf
-          echo "character-set-server=utf8mb4" >> /mnt/mysql-config/my.cnf
-          echo "collation-server=utf8mb4_unicode_ci" >> /mnt/mysql-config/my.cnf
-          echo "bind-address=0.0.0.0" >> /mnt/mysql-config/my.cnf
-          echo "innodb_buffer_pool_size=314572800" >> /mnt/mysql-config/my.cnf
-          echo "max_connections=100" >> /mnt/mysql-config/my.cnf
-          # Determine this pod's ordinal from its hostname.
-          # The hostname for mysql-1 is 'mysql-1'; the ordinal is the number after the last dash.
-          ORDINAL=$(hostname | awk -F- '{print $NF}')
-          # server-id must be unique per MySQL instance for binary log replication to work.
-          # Using ordinal+1 ensures: mysql-0=1, mysql-1=2, mysql-2=3.
-          # server-id=0 is reserved and disables replication.
-          echo "server-id=$((ORDINAL + 1))" >> /mnt/mysql-config/my.cnf
-          echo "Config written for server-id=$((ORDINAL + 1))"
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          runAsNonRoot: true
-          runAsUser: 999
-        resources:
-          requests:
-            memory: "64Mi"
-            cpu: "50m"
-          limits:
-            memory: "64Mi"
-        volumeMounts:
-        - name: mysql-config-volume
-          mountPath: /mnt/mysql-config
-
-      containers:
-      - name: mysql
-        image: mysql:8.0
-        imagePullPolicy: IfNotPresent
-
-        securityContext:
-          allowPrivilegeEscalation: false
-          # NOTE: readOnlyRootFilesystem is intentionally FALSE for MySQL.
-          # MySQL writes to many paths at runtime that cannot be volume-mounted:
-          #   /var/run/mysqld/  — unix socket and PID file
-          #   /tmp/             — sort and temp files (we mount this as emptyDir)
-          #   /etc/             — some configs are written at startup
-          # Setting this to true causes MySQL to fail immediately at startup.
-          # This is a documented exception to the production security standard.
-          # Mitigation: runAsNonRoot + dropped capabilities + seccomp still provide
-          # strong isolation even without a read-only filesystem.
-          readOnlyRootFilesystem: false
-          capabilities:
-            drop: ["ALL"]   # Drop ALL Linux capabilities — MySQL requires none of them
-
-        resources:
-          requests:
-            memory: "512Mi"
-            cpu: "200m"
-          limits:
-            memory: "512Mi"
-            # No CPU limit intentionally — CPU limits cause throttling via CFS quota,
-            # which can cause latency spikes in database workloads even when nodes have
-            # spare capacity. CPU requests provide scheduling guarantees without throttling.
-            # See: https://www.robustperception.io/cpu-throttling-and-kubernetes
-
-        env:
-        # Load non-sensitive config from ConfigMap
-        - name: MYSQL_DATABASE
-          valueFrom:
-            configMapKeyRef:
-              name: mysql-config
-              key: MYSQL_DATABASE
-        - name: MYSQL_CHARACTER_SET_SERVER
-          valueFrom:
-            configMapKeyRef:
-              name: mysql-config
-              key: MYSQL_CHARACTER_SET_SERVER
-        - name: MYSQL_COLLATION_SERVER
-          valueFrom:
-            configMapKeyRef:
-              name: mysql-config
-              key: MYSQL_COLLATION_SERVER
-
-        # Load sensitive credentials from Secret
-        - name: MYSQL_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: mysql-secret
-              key: MYSQL_ROOT_PASSWORD
-        - name: MYSQL_USER
-          valueFrom:
-            secretKeyRef:
-              name: mysql-secret
-              key: MYSQL_USER
-        - name: MYSQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: mysql-secret
-              key: MYSQL_PASSWORD
-
-        # Point MySQL to use the tmpfs-backed emptyDir for temp files.
-        # This is required because readOnlyRootFilesystem is false but /tmp on the
-        # container's writable layer is not ideal for performance — emptyDir is backed
-        # by the node's disk or memory and is cleaned up when the pod terminates.
-        - name: TMPDIR
-          value: /tmp
-
-        ports:
-        - name: mysql
-          containerPort: 3306
-          protocol: TCP
-
-        volumeMounts:
-        - name: mysql-data
-          mountPath: /var/lib/mysql   # MySQL data directory — backed by PVC
-        - name: mysql-config-volume
-          mountPath: /etc/mysql/conf.d   # Custom config written by init container
-          readOnly: true
-        - name: tmpdir
-          mountPath: /tmp              # tmpfs emptyDir for sort/temp files
-
-        # startupProbe runs FIRST, before liveness and readiness probes.
-        # It gives the container time to initialize before the kubelet starts
-        # checking liveness. MySQL can take several minutes to initialize a fresh
-        # data directory (running mysql_install_db, InnoDB log creation, etc.).
-        # failureThreshold * periodSeconds = 30 * 10 = 300 seconds (5 minutes) max startup time.
-        # Once the startupProbe succeeds, it stops running and liveness takes over.
-        startupProbe:
-          exec:
-            command:
-            - mysqladmin
-            - ping
-            - -h
-            - localhost
-          failureThreshold: 30   # Allow up to 5 minutes for startup
-          periodSeconds: 10
-          timeoutSeconds: 5
-
-        # livenessProbe: if this fails, the kubelet RESTARTS the container.
-        # Use a lightweight check — mysqladmin ping sends a COM_PING packet and
-        # returns immediately. It does NOT run a query, so it works even if the
-        # query engine is overloaded but the server is still running.
-        # Do NOT use a query-based liveness probe — a slow query can cause false
-        # positives and restart cascades under load.
-        livenessProbe:
-          exec:
-            command:
-            - mysqladmin
-            - ping
-            - -h
-            - localhost
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 3       # 3 consecutive failures = restart
-          successThreshold: 1
-
-        # readinessProbe: if this fails, the pod is removed from Service endpoints.
-        # Traffic stops being sent to this pod but it is NOT restarted.
-        # This probe verifies the MySQL server can actually execute queries,
-        # not just respond to ping. This prevents routing traffic to a pod that
-        # is starting up (InnoDB recovery) or temporarily overloaded.
-        readinessProbe:
-          exec:
-            command:
+        - name: mysql-init-config
+          # Use the same image as the main container for consistency — avoids tool version mismatches.
+          image: mysql:8.0
+          imagePullPolicy: IfNotPresent
+          command:
             - /bin/sh
             - -c
-            # Use -u root with password from env var. The -e flag executes a query.
-            # SELECT 1 is the canonical "database is alive and responsive" health check.
-            # Note: -p with no space before the password is the correct syntax to avoid
-            # a "Using a password on the command line interface can be insecure" warning
-            # being interpreted as a failure.
-            - "mysql -u root -p\"${MYSQL_ROOT_PASSWORD}\" -e 'SELECT 1' 2>/dev/null"
-          periodSeconds: 5
-          timeoutSeconds: 3
-          failureThreshold: 3
-          successThreshold: 1
+            - |
+              set -e
+              echo "[mysqld]" > /mnt/mysql-config/my.cnf
+              echo "character-set-server=utf8mb4" >> /mnt/mysql-config/my.cnf
+              echo "collation-server=utf8mb4_unicode_ci" >> /mnt/mysql-config/my.cnf
+              echo "bind-address=0.0.0.0" >> /mnt/mysql-config/my.cnf
+              echo "innodb_buffer_pool_size=314572800" >> /mnt/mysql-config/my.cnf
+              echo "max_connections=100" >> /mnt/mysql-config/my.cnf
+              # Determine this pod's ordinal from its hostname.
+              # The hostname for mysql-1 is 'mysql-1'; the ordinal is the number after the last dash.
+              ORDINAL=$(hostname | awk -F- '{print $NF}')
+              # server-id must be unique per MySQL instance for binary log replication to work.
+              # Using ordinal+1 ensures: mysql-0=1, mysql-1=2, mysql-2=3.
+              # server-id=0 is reserved and disables replication.
+              echo "server-id=$((ORDINAL + 1))" >> /mnt/mysql-config/my.cnf
+              echo "Config written for server-id=$((ORDINAL + 1))"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 999
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "64Mi"
+          volumeMounts:
+            - name: mysql-config-volume
+              mountPath: /mnt/mysql-config
 
-        lifecycle:
-          preStop:
+      containers:
+        - name: mysql
+          image: mysql:8.0
+          imagePullPolicy: IfNotPresent
+
+          securityContext:
+            allowPrivilegeEscalation: false
+            # NOTE: readOnlyRootFilesystem is intentionally FALSE for MySQL.
+            # MySQL writes to many paths at runtime that cannot be volume-mounted:
+            #   /var/run/mysqld/  — unix socket and PID file
+            #   /tmp/             — sort and temp files (we mount this as emptyDir)
+            #   /etc/             — some configs are written at startup
+            # Setting this to true causes MySQL to fail immediately at startup.
+            # This is a documented exception to the production security standard.
+            # Mitigation: runAsNonRoot + dropped capabilities + seccomp still provide
+            # strong isolation even without a read-only filesystem.
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: ["ALL"]   # Drop ALL Linux capabilities — MySQL requires none of them
+
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "200m"
+            limits:
+              memory: "512Mi"
+              # No CPU limit intentionally — CPU limits cause throttling via CFS quota,
+              # which can cause latency spikes in database workloads even when nodes have
+              # spare capacity. CPU requests provide scheduling guarantees without throttling.
+              # See: https://www.robustperception.io/cpu-throttling-and-kubernetes
+
+          env:
+            # Load non-sensitive config from ConfigMap
+            - name: MYSQL_DATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: mysql-config
+                  key: MYSQL_DATABASE
+            - name: MYSQL_CHARACTER_SET_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: mysql-config
+                  key: MYSQL_CHARACTER_SET_SERVER
+            - name: MYSQL_COLLATION_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: mysql-config
+                  key: MYSQL_COLLATION_SERVER
+
+            # Load sensitive credentials from Secret
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-secret
+                  key: MYSQL_ROOT_PASSWORD
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-secret
+                  key: MYSQL_USER
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-secret
+                  key: MYSQL_PASSWORD
+
+            # Point MySQL to use the tmpfs-backed emptyDir for temp files.
+            # This is required because readOnlyRootFilesystem is false but /tmp on the
+            # container's writable layer is not ideal for performance — emptyDir is backed
+            # by the node's disk or memory and is cleaned up when the pod terminates.
+            - name: TMPDIR
+              value: /tmp
+
+          ports:
+            - name: mysql
+              containerPort: 3306
+              protocol: TCP
+
+          volumeMounts:
+            - name: mysql-data
+              mountPath: /var/lib/mysql   # MySQL data directory — backed by PVC
+            - name: mysql-config-volume
+              mountPath: /etc/mysql/conf.d   # Custom config written by init container
+              readOnly: true
+            - name: tmpdir
+              mountPath: /tmp              # tmpfs emptyDir for sort/temp files
+
+          # startupProbe runs FIRST, before liveness and readiness probes.
+          # It gives the container time to initialize before the kubelet starts
+          # checking liveness. MySQL can take several minutes to initialize a fresh
+          # data directory (running mysql_install_db, InnoDB log creation, etc.).
+          # failureThreshold * periodSeconds = 30 * 10 = 300 seconds (5 minutes) max startup time.
+          # Once the startupProbe succeeds, it stops running and liveness takes over.
+          startupProbe:
             exec:
-              # On SIGTERM, tell MySQL to shut down cleanly before the kubelet sends SIGKILL.
-              # 'mysqladmin shutdown' flushes the InnoDB buffer pool, closes all connections,
-              # and writes the final binary log events. This is far safer than relying on
-              # MySQL's SIGTERM handler alone. The terminationGracePeriodSeconds: 120 gives
-              # this command up to 115 seconds to complete (5 seconds are consumed before
-              # SIGTERM is sent to the process).
               command:
-              - /bin/sh
-              - -c
-              - "mysqladmin -u root -p\"${MYSQL_ROOT_PASSWORD}\" shutdown 2>/dev/null || true"
+                - mysqladmin
+                - ping
+                - -h
+                - localhost
+            failureThreshold: 30   # Allow up to 5 minutes for startup
+            periodSeconds: 10
+            timeoutSeconds: 5
+
+          # livenessProbe: if this fails, the kubelet RESTARTS the container.
+          # Use a lightweight check — mysqladmin ping sends a COM_PING packet and
+          # returns immediately. It does NOT run a query, so it works even if the
+          # query engine is overloaded but the server is still running.
+          # Do NOT use a query-based liveness probe — a slow query can cause false
+          # positives and restart cascades under load.
+          livenessProbe:
+            exec:
+              command:
+                - mysqladmin
+                - ping
+                - -h
+                - localhost
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3       # 3 consecutive failures = restart
+            successThreshold: 1
+
+          # readinessProbe: if this fails, the pod is removed from Service endpoints.
+          # Traffic stops being sent to this pod but it is NOT restarted.
+          # This probe verifies the MySQL server can actually execute queries,
+          # not just respond to ping. This prevents routing traffic to a pod that
+          # is starting up (InnoDB recovery) or temporarily overloaded.
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                # Use -u root with password from env var. The -e flag executes a query.
+                # SELECT 1 is the canonical "database is alive and responsive" health check.
+                # Note: -p with no space before the password is the correct syntax to avoid
+                # a "Using a password on the command line interface can be insecure" warning
+                # being interpreted as a failure.
+                - "mysql -u root -p\"${MYSQL_ROOT_PASSWORD}\" -e 'SELECT 1' 2>/dev/null"
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+            successThreshold: 1
+
+          lifecycle:
+            preStop:
+              exec:
+                # On SIGTERM, tell MySQL to shut down cleanly before the kubelet sends SIGKILL.
+                # 'mysqladmin shutdown' flushes the InnoDB buffer pool, closes all connections,
+                # and writes the final binary log events. This is far safer than relying on
+                # MySQL's SIGTERM handler alone. The terminationGracePeriodSeconds: 120 gives
+                # this command up to 115 seconds to complete (5 seconds are consumed before
+                # SIGTERM is sent to the process).
+                command:
+                  - /bin/sh
+                  - -c
+                  - "mysqladmin -u root -p\"${MYSQL_ROOT_PASSWORD}\" shutdown 2>/dev/null || true"
 
       volumes:
-      # emptyDir is created fresh for each pod and deleted when the pod terminates.
-      # It lives on the node's disk (or in memory if medium: Memory is set).
-      # Used here for /tmp to give MySQL a writable temp directory without needing
-      # to relax the readOnlyRootFilesystem constraint on /tmp in the container layer.
-      - name: tmpdir
-        emptyDir: {}
-      # Config volume written by init container, read by main container
-      - name: mysql-config-volume
-        emptyDir: {}
+        # emptyDir is created fresh for each pod and deleted when the pod terminates.
+        # It lives on the node's disk (or in memory if medium: Memory is set).
+        # Used here for /tmp to give MySQL a writable temp directory without needing
+        # to relax the readOnlyRootFilesystem constraint on /tmp in the container layer.
+        - name: tmpdir
+          emptyDir: {}
+        # Config volume written by init container, read by main container
+        - name: mysql-config-volume
+          emptyDir: {}
 
   # volumeClaimTemplates act as a PVC factory.
   # For each pod, Kubernetes creates a PVC named: mysql-data-mysql-<ordinal>
@@ -316,20 +315,20 @@ spec:
   # Each pod gets its own isolated storage. This PVC persists across pod restarts
   # and (with Retain policy) across StatefulSet deletion.
   volumeClaimTemplates:
-  - metadata:
-      name: mysql-data
-      labels:
-        app.kubernetes.io/name: mysql
-        app.kubernetes.io/component: database
-        app.kubernetes.io/part-of: kube-platform
-    spec:
-      # ReadWriteOncePod (introduced in Kubernetes 1.22, stable in 1.29) is stricter
-      # than ReadWriteOnce. ReadWriteOnce allows multiple pods on the SAME NODE to mount
-      # the volume — this can cause data corruption if two mysql pods land on the same node.
-      # ReadWriteOncePod guarantees only ONE pod cluster-wide can mount the volume at a time,
-      # regardless of which node it's on.
-      accessModes: ["ReadWriteOncePod"]
-      storageClassName: standard   # Replace with your cluster's storage class (gp3, premium-ssd, etc.)
-      resources:
-        requests:
-          storage: 10Gi
+    - metadata:
+        name: mysql-data
+        labels:
+          app.kubernetes.io/name: mysql
+          app.kubernetes.io/component: database
+          app.kubernetes.io/part-of: kube-platform
+      spec:
+        # ReadWriteOncePod (introduced in Kubernetes 1.22, stable in 1.29) is stricter
+        # than ReadWriteOnce. ReadWriteOnce allows multiple pods on the SAME NODE to mount
+        # the volume — this can cause data corruption if two mysql pods land on the same node.
+        # ReadWriteOncePod guarantees only ONE pod cluster-wide can mount the volume at a time,
+        # regardless of which node it's on.
+        accessModes: ["ReadWriteOncePod"]
+        storageClassName: standard   # Replace with your cluster's storage class (gp3, premium-ssd, etc.)
+        resources:
+          requests:
+            storage: 10Gi

--- a/helm/apache/templates/deployment.yaml
+++ b/helm/apache/templates/deployment.yaml
@@ -42,9 +42,7 @@ spec:
   template:
     metadata:
       labels:
-        # Selector labels must be present on the pod template.
-        {{- include "apache.selectorLabels" . | nindent 8 }}
-        # Full label set (includes version, component, etc.) for observability.
+        # Full label set — superset of selectorLabels, so selector is satisfied.
         {{- include "apache.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/helm/apache/templates/deployment.yaml
+++ b/helm/apache/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         # Trigger a rolling restart when the ConfigMap or Secret changes by
         # embedding a checksum annotation. Without this, pods may run stale config.
         # Example (add in a real chart with configmap):
-        # checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        # checksum/config: <sha256sum of configmap.yaml — add when a ConfigMap exists in the chart>
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/apache/templates/tests/test-connection.yaml
+++ b/helm/apache/templates/tests/test-connection.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "apache.fullname" . }}-test-connection
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "apache.labels" . | nindent 4 }}
+    {{- include "apache.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: test
   annotations:
     kubernetes.io/description: "Helm test pod — verifies HTTP connectivity to the Apache service."

--- a/helm/node-app/templates/deployment.yaml
+++ b/helm/node-app/templates/deployment.yaml
@@ -31,7 +31,6 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "node-app.selectorLabels" . | nindent 8 }}
         {{- include "node-app.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/helm/node-app/templates/tests/test-connection.yaml
+++ b/helm/node-app/templates/tests/test-connection.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "node-app.fullname" . }}-test-connection
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "node-app.labels" . | nindent 4 }}
+    {{- include "node-app.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: test
   annotations:
     kubernetes.io/description: "Helm test pod — verifies HTTP connectivity to the Node.js service."


### PR DESCRIPTION
## Summary

- **yamllint**: add `comments-indentation: disable` to suppress cosmetic alignment warnings across educational files; fix indentation in daemonset, jobs, and StatefulSet service files
- **kubeconform**: remove `whenScaledDown` from StatefulSet (not in 1.32.0 strict schema); exclude prometheus-grafana values files (Helm values are not K8s manifests); fix StorageClass structure (`provisioner` and `volumeBindingMode` are top-level fields, not under `spec`)
- **helm lint**: remove Helm template directive from YAML comment in `helm/apache/templates/deployment.yaml` — Helm processes `{{ }}` inside YAML comments even when commented out with `#`

## Test plan
- [ ] yamllint passes on all YAML files
- [ ] kubeconform validates all Kubernetes manifests
- [ ] helm lint passes for apache and node-app charts
- [ ] CI Success gate passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed YAML indentation and nesting issues in Kubernetes manifests (DaemonSets, Jobs, CronJobs, StatefulSets, and Services) to ensure proper configuration validation and interpretation.
  * Corrected container and volume specification structures across multiple workload types.

* **Chores**
  * Updated validation configuration for improved manifest accuracy.
  * Enhanced deployment documentation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->