### PR TITLE
feat: MySQL Helm chart, helmfile, setup scripts, and multi-tier/cert-manager examples

### DIFF
--- a/examples/cert-manager/README.md
+++ b/examples/cert-manager/README.md
@@ -1,0 +1,152 @@
+# cert-manager Example
+
+This example demonstrates how to use [cert-manager](https://cert-manager.io/) to automatically provision and renew TLS certificates from Let's Encrypt.
+
+---
+
+## Architecture
+
+```
+Browser
+  |  (HTTPS)
+  v
+[ Ingress (nginx) ] ← TLS termination with cert-manager cert
+  |
+  v
+[ Your App Service ]
+```
+
+cert-manager watches Ingress resources annotated with `cert-manager.io/cluster-issuer`. When it finds one, it:
+1. Creates an ACME challenge (HTTP-01) to prove domain ownership.
+2. Requests a certificate from Let's Encrypt.
+3. Stores the certificate in a Kubernetes Secret (TLS type).
+4. Automatically renews the certificate ~30 days before expiry.
+
+---
+
+## Prerequisites
+
+- Kubernetes >= 1.25
+- Helm >= 3.14
+- ingress-nginx installed and accessible from the internet
+- A domain name with DNS pointing to your cluster's ingress IP
+
+---
+
+## Installation
+
+### 1. Install cert-manager with Helm
+
+```bash
+# Add the jetstack Helm repository
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+
+# Install cert-manager with CRDs
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --version v1.16.2 \
+  --set crds.enabled=true
+
+# Verify installation
+kubectl get pods -n cert-manager
+```
+
+### 2. Create the ClusterIssuers
+
+```bash
+# Edit cluster-issuer.yml to replace admin@example.com with your email address
+kubectl apply -f examples/cert-manager/cluster-issuer.yml
+
+# Verify the issuers are ready
+kubectl get clusterissuer
+```
+
+Expected output:
+```
+NAME                   READY   AGE
+letsencrypt-prod       True    30s
+letsencrypt-staging    True    30s
+```
+
+### 3. Apply the Ingress with TLS
+
+```bash
+# Edit ingress-with-cert.yml to set your actual hostname and service name
+kubectl apply -f examples/cert-manager/ingress-with-cert.yml
+```
+
+### 4. Verify certificate issuance
+
+```bash
+# Watch the Certificate resource (created automatically by cert-manager)
+kubectl get certificate -n web --watch
+
+# Check the Certificate details
+kubectl describe certificate app-example-com-tls -n web
+
+# Check the CertificateRequest
+kubectl get certificaterequest -n web
+
+# Check the ACME Order and Challenge
+kubectl get order -n web
+kubectl get challenge -n web
+```
+
+---
+
+## Troubleshooting
+
+### Certificate stuck in "False/Pending"
+
+```bash
+# Check the certificate status
+kubectl describe certificate <cert-name> -n <namespace>
+
+# Check the ClusterIssuer status
+kubectl describe clusterissuer letsencrypt-prod
+
+# Check cert-manager logs
+kubectl logs -n cert-manager deploy/cert-manager --tail=100
+```
+
+Common causes:
+- DNS not resolving to the ingress IP
+- Ingress controller not reachable from the internet (port 80 must be open for HTTP-01)
+- Rate limit hit (use staging issuer first)
+
+### Test with staging issuer first
+
+Always test with `letsencrypt-staging` before switching to `letsencrypt-prod`. The staging issuer has much more permissive rate limits but issues untrusted certificates (browsers will show a warning, which is fine for testing).
+
+```bash
+# Switch the annotation to staging:
+# cert-manager.io/cluster-issuer: letsencrypt-staging
+
+# After verifying, delete the staging cert and switch to prod:
+kubectl delete certificate app-example-com-tls -n web
+# Update the annotation to: cert-manager.io/cluster-issuer: letsencrypt-prod
+kubectl apply -f examples/cert-manager/ingress-with-cert.yml
+```
+
+---
+
+## Useful Commands
+
+```bash
+# List all managed certificates cluster-wide
+kubectl get certificate --all-namespaces
+
+# Check certificate expiry
+kubectl get certificate -n web -o jsonpath='{.items[*].status.notAfter}'
+
+# Manually trigger certificate renewal (usually not needed — cert-manager auto-renews)
+kubectl annotate certificate app-example-com-tls \
+  cert-manager.io/issuer-name=letsencrypt-prod \
+  --overwrite -n web
+
+# Uninstall cert-manager
+helm uninstall cert-manager -n cert-manager
+kubectl delete namespace cert-manager
+```

--- a/examples/cert-manager/cluster-issuer.yml
+++ b/examples/cert-manager/cluster-issuer.yml
@@ -1,0 +1,71 @@
+# =============================================================================
+# cert-manager ClusterIssuers — Let's Encrypt ACME
+# =============================================================================
+# Two issuers are defined:
+#   1. letsencrypt-staging  — For testing. Issues untrusted certificates.
+#                             Use this first to verify your setup before
+#                             switching to production (avoids rate limit hits).
+#   2. letsencrypt-prod     — For production. Issues trusted certificates.
+#                             Strict rate limits (50 certs/domain/week).
+#
+# Prerequisites:
+#   cert-manager must be installed. See README.md.
+# =============================================================================
+
+---
+# Staging issuer — use for initial testing.
+# Certificates are issued by: "Fake LE Intermediate X1" (not browser-trusted)
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+  labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: cluster-issuer
+spec:
+  acme:
+    # Let's Encrypt staging ACME server.
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+
+    # Email address used for expiry notifications. Replace with your address.
+    email: admin@example.com
+
+    # Secret where the ACME account private key is stored.
+    privateKeySecretRef:
+      name: letsencrypt-staging-account-key
+
+    # HTTP-01 challenge solver — cert-manager creates a temporary Ingress
+    # that Let's Encrypt uses to verify domain ownership.
+    # Requires an Ingress controller (e.g., ingress-nginx) to be installed.
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx
+
+---
+# Production issuer — use after verifying with staging.
+# Certificates are issued by: "R10" / "R11" (browser-trusted, 90-day validity)
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+  labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: cluster-issuer
+spec:
+  acme:
+    # Let's Encrypt production ACME server.
+    server: https://acme-v02.api.letsencrypt.org/directory
+
+    # Email address used for expiry notifications and account recovery.
+    # IMPORTANT: Replace with a real, monitored email address.
+    email: admin@example.com
+
+    # Secret where the ACME account private key is stored.
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx

--- a/examples/cert-manager/ingress-with-cert.yml
+++ b/examples/cert-manager/ingress-with-cert.yml
@@ -1,0 +1,41 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-app
+  namespace: web
+  labels:
+    app.kubernetes.io/name: example-app
+    app.kubernetes.io/component: ingress
+  annotations:
+    # Tell cert-manager which ClusterIssuer to use for this Ingress.
+    # Start with letsencrypt-staging to verify setup, then switch to letsencrypt-prod.
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+
+    # Optional: configure nginx-specific settings.
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+
+    # Optional: force HTTPS redirect for all HTTP traffic.
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: app.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: example-app
+                port:
+                  number: 80
+  # TLS section — cert-manager will automatically provision the certificate
+  # and store it in the secret named below.
+  # The certificate is renewed automatically ~30 days before expiry.
+  tls:
+    - hosts:
+        - app.example.com
+      # cert-manager creates and manages this Secret automatically.
+      # Do not create this Secret manually — cert-manager owns it.
+      secretName: app-example-com-tls

--- a/examples/easyshop-kind/redis-configmap.yml
+++ b/examples/easyshop-kind/redis-configmap.yml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+  namespace: easyshop
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: cache
+    app.kubernetes.io/part-of: easyshop
+data:
+  redis.conf: |
+    # Memory management
+    maxmemory 128mb
+    maxmemory-policy allkeys-lru
+
+    # Persistence (disabled for cache use-case)
+    save ""
+    appendonly no
+
+    # Connection settings
+    timeout 300
+    tcp-keepalive 60
+
+    # Disable dangerous commands in production
+    rename-command FLUSHALL ""
+    rename-command FLUSHDB  ""
+    rename-command DEBUG    ""
+    rename-command CONFIG   ""

--- a/examples/easyshop-kind/redis-deployment.yml
+++ b/examples/easyshop-kind/redis-deployment.yml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: easyshop
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: cache
+    app.kubernetes.io/part-of: easyshop
+    app.kubernetes.io/version: "7.2"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+      app.kubernetes.io/part-of: easyshop
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/component: cache
+        app.kubernetes.io/part-of: easyshop
+        app.kubernetes.io/version: "7.2"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+
+      containers:
+        - name: redis
+          image: redis:7.2-alpine
+          imagePullPolicy: IfNotPresent
+          command:
+            - redis-server
+            - /etc/redis/redis.conf
+
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+
+          volumeMounts:
+            - name: config
+              mountPath: /etc/redis
+            - name: data
+              mountPath: /data
+
+      volumes:
+        - name: config
+          configMap:
+            name: redis-config
+        - name: data
+          emptyDir: {}

--- a/examples/easyshop-kind/redis-service.yml
+++ b/examples/easyshop-kind/redis-service.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: easyshop
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: cache
+    app.kubernetes.io/part-of: easyshop
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: redis
+      protocol: TCP
+      name: redis
+  selector:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: easyshop

--- a/examples/multi-tier/README.md
+++ b/examples/multi-tier/README.md
@@ -1,0 +1,127 @@
+# Multi-Tier Application Example
+
+A complete, namespace-scoped, production-ready multi-tier Kubernetes example.
+
+## Architecture
+
+```
+Internet
+    |
+    v
+[ Ingress (nginx) ]
+    |           |
+    v           v
+[Frontend]   [Frontend]   (nginx:1.25-alpine, 2 replicas, HPA 2-10)
+    |
+    v
+[Backend]    [Backend]    (node:18-alpine API, 2 replicas, HPA 2-10)
+    |              |
+    v              v
+[PostgreSQL]   [Redis]    (postgres:16-alpine StatefulSet, redis:7.2-alpine)
+```
+
+### Tiers
+
+| Tier | Component | Image | Port | Notes |
+|------|-----------|-------|------|-------|
+| Frontend | nginx | `nginx:1.25-alpine` | 8080 | Serves static files, proxies /api to backend |
+| Backend | Node.js API | `node:18-alpine` | 3000 | REST API |
+| Database | PostgreSQL | `postgres:16-alpine` | 5432 | StatefulSet with PVC |
+| Cache | Redis | `redis:7.2-alpine` | 6379 | In-memory cache |
+
+### Security
+
+- **Pod Security Admission**: `restricted` enforced on the namespace
+- **Network Policies**: default deny-all, explicit allow rules per tier
+- **Security Context**: `runAsNonRoot`, `readOnlyRootFilesystem`, `drop ALL capabilities`
+- **No service account token auto-mount**
+
+---
+
+## Prerequisites
+
+- Kubernetes >= 1.25 (for Pod Security Admission)
+- [ingress-nginx](https://kubernetes.github.io/ingress-nginx/deploy/) installed
+- A default StorageClass for PostgreSQL PVC
+
+---
+
+## Deployment Steps
+
+### 1. Apply all manifests
+
+```bash
+# From the repo root:
+kubectl apply -f examples/multi-tier/namespace.yml
+
+kubectl apply -f examples/multi-tier/frontend/
+kubectl apply -f examples/multi-tier/backend/
+kubectl apply -f examples/multi-tier/database/
+kubectl apply -f examples/multi-tier/cache/
+
+kubectl apply -f examples/multi-tier/network-policy.yml
+kubectl apply -f examples/multi-tier/ingress.yml
+kubectl apply -f examples/multi-tier/hpa.yml
+kubectl apply -f examples/multi-tier/pdb.yml
+```
+
+### 2. Create the database secret
+
+```bash
+kubectl create secret generic database-secret \
+  --namespace=multi-tier \
+  --from-literal=postgres-password="$(openssl rand -base64 16)"
+```
+
+### 3. Verify everything is running
+
+```bash
+kubectl get all -n multi-tier
+kubectl get ingress -n multi-tier
+kubectl get networkpolicies -n multi-tier
+kubectl get pdb -n multi-tier
+kubectl get hpa -n multi-tier
+```
+
+### 4. Access the application
+
+Add the following to `/etc/hosts` (for local development):
+```
+<minikube-ip>  multi-tier.example.local
+```
+
+Then open: `http://multi-tier.example.local`
+
+For minikube:
+```bash
+minikube ip
+```
+
+For kind (with ingress-nginx):
+```bash
+kubectl port-forward svc/ingress-nginx-controller 8080:80 -n ingress-nginx
+# Then access: http://localhost:8080
+```
+
+---
+
+## Cleanup
+
+```bash
+kubectl delete namespace multi-tier
+# Note: PVCs are not deleted with the namespace by default.
+# To also delete data:
+kubectl delete pvc -n multi-tier --all
+```
+
+---
+
+## Customization
+
+| What to change | File |
+|---------------|------|
+| Number of frontend/backend replicas | `frontend/deployment.yml`, `backend/deployment.yml` |
+| HPA min/max replicas | `hpa.yml` |
+| Database size | `database/statefulset.yml` → `volumeClaimTemplates` |
+| Ingress hostname | `ingress.yml` |
+| Network policies | `network-policy.yml` |

--- a/examples/multi-tier/backend/deployment.yml
+++ b/examples/multi-tier/backend/deployment.yml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: multi-tier
+    app.kubernetes.io/version: "18"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: backend
+      app.kubernetes.io/part-of: multi-tier
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  minReadySeconds: 10
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: backend
+        app.kubernetes.io/component: backend
+        app.kubernetes.io/part-of: multi-tier
+        app.kubernetes.io/version: "18"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+
+      containers:
+        - name: api
+          image: node:18-alpine
+          imagePullPolicy: IfNotPresent
+          command: ["node", "-e", "require('http').createServer((req,res)=>{res.writeHead(200);res.end(JSON.stringify({status:'ok',path:req.url}));}).listen(3000)"]
+
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+
+          ports:
+            - name: api
+              containerPort: 3000
+              protocol: TCP
+
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: PORT
+              value: "3000"
+
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: api
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: api
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: backend
+                topologyKey: kubernetes.io/hostname

--- a/examples/multi-tier/backend/service.yml
+++ b/examples/multi-tier/backend/service.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: api
+      protocol: TCP
+      name: api
+  selector:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/part-of: multi-tier

--- a/examples/multi-tier/cache/deployment.yml
+++ b/examples/multi-tier/cache/deployment.yml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cache
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/name: cache
+    app.kubernetes.io/component: cache
+    app.kubernetes.io/part-of: multi-tier
+    app.kubernetes.io/version: "7.2"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cache
+      app.kubernetes.io/part-of: multi-tier
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cache
+        app.kubernetes.io/component: cache
+        app.kubernetes.io/part-of: multi-tier
+        app.kubernetes.io/version: "7.2"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+
+      containers:
+        - name: redis
+          image: redis:7.2-alpine
+          imagePullPolicy: IfNotPresent
+          command:
+            - redis-server
+            - --maxmemory
+            - 128mb
+            - --maxmemory-policy
+            - allkeys-lru
+            - --save
+            - ""
+
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 3
+
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+
+          volumeMounts:
+            - name: data
+              mountPath: /data
+
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/examples/multi-tier/cache/service.yml
+++ b/examples/multi-tier/cache/service.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cache
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/name: cache
+    app.kubernetes.io/component: cache
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: redis
+      protocol: TCP
+      name: redis
+  selector:
+    app.kubernetes.io/name: cache
+    app.kubernetes.io/part-of: multi-tier

--- a/examples/multi-tier/database/service-headless.yml
+++ b/examples/multi-tier/database/service-headless.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: database-headless
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/name: database
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  clusterIP: None
+  ports:
+    - port: 5432
+      targetPort: postgres
+      protocol: TCP
+      name: postgres
+  selector:
+    app.kubernetes.io/name: database
+    app.kubernetes.io/part-of: multi-tier
+  publishNotReadyAddresses: true

--- a/examples/multi-tier/database/service.yml
+++ b/examples/multi-tier/database/service.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: database
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/name: database
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: postgres
+      protocol: TCP
+      name: postgres
+  selector:
+    app.kubernetes.io/name: database
+    app.kubernetes.io/part-of: multi-tier

--- a/examples/multi-tier/database/statefulset.yml
+++ b/examples/multi-tier/database/statefulset.yml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: database
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/name: database
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: multi-tier
+    app.kubernetes.io/version: "16"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: database
+      app.kubernetes.io/part-of: multi-tier
+  serviceName: database-headless
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: database
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: multi-tier
+        app.kubernetes.io/version: "16"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 60
+
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+
+          env:
+            - name: POSTGRES_DB
+              value: appdb
+            - name: POSTGRES_USER
+              value: appuser
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: database-secret
+                  key: postgres-password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - appuser
+                - -d
+                - appdb
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - appuser
+                - -d
+                - appdb
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: database
+          app.kubernetes.io/part-of: multi-tier
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi

--- a/examples/multi-tier/frontend/deployment.yml
+++ b/examples/multi-tier/frontend/deployment.yml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: multi-tier
+    app.kubernetes.io/version: "1.25"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+      app.kubernetes.io/part-of: multi-tier
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  minReadySeconds: 10
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: frontend
+        app.kubernetes.io/component: frontend
+        app.kubernetes.io/part-of: multi-tier
+        app.kubernetes.io/version: "1.25"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          imagePullPolicy: IfNotPresent
+
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: frontend
+                topologyKey: kubernetes.io/hostname

--- a/examples/multi-tier/frontend/service.yml
+++ b/examples/multi-tier/frontend/service.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/part-of: multi-tier

--- a/examples/multi-tier/hpa.yml
+++ b/examples/multi-tier/hpa.yml
@@ -1,0 +1,89 @@
+---
+# HPA for the frontend deployment.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: frontend
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: frontend
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+
+---
+# HPA for the backend deployment.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: backend
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60

--- a/examples/multi-tier/ingress.yml
+++ b/examples/multi-tier/ingress.yml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: multi-tier
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/name: multi-tier-ingress
+    app.kubernetes.io/part-of: multi-tier
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: multi-tier.example.local
+      http:
+        paths:
+          # Route /api/* to the backend service (Node.js API)
+          - path: /api(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 3000
+          # Route / to the frontend service (nginx)
+          - path: /()(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - multi-tier.example.local
+      secretName: multi-tier-tls

--- a/examples/multi-tier/namespace.yml
+++ b/examples/multi-tier/namespace.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: multi-tier
+  labels:
+    # Pod Security Admission — enforce the restricted standard for all pods in this namespace.
+    # https://kubernetes.io/docs/concepts/security/pod-security-standards/
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    app.kubernetes.io/part-of: multi-tier

--- a/examples/multi-tier/network-policy.yml
+++ b/examples/multi-tier/network-policy.yml
@@ -1,0 +1,208 @@
+# =============================================================================
+# Network Policies — multi-tier namespace
+# =============================================================================
+# Default: deny all ingress and egress. Then add explicit allow rules.
+# This follows the principle of least privilege for network traffic.
+# =============================================================================
+
+---
+# Default deny: block all ingress traffic to all pods in the namespace.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+
+---
+# Default deny: block all egress traffic from all pods in the namespace.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+
+---
+# Allow DNS egress from all pods (required for service discovery).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+
+---
+# Allow ingress traffic to frontend from the ingress controller.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-frontend
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 8080
+          protocol: TCP
+
+---
+# Allow ingress to backend from ingress controller and frontend.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-frontend-to-backend
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: backend
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: frontend
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 3000
+          protocol: TCP
+
+---
+# Allow backend to query the database.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-backend-to-database
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: database
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: backend
+      ports:
+        - port: 5432
+          protocol: TCP
+
+---
+# Allow backend to connect to the cache.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-backend-to-cache
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cache
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: backend
+      ports:
+        - port: 6379
+          protocol: TCP
+
+---
+# Allow frontend to make egress calls to backend.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-frontend-egress-to-backend
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: backend
+      ports:
+        - port: 3000
+          protocol: TCP
+
+---
+# Allow backend egress to database and cache.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-backend-egress
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: backend
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: database
+      ports:
+        - port: 5432
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: cache
+      ports:
+        - port: 6379
+          protocol: TCP

--- a/examples/multi-tier/pdb.yml
+++ b/examples/multi-tier/pdb.yml
@@ -1,0 +1,37 @@
+---
+# PodDisruptionBudget for the frontend deployment.
+# Ensures at least 1 frontend pod is available during voluntary disruptions.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: frontend
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+      app.kubernetes.io/part-of: multi-tier
+
+---
+# PodDisruptionBudget for the backend deployment.
+# Ensures at least 1 backend pod is available during voluntary disruptions.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: backend
+  namespace: multi-tier
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: multi-tier
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: backend
+      app.kubernetes.io/part-of: multi-tier

--- a/helm/apache/templates/hooks/post-install-job.yaml
+++ b/helm/apache/templates/hooks/post-install-job.yaml
@@ -1,0 +1,70 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "apache.fullname" . }}-smoke-test
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+  annotations:
+    # Run this Job after install and upgrade hooks complete.
+    "helm.sh/hook": post-install,post-upgrade
+    # Delete the Job before creating a new one (on re-install/upgrade),
+    # and also delete it once it succeeds.
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    # Weight controls execution order relative to other hooks (lower = earlier).
+    "helm.sh/hook-weight": "5"
+    kubernetes.io/description: >-
+      Post-install smoke test Job. Verifies the Apache service is responding
+      with an HTTP 200 after the chart is installed or upgraded.
+spec:
+  # Retry the Job once on failure before marking it as failed.
+  backoffLimit: 1
+  # Clean up the Job 120 seconds after it completes (pass or fail).
+  ttlSecondsAfterFinished: 120
+  template:
+    metadata:
+      labels:
+        {{- include "apache.selectorLabels" . | nindent 8 }}
+    spec:
+      # The Job pod must not be restarted automatically — it will be retried
+      # by the Job controller up to backoffLimit times instead.
+      restartPolicy: Never
+
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534   # nobody
+        seccompProfile:
+          type: RuntimeDefault
+
+      containers:
+        - name: smoke-test
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          # wget --spider fetches the URL and checks the HTTP status code.
+          # Exit code 1 on any non-2xx response → Job fails → helm install fails.
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "=== Apache smoke test starting ==="
+              echo "Target: http://{{ include "apache.fullname" . }}:{{ .Values.service.port }}/"
+              wget \
+                --spider \
+                --server-response \
+                --tries=5 \
+                --timeout=10 \
+                --waitretry=5 \
+                "http://{{ include "apache.fullname" . }}:{{ .Values.service.port }}/" \
+              && echo "=== Smoke test PASSED ===" \
+              || { echo "=== Smoke test FAILED ==="; exit 1; }
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 16Mi

--- a/helm/apache/tests/deployment_test.yaml
+++ b/helm/apache/tests/deployment_test.yaml
@@ -1,0 +1,108 @@
+suite: apache deployment tests
+templates:
+  - deployment.yaml
+  - hpa.yaml
+tests:
+  - it: should have correct replica count when autoscaling is disabled
+    set:
+      autoscaling.enabled: false
+      replicaCount: 2
+    asserts:
+      - isKind:
+          of: Deployment
+        template: deployment.yaml
+      - equal:
+          path: spec.replicas
+          value: 2
+        template: deployment.yaml
+
+  - it: should not set replicas when autoscaling is enabled
+    set:
+      autoscaling.enabled: true
+      autoscaling.minReplicas: 2
+      autoscaling.maxReplicas: 10
+    asserts:
+      - notExists:
+          path: spec.replicas
+        template: deployment.yaml
+
+  - it: should use the correct image
+    set:
+      image.repository: httpd
+      image.tag: "2.4"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: httpd:2.4
+        template: deployment.yaml
+
+  - it: should have app.kubernetes.io/name label
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: apache
+        template: deployment.yaml
+
+  - it: should have correct selector labels
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: apache
+        template: deployment.yaml
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+        template: deployment.yaml
+
+  - it: should render HPA when autoscaling is enabled
+    set:
+      autoscaling.enabled: true
+      autoscaling.minReplicas: 2
+      autoscaling.maxReplicas: 10
+      autoscaling.targetCPUUtilizationPercentage: 70
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+        template: hpa.yaml
+      - equal:
+          path: spec.minReplicas
+          value: 2
+        template: hpa.yaml
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+        template: hpa.yaml
+
+  - it: should not render HPA when autoscaling is disabled
+    set:
+      autoscaling.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: hpa.yaml
+
+  - it: should set imagePullPolicy
+    set:
+      image.pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+        template: deployment.yaml
+
+  - it: should set serviceAccountName
+    set:
+      serviceAccount.create: true
+      serviceAccount.name: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-apache
+        template: deployment.yaml
+
+  - it: should have managed-by Helm label
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+        template: deployment.yaml

--- a/helm/apache/tests/service_test.yaml
+++ b/helm/apache/tests/service_test.yaml
@@ -1,0 +1,60 @@
+suite: apache service tests
+templates:
+  - service.yaml
+tests:
+  - it: should be a ClusterIP service by default
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: should expose port 80 by default
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+
+  - it: should target the http named port
+    asserts:
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+
+  - it: should have the correct selector labels
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: apache
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should expose the configured service port
+    set:
+      service.port: 8080
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+
+  - it: should support NodePort service type
+    set:
+      service.type: NodePort
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+
+  - it: should have helm.sh/chart label
+    asserts:
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^apache-
+
+  - it: should be in the release namespace
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE

--- a/helm/mysql/.helmignore
+++ b/helm/mysql/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/mysql/Chart.yaml
+++ b/helm/mysql/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: mysql
+description: Production-grade MySQL StatefulSet Helm chart
+type: application
+version: 0.1.0
+appVersion: "8.0.36"
+keywords: [mysql, database, statefulset]
+maintainers:
+  - name: kube-platform
+home: https://github.com/sanskarpan/Kubernetes
+sources:
+  - https://hub.docker.com/_/mysql

--- a/helm/mysql/templates/NOTES.txt
+++ b/helm/mysql/templates/NOTES.txt
@@ -1,0 +1,66 @@
+============================================================
+  MySQL Helm Chart — Deployment Complete
+  Release  : {{ .Release.Name }}
+  Namespace: {{ .Release.Namespace }}
+  Chart    : {{ .Chart.Name }}-{{ .Chart.Version }}
+  App      : MySQL {{ .Chart.AppVersion }}
+============================================================
+
+1. Verify the StatefulSet is running:
+
+   kubectl rollout status statefulset/{{ include "mysql.fullname" . }} \
+     -n {{ .Release.Namespace }}
+
+   kubectl get pods -l {{ include "mysql.selectorLabels" . | replace ": " "=" | replace "\n" "," }} \
+     -n {{ .Release.Namespace }}
+
+2. Retrieve the MySQL root password:
+
+{{- if .Values.auth.existingSecret }}
+   # Using existing secret: {{ .Values.auth.existingSecret }}
+   kubectl get secret {{ .Values.auth.existingSecret }} \
+     -n {{ .Release.Namespace }} \
+     -o jsonpath='{.data.mysql-root-password}' | base64 -d
+{{- else }}
+   kubectl get secret {{ include "mysql.fullname" . }} \
+     -n {{ .Release.Namespace }} \
+     -o jsonpath='{.data.mysql-root-password}' | base64 -d
+{{- end }}
+
+3. Connect to MySQL via port-forward (for local development):
+
+   kubectl port-forward service/{{ include "mysql.fullname" . }} \
+     3306:{{ .Values.service.port }} \
+     -n {{ .Release.Namespace }}
+
+   Then connect:
+   mysql -h 127.0.0.1 -P 3306 -u root -p{{ " " }}
+   # Or with the app user:
+   mysql -h 127.0.0.1 -P 3306 -u {{ .Values.auth.username }} -p {{ .Values.auth.database }}
+
+4. Connect from within the cluster:
+
+   Host (ClusterIP):  {{ include "mysql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+   Host (Headless):   {{ include "mysql.fullname" . }}-0.{{ include "mysql.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+   Database:          {{ .Values.auth.database }}
+   User:              {{ .Values.auth.username }}
+
+5. View MySQL logs:
+
+   kubectl logs {{ include "mysql.fullname" . }}-0 \
+     -n {{ .Release.Namespace }} \
+     --tail=100 -f
+
+6. Upgrade the release:
+
+   helm upgrade {{ .Release.Name }} ./helm/mysql \
+     -n {{ .Release.Namespace }} \
+     -f values-prod.yaml \
+     --atomic \
+     --timeout 5m
+
+7. Uninstall the release (data PVCs are NOT deleted automatically):
+
+   helm uninstall {{ .Release.Name }} -n {{ .Release.Namespace }}
+   # To also delete data (DESTRUCTIVE):
+   kubectl delete pvc data-{{ include "mysql.fullname" . }}-0 -n {{ .Release.Namespace }}

--- a/helm/mysql/templates/_helpers.tpl
+++ b/helm/mysql/templates/_helpers.tpl
@@ -1,0 +1,144 @@
+{{/*
+_helpers.tpl — MySQL Helm Chart Template Helpers
+=================================================
+Template functions defined here are available to all templates in this chart.
+Files whose names begin with an underscore are not rendered as Kubernetes
+manifests — they exist solely to define reusable helpers.
+
+Usage: {{ include "mysql.fullname" . }}
+*/}}
+
+{{/*
+mysql.name
+----------
+Expand the name of the chart. If the user sets .Values.nameOverride, that takes
+precedence. The result is truncated to 63 characters because Kubernetes DNS label
+names have a 63-character maximum length.
+
+Example output: "mysql"
+*/}}
+{{- define "mysql.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+mysql.fullname
+--------------
+Create a fully qualified app name by combining the Helm release name and the
+chart name. This avoids name collisions when multiple releases of the same chart
+are installed in the same namespace.
+
+If .Values.fullnameOverride is set, it is used verbatim (truncated to 63 chars).
+If the release name already contains the chart name, we don't duplicate it.
+
+Examples:
+  Release "my-release", chart "mysql" → "my-release-mysql"
+  Release "mysql", chart "mysql"      → "mysql"             (no duplication)
+  fullnameOverride "my-db"            → "my-db"
+*/}}
+{{- define "mysql.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+mysql.chart
+-----------
+Produces the "chart label" value in the format "chart-name-version".
+Used in the helm.sh/chart annotation to record which chart version created
+the resource — useful for auditing and debugging.
+
+Example output: "mysql-0.1.0"
+*/}}
+{{- define "mysql.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+mysql.labels
+------------
+Standard set of labels applied to ALL resources in this chart.
+These labels follow the app.kubernetes.io/* label convention:
+  https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+
+Labels here are IMMUTABLE on StatefulSets (selector labels).
+Do NOT add user-supplied labels here — add them only to the pod template metadata.
+
+Fields:
+  app.kubernetes.io/name        — The name of the application (the chart name)
+  app.kubernetes.io/instance    — The Helm release name (unique per installation)
+  app.kubernetes.io/version     — The version of the application (appVersion)
+  app.kubernetes.io/component   — The role this resource plays (e.g., database)
+  app.kubernetes.io/part-of     — The higher-level application this belongs to
+  app.kubernetes.io/managed-by  — The tool managing this resource (Helm)
+  helm.sh/chart                 — Chart name + version for auditing
+*/}}
+{{- define "mysql.labels" -}}
+helm.sh/chart: {{ include "mysql.chart" . }}
+app.kubernetes.io/name: {{ include "mysql.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/component: database
+app.kubernetes.io/part-of: {{ include "mysql.name" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+mysql.selectorLabels
+--------------------
+A MINIMAL subset of labels used as the StatefulSet selector and Pod template labels.
+These labels MUST be stable across upgrades — changing them requires deleting and
+re-creating the StatefulSet. Do NOT include version or chart labels here, as those
+change with every release and would break the selector immutability requirement.
+
+These same labels are used by:
+  - StatefulSet.spec.selector.matchLabels
+  - StatefulSet.spec.template.metadata.labels (must be a superset)
+  - Service.spec.selector
+  - PodDisruptionBudget.spec.selector
+*/}}
+{{- define "mysql.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mysql.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+mysql.serviceAccountName
+------------------------
+Determine the name of the ServiceAccount to use for the StatefulSet pods.
+
+Logic:
+  1. If serviceAccount.create is true and serviceAccount.name is set → use the provided name
+  2. If serviceAccount.create is true and name is empty → generate from mysql.fullname
+  3. If serviceAccount.create is false and name is set → use the provided name (existing SA)
+  4. If serviceAccount.create is false and name is empty → use "default" (not recommended)
+*/}}
+{{- define "mysql.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mysql.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+mysql.secretName
+----------------
+Determine the name of the Secret containing MySQL credentials.
+If auth.existingSecret is set, use that; otherwise use the chart-managed secret.
+*/}}
+{{- define "mysql.secretName" -}}
+{{- if .Values.auth.existingSecret }}
+{{- .Values.auth.existingSecret }}
+{{- else }}
+{{- include "mysql.fullname" . }}
+{{- end }}
+{{- end }}

--- a/helm/mysql/templates/configmap.yaml
+++ b/helm/mysql/templates/configmap.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mysql.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mysql.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "MySQL configuration ConfigMap. Mounted at /etc/mysql/conf.d/."
+data:
+  my.cnf: |
+    [mysqld]
+    # -------------------------------------------------------------------
+    # Character set and collation
+    # -------------------------------------------------------------------
+    character-set-server  = utf8mb4
+    collation-server      = utf8mb4_unicode_ci
+
+    # -------------------------------------------------------------------
+    # InnoDB settings
+    # -------------------------------------------------------------------
+    # innodb_buffer_pool_size: set to ~70-80% of available memory in production.
+    # Default (128MB) is used here; override via configMap.extraConfig.
+    default_storage_engine = InnoDB
+    innodb_flush_log_at_trx_commit = 1
+    innodb_log_buffer_size         = 16M
+    innodb_file_per_table          = ON
+
+    # -------------------------------------------------------------------
+    # Connection settings
+    # -------------------------------------------------------------------
+    max_connections        = 150
+    max_connect_errors     = 1000000
+    wait_timeout           = 28800
+    interactive_timeout    = 28800
+
+    # -------------------------------------------------------------------
+    # Logging
+    # -------------------------------------------------------------------
+    slow_query_log         = ON
+    long_query_time        = 2
+    log_queries_not_using_indexes = OFF
+
+    # -------------------------------------------------------------------
+    # Replication / GTID (enable when using replication)
+    # -------------------------------------------------------------------
+    # gtid_mode              = ON
+    # enforce_gtid_consistency = ON
+
+    [client]
+    default-character-set  = utf8mb4
+
+    [mysql]
+    default-character-set  = utf8mb4
+    {{- if .Values.configMap.extraConfig }}
+    {{ .Values.configMap.extraConfig | nindent 4 }}
+    {{- end }}

--- a/helm/mysql/templates/pdb.yaml
+++ b/helm/mysql/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "mysql.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mysql.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >-
+      PodDisruptionBudget for the MySQL StatefulSet. Ensures at least
+      {{ .Values.pdb.minAvailable }} pod(s) remain available during voluntary
+      disruptions such as node drains or cluster upgrades.
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "mysql.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/mysql/templates/secret.yaml
+++ b/helm/mysql/templates/secret.yaml
@@ -1,0 +1,21 @@
+{{- if not .Values.auth.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mysql.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mysql.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "MySQL credentials Secret managed by Helm."
+    # IMPORTANT: This Secret is managed by Helm. If you delete the release,
+    # this Secret is deleted too. Back up credentials before uninstalling.
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  # Root password: use provided value or generate a random 16-character password.
+  # The password is base64-encoded as required by Kubernetes Secrets.
+  mysql-root-password: {{ .Values.auth.rootPassword | default (randAlphaNum 16) | b64enc | quote }}
+  # Application user password.
+  mysql-password: {{ .Values.auth.password | default (randAlphaNum 16) | b64enc | quote }}
+{{- end }}

--- a/helm/mysql/templates/service-headless.yaml
+++ b/helm/mysql/templates/service-headless.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mysql.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mysql.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >-
+      Headless Service for MySQL StatefulSet. Provides stable DNS entries for each pod:
+      <pod-name>.{{ include "mysql.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local
+    # Headless services with selectors create DNS A records for individual pod IPs.
+    # Required by StatefulSet for stable network identity (pod hostname resolution).
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  # clusterIP: None — makes this a headless service (no cluster IP assigned).
+  # DNS queries return individual pod IPs instead of a single virtual IP.
+  clusterIP: None
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: mysql
+      protocol: TCP
+      name: mysql
+  selector:
+    {{- include "mysql.selectorLabels" . | nindent 4 }}
+  # publishNotReadyAddresses: true — include pods that are not yet Ready in DNS.
+  # This is important during StatefulSet initialization and rolling updates.
+  publishNotReadyAddresses: true

--- a/helm/mysql/templates/service.yaml
+++ b/helm/mysql/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mysql.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mysql.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "ClusterIP Service for MySQL — use this for application connections."
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: mysql
+      protocol: TCP
+      name: mysql
+  selector:
+    {{- include "mysql.selectorLabels" . | nindent 4 }}

--- a/helm/mysql/templates/serviceaccount.yaml
+++ b/helm/mysql/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mysql.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mysql.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "Dedicated ServiceAccount for the MySQL StatefulSet pod."
+automountServiceAccountToken: false
+{{- end }}

--- a/helm/mysql/templates/statefulset.yaml
+++ b/helm/mysql/templates/statefulset.yaml
@@ -1,0 +1,171 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "mysql.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mysql.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "Production-grade MySQL StatefulSet managed by Helm."
+spec:
+  # StatefulSet requires an explicit replica count.
+  replicas: {{ .Values.replicaCount }}
+
+  # Selector is IMMUTABLE after creation. Never change selectorLabels.
+  selector:
+    matchLabels:
+      {{- include "mysql.selectorLabels" . | nindent 6 }}
+
+  # serviceName must match the headless service name for stable DNS entries.
+  # Each pod gets a DNS record: <pod>.<service>.<namespace>.svc.cluster.local
+  serviceName: {{ include "mysql.fullname" . }}-headless
+
+  # Rolling update strategy — replaces pods one at a time.
+  updateStrategy:
+    type: RollingUpdate
+
+  template:
+    metadata:
+      labels:
+        # Full label set — superset of selectorLabels, so selector is satisfied.
+        {{- include "mysql.labels" . | nindent 8 }}
+      annotations:
+        # Trigger a rolling restart when the Secret or ConfigMap changes.
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "mysql.serviceAccountName" . }}
+      automountServiceAccountToken: false
+
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      # Pod-level security context — applies to all containers.
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+
+      # Give MySQL time to flush data and close connections cleanly.
+      terminationGracePeriodSeconds: 60
+
+      containers:
+        - name: mysql
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+
+          # Container-level security context.
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+
+          ports:
+            - name: mysql
+              containerPort: 3306
+              protocol: TCP
+
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mysql.secretName" . }}
+                  key: mysql-root-password
+            - name: MYSQL_DATABASE
+              value: {{ .Values.auth.database | quote }}
+            - name: MYSQL_USER
+              value: {{ .Values.auth.username | quote }}
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mysql.secretName" . }}
+                  key: mysql-password
+
+          # Readiness probe — removes the pod from Service endpoints if MySQL is not ready.
+          # Uses mysqladmin ping which is a lightweight built-in health check.
+          readinessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - |
+                  mysqladmin ping -h 127.0.0.1 -u root -p"${MYSQL_ROOT_PASSWORD}"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+          # Liveness probe — kills the container if MySQL stops responding.
+          # Only run after the readiness probe has passed (initialDelaySeconds > readiness).
+          livenessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - |
+                  mysqladmin ping -h 127.0.0.1 -u root -p"${MYSQL_ROOT_PASSWORD}"
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+          # Startup probe — gives MySQL time to initialize before liveness kicks in.
+          startupProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - |
+                  mysqladmin ping -h 127.0.0.1 -u root -p"${MYSQL_ROOT_PASSWORD}"
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 30
+
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/mysql
+            - name: config
+              mountPath: /etc/mysql/conf.d
+            - name: tmp
+              mountPath: /tmp
+
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "mysql.fullname" . }}
+        - name: tmp
+          emptyDir: {}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+  # VolumeClaimTemplates — Kubernetes creates a PVC for each pod.
+  # PVCs are NOT deleted when the StatefulSet is deleted (prevents data loss).
+  # To reclaim storage: kubectl delete pvc data-<release>-mysql-0
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "mysql.labels" . | nindent 10 }}
+      spec:
+        accessModes:
+          - {{ .Values.storage.accessMode }}
+        {{- if .Values.storage.storageClassName }}
+        storageClassName: {{ .Values.storage.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.storage.size }}

--- a/helm/mysql/values.schema.json
+++ b/helm/mysql/values.schema.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "MySQL Helm Chart Values",
+  "description": "JSON Schema for validating the MySQL Helm chart values.yaml.",
+  "type": "object",
+  "required": ["replicaCount", "image", "auth", "storage", "service"],
+  "additionalProperties": true,
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 10,
+      "description": "Number of MySQL pod replicas."
+    },
+    "image": {
+      "type": "object",
+      "required": ["repository", "pullPolicy"],
+      "additionalProperties": true,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Container image repository."
+        },
+        "tag": {
+          "type": "string",
+          "description": "Image tag. Defaults to Chart.AppVersion when empty."
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "description": "Image pull policy."
+        }
+      }
+    },
+    "auth": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "rootPassword": {
+          "type": "string",
+          "description": "MySQL root password. Auto-generated if empty."
+        },
+        "database": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Default database name to create."
+        },
+        "username": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Application database user."
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for the application user. Auto-generated if empty."
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Existing Secret name with MySQL credentials."
+        }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "required": ["size", "accessMode"],
+      "additionalProperties": true,
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "PVC size (e.g., 10Gi)."
+        },
+        "storageClassName": {
+          "type": "string",
+          "description": "StorageClass name. Empty uses cluster default."
+        },
+        "accessMode": {
+          "type": "string",
+          "enum": ["ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany"],
+          "description": "PVC access mode."
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "required": ["port"],
+      "additionalProperties": true,
+      "properties": {
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "MySQL service port."
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "requests": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        }
+      }
+    },
+    "pdb": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "string", "pattern": "^[0-9]+%$" }
+          ]
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" }
+      }
+    },
+    "configMap": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "extraConfig": {
+          "type": "string",
+          "description": "Extra content appended to my.cnf."
+        }
+      }
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "securityContext": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object" },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "imagePullSecrets": { "type": "array" }
+  }
+}

--- a/helm/mysql/values.yaml
+++ b/helm/mysql/values.yaml
@@ -1,0 +1,128 @@
+# =============================================================================
+# MySQL Helm Chart — Default Values
+# =============================================================================
+# All values here act as defaults and are intended to be overridden by
+# environment-specific values files (-f values-prod.yaml).
+#
+# Every property has a comment explaining its purpose and any production notes.
+# =============================================================================
+
+# Number of MySQL replicas.
+# Production: use 1 for a standalone instance or configure Group Replication.
+replicaCount: 1
+
+image:
+  # Container image repository. Do not include the tag here.
+  repository: mysql
+
+  # Image tag. Overrides Chart.AppVersion when set.
+  # Leave empty to use Chart.AppVersion (8.0.36).
+  tag: ""
+
+  # Image pull policy.
+  # Production: use IfNotPresent with a pinned tag to ensure reproducible deployments.
+  pullPolicy: IfNotPresent
+
+# Image pull secrets for private container registries.
+imagePullSecrets: []
+
+# Override the chart name portion of resource names.
+nameOverride: ""
+
+# Override the full resource name prefix.
+fullnameOverride: ""
+
+# MySQL authentication configuration.
+auth:
+  # Root password. If empty and auth.existingSecret is empty, a random password
+  # is generated and stored in a Secret. Retrieve it with:
+  #   kubectl get secret <release>-mysql -o jsonpath='{.data.mysql-root-password}' | base64 -d
+  rootPassword: ""
+
+  # Default database name to create on first start.
+  database: myapp
+
+  # Application user (non-root) to create.
+  username: appuser
+
+  # Password for the application user. If empty, a random password is generated.
+  password: ""
+
+  # Name of an existing Kubernetes Secret containing MySQL credentials.
+  # If set, rootPassword and password above are ignored.
+  # The Secret must contain keys: mysql-root-password, mysql-password.
+  existingSecret: ""
+
+# Persistent storage configuration for MySQL data.
+storage:
+  # Size of the PersistentVolumeClaim.
+  size: 10Gi
+
+  # StorageClass name. Leave empty to use the cluster default StorageClass.
+  # Production: use a StorageClass with Retain reclaim policy to prevent data loss.
+  storageClassName: ""
+
+  # Access mode for the PVC. MySQL requires ReadWriteOnce (single node write).
+  accessMode: ReadWriteOnce
+
+# Container resource requests and limits.
+# Requests: what the scheduler uses to place the pod.
+# Limits: hard upper bounds; exceeding memory limit = OOMKilled.
+resources:
+  requests:
+    memory: 512Mi
+    cpu: 250m
+  limits:
+    memory: 1Gi
+
+# Service configuration.
+service:
+  # Port the ClusterIP Service exposes.
+  port: 3306
+
+# PodDisruptionBudget — ensures minimum availability during voluntary disruptions.
+pdb:
+  enabled: true
+  # Minimum number of pods that must remain available during a disruption.
+  minAvailable: 1
+
+# ServiceAccount configuration.
+serviceAccount:
+  # Whether to create a dedicated ServiceAccount for this workload.
+  create: true
+
+  # Name of the ServiceAccount. Generated from fullname if empty and create=true.
+  name: ""
+
+# ConfigMap for additional my.cnf configuration.
+configMap:
+  # Extra configuration to append to my.cnf.
+  # Example:
+  #   extraConfig: |
+  #     [mysqld]
+  #     max_connections = 500
+  #     slow_query_log = ON
+  extraConfig: ""
+
+# Pod-level security context.
+podSecurityContext:
+  runAsUser: 999
+  runAsGroup: 999
+  fsGroup: 999
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level security context.
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+
+# Node selector — constrain pods to nodes with specific labels.
+nodeSelector: {}
+
+# Tolerations — allow pods to be scheduled on tainted nodes.
+tolerations: []
+
+# Affinity rules — pod anti-affinity for HA.
+affinity: {}

--- a/helm/node-app/tests/deployment_test.yaml
+++ b/helm/node-app/tests/deployment_test.yaml
@@ -1,0 +1,113 @@
+suite: node-app deployment tests
+templates:
+  - deployment.yaml
+  - hpa.yaml
+tests:
+  - it: should have correct replica count when autoscaling is disabled
+    set:
+      autoscaling.enabled: false
+      replicaCount: 2
+    asserts:
+      - isKind:
+          of: Deployment
+        template: deployment.yaml
+      - equal:
+          path: spec.replicas
+          value: 2
+        template: deployment.yaml
+
+  - it: should not set replicas when autoscaling is enabled
+    set:
+      autoscaling.enabled: true
+      autoscaling.minReplicas: 2
+      autoscaling.maxReplicas: 10
+      autoscaling.targetCPUUtilizationPercentage: 70
+      autoscaling.targetMemoryUtilizationPercentage: 80
+      autoscaling.scaleDownStabilizationWindowSeconds: 300
+    asserts:
+      - notExists:
+          path: spec.replicas
+        template: deployment.yaml
+
+  - it: should use the correct image
+    set:
+      image.repository: trainwithshubham/node-app-test-new
+      image.tag: "1.0.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: trainwithshubham/node-app-test-new:1.0.0
+        template: deployment.yaml
+
+  - it: should have app.kubernetes.io/name label
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: node-app
+        template: deployment.yaml
+
+  - it: should have correct selector labels
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: node-app
+        template: deployment.yaml
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+        template: deployment.yaml
+
+  - it: should render HPA when autoscaling is enabled
+    set:
+      autoscaling.enabled: true
+      autoscaling.minReplicas: 2
+      autoscaling.maxReplicas: 10
+      autoscaling.targetCPUUtilizationPercentage: 70
+      autoscaling.targetMemoryUtilizationPercentage: 80
+      autoscaling.scaleDownStabilizationWindowSeconds: 300
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+        template: hpa.yaml
+      - equal:
+          path: spec.minReplicas
+          value: 2
+        template: hpa.yaml
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+        template: hpa.yaml
+
+  - it: should not render HPA when autoscaling is disabled
+    set:
+      autoscaling.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: hpa.yaml
+
+  - it: should set imagePullPolicy
+    set:
+      image.pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+        template: deployment.yaml
+
+  - it: should set serviceAccountName
+    set:
+      serviceAccount.create: true
+      serviceAccount.name: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-node-app
+        template: deployment.yaml
+
+  - it: should have managed-by Helm label
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+        template: deployment.yaml

--- a/helm/node-app/tests/service_test.yaml
+++ b/helm/node-app/tests/service_test.yaml
@@ -1,0 +1,60 @@
+suite: node-app service tests
+templates:
+  - service.yaml
+tests:
+  - it: should be a ClusterIP service by default
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: should expose port 80 by default
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+
+  - it: should target the node-app named port
+    asserts:
+      - equal:
+          path: spec.ports[0].targetPort
+          value: node-app
+
+  - it: should have the correct selector labels
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: node-app
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should expose the configured service port
+    set:
+      service.port: 3000
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 3000
+
+  - it: should support NodePort service type
+    set:
+      service.type: NodePort
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+
+  - it: should have helm.sh/chart label
+    asserts:
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^node-app-
+
+  - it: should be in the release namespace
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,0 +1,157 @@
+# helmfile.yaml — multi-chart stack deployment
+# Install: brew install helmfile
+# Usage: helmfile sync, helmfile diff, helmfile apply
+#
+# Overview:
+#   This Helmfile manages the full kube-platform stack across multiple
+#   environments (dev, staging, prod). It deploys:
+#     - apache     : Apache HTTP Server (web tier)
+#     - node-app   : Node.js API server (api tier)
+#     - mysql      : MySQL database (data tier)
+#     - prometheus  : kube-prometheus-stack (monitoring)
+#
+# Getting started:
+#   1. Install helmfile: brew install helmfile
+#   2. Install helm plugins: helm plugin install https://github.com/databus23/helm-diff
+#   3. Preview changes:  helmfile diff
+#   4. Apply changes:    helmfile apply
+#   5. Sync all:         helmfile sync
+#   6. Destroy all:      helmfile destroy
+
+# =============================================================================
+# Helm defaults applied to all releases unless overridden.
+# =============================================================================
+helmDefaults:
+  # Wait for all resources to be ready before marking a release as successful.
+  wait: true
+  # Timeout for each release operation (install/upgrade).
+  timeout: 600
+  # Clean up resources if the install/upgrade fails (prevents partial deployments).
+  cleanupOnFail: true
+  # Perform a 3-way strategic merge patch during upgrades (like kubectl apply).
+  force: false
+  # Atomic: roll back automatically on failure.
+  atomic: true
+  # Create the namespace if it does not exist.
+  createNamespace: true
+
+# =============================================================================
+# Helm chart repositories.
+# =============================================================================
+repositories:
+  - name: stable
+    url: https://charts.helm.sh/stable
+  - name: bitnami
+    url: https://charts.bitnami.com/bitnami
+  - name: prometheus-community
+    url: https://prometheus-community.github.io/helm-charts
+
+# =============================================================================
+# Environments — each maps to a different set of overrides.
+# =============================================================================
+environments:
+  dev:
+    values:
+      - environment: dev
+      - replicaCount: 1
+      - resourcesEnabled: false
+  staging:
+    values:
+      - environment: staging
+      - replicaCount: 2
+      - resourcesEnabled: true
+  prod:
+    values:
+      - environment: prod
+      - replicaCount: 3
+      - resourcesEnabled: true
+
+# =============================================================================
+# Releases — one entry per Helm chart deployment.
+# =============================================================================
+releases:
+  # ---------------------------------------------------------------------------
+  # Apache HTTP Server — web tier
+  # ---------------------------------------------------------------------------
+  - name: apache
+    namespace: web
+    chart: ./helm/apache
+    version: ~0.2.0
+    values:
+      - helm/apache/values.yaml
+      # Environment-specific overrides (file is optional; helmfile ignores missing files).
+      - "helm/apache/values-{{ .Environment.Name }}.yaml"
+    set:
+      - name: replicaCount
+        value: {{ .Values | get "replicaCount" 1 }}
+    labels:
+      tier: web
+      app: apache
+
+  # ---------------------------------------------------------------------------
+  # Node.js API Server — api tier
+  # ---------------------------------------------------------------------------
+  - name: node-app
+    namespace: api
+    chart: ./helm/node-app
+    version: ~0.1.0
+    values:
+      - helm/node-app/values.yaml
+      - "helm/node-app/values-{{ .Environment.Name }}.yaml"
+    set:
+      - name: replicaCount
+        value: {{ .Values | get "replicaCount" 1 }}
+    labels:
+      tier: api
+      app: node-app
+
+  # ---------------------------------------------------------------------------
+  # MySQL Database — data tier
+  # ---------------------------------------------------------------------------
+  - name: mysql
+    namespace: data
+    chart: ./helm/mysql
+    version: ~0.1.0
+    values:
+      - helm/mysql/values.yaml
+      - "helm/mysql/values-{{ .Environment.Name }}.yaml"
+    set:
+      - name: auth.database
+        value: myapp
+      - name: storage.size
+        value: 10Gi
+    secrets:
+      # Encrypted secrets file (requires helm-secrets plugin + sops/age):
+      # helm plugin install https://github.com/jkroepke/helm-secrets
+      # - "secrets/mysql-{{ .Environment.Name }}.yaml"
+    labels:
+      tier: data
+      app: mysql
+
+  # ---------------------------------------------------------------------------
+  # Prometheus / Grafana — monitoring stack
+  # ---------------------------------------------------------------------------
+  - name: prometheus
+    namespace: monitoring
+    chart: prometheus-community/kube-prometheus-stack
+    version: "~65.0.0"
+    values:
+      - grafana:
+          enabled: true
+          adminPassword: "changeme"
+          ingress:
+            enabled: false
+      - prometheus:
+          prometheusSpec:
+            retention: 7d
+            resources:
+              requests:
+                memory: 512Mi
+                cpu: 250m
+              limits:
+                memory: 2Gi
+      - alertmanager:
+          enabled: true
+    labels:
+      tier: monitoring
+      app: prometheus

--- a/platform/storage/velero/README.md
+++ b/platform/storage/velero/README.md
@@ -1,0 +1,209 @@
+# Velero — Kubernetes Backup and Restore
+
+[Velero](https://velero.io/) provides disaster recovery, cluster migration, and data protection for Kubernetes workloads and persistent volumes.
+
+---
+
+## Architecture
+
+```
+Kubernetes Cluster
+    |
+    v
+[ Velero Server (Pod) ]
+    |                 \
+    v                  v
+[ Object Storage ]  [ Volume Snapshots ]
+  (S3/GCS/Azure)    (EBS/PD/Azure Disk)
+```
+
+Velero consists of:
+- **Velero server**: runs in the cluster, manages backup/restore operations
+- **BackupStorageLocation (BSL)**: where backup metadata is stored (S3, GCS, Azure Blob)
+- **VolumeSnapshotLocation (VSL)**: where volume snapshots are stored (cloud provider)
+
+---
+
+## Prerequisites
+
+- Kubernetes >= 1.25
+- Helm >= 3.14
+- Object storage bucket (S3, GCS, or Azure Blob)
+- Appropriate IAM permissions for Velero to access object storage
+
+---
+
+## Installation
+
+### 1. Install the Velero CLI
+
+```bash
+# macOS
+brew install velero
+
+# Linux (amd64)
+VELERO_VERSION="1.14.0"
+curl -fsSL "https://github.com/vmware-tanzu/velero/releases/download/v${VELERO_VERSION}/velero-v${VELERO_VERSION}-linux-amd64.tar.gz" \
+  | tar -xz -C /tmp
+sudo mv "/tmp/velero-v${VELERO_VERSION}-linux-amd64/velero" /usr/local/bin/velero
+
+# Verify
+velero version --client-only
+```
+
+### 2. Install Velero with Helm
+
+```bash
+helm repo add vmware-tanzu https://vmware-tanzu.github.io/helm-charts
+helm repo update
+
+helm install velero vmware-tanzu/velero \
+  --namespace velero \
+  --create-namespace \
+  --version 7.2.1 \
+  --set-json "configuration.backupStorageLocation[0].name=default" \
+  --set-json "configuration.backupStorageLocation[0].provider=aws" \
+  --set-json "configuration.backupStorageLocation[0].bucket=your-velero-bucket" \
+  --set-json "configuration.backupStorageLocation[0].config.region=us-east-1" \
+  --set serviceAccount.server.annotations."eks.amazonaws.com/role-arn"="arn:aws:iam::ACCOUNT_ID:role/velero-role"
+
+# Verify
+kubectl get pods -n velero
+velero backup-location get
+```
+
+---
+
+## BackupStorageLocation Configuration
+
+### AWS S3
+
+```bash
+helm install velero vmware-tanzu/velero \
+  --namespace velero \
+  --create-namespace \
+  --set-json 'configuration.backupStorageLocation[0]={"name":"default","provider":"aws","bucket":"your-bucket","config":{"region":"us-east-1"}}' \
+  --set-json 'configuration.volumeSnapshotLocation[0]={"name":"default","provider":"aws","config":{"region":"us-east-1"}}' \
+  --set credentials.useSecret=false \
+  --set serviceAccount.server.annotations."eks.amazonaws.com/role-arn"="arn:aws:iam::ACCOUNT_ID:role/velero-role"
+```
+
+### Google Cloud Storage (GCS)
+
+```bash
+helm install velero vmware-tanzu/velero \
+  --namespace velero \
+  --create-namespace \
+  --set-json 'configuration.backupStorageLocation[0]={"name":"default","provider":"gcp","bucket":"your-gcs-bucket","config":{}}' \
+  --set-json 'configuration.volumeSnapshotLocation[0]={"name":"default","provider":"gcp","config":{"project":"your-project-id"}}' \
+  --set credentials.useSecret=false \
+  --set serviceAccount.server.annotations."iam.gke.io/gcp-service-account"="velero@your-project.iam.gserviceaccount.com"
+```
+
+### Azure Blob Storage
+
+```bash
+helm install velero vmware-tanzu/velero \
+  --namespace velero \
+  --create-namespace \
+  --set-json 'configuration.backupStorageLocation[0]={"name":"default","provider":"azure","bucket":"your-container","config":{"resourceGroup":"velero-rg","storageAccount":"velerosa"}}' \
+  --set-json 'configuration.volumeSnapshotLocation[0]={"name":"default","provider":"azure","config":{"resourceGroup":"velero-rg"}}' \
+  --set credentials.useSecret=false \
+  --set serviceAccount.server.annotations."azure.workload.identity/client-id"="your-client-id"
+```
+
+---
+
+## Apply the Backup Schedule
+
+```bash
+# Apply the daily backup schedule
+kubectl apply -f platform/storage/velero/backup-schedule.yml
+
+# Verify the schedule is registered
+velero schedule get
+
+# Trigger a manual backup from the schedule immediately (for testing)
+velero backup create manual-test --from-schedule=daily-statefulset-backup
+
+# Watch the backup progress
+velero backup describe manual-test --details
+```
+
+---
+
+## Restore from Backup
+
+```bash
+# List available backups
+velero backup get
+
+# Edit restore-example.yml to set the correct backupName, then apply:
+kubectl apply -f platform/storage/velero/restore-example.yml
+
+# Monitor restore progress
+kubectl get restore -n velero --watch
+velero restore describe restore-data-namespace --details
+
+# Or restore directly via CLI:
+velero restore create \
+  --from-backup daily-statefulset-backup-20260115020000 \
+  --include-namespaces data \
+  --restore-volumes
+```
+
+---
+
+## Useful Commands
+
+```bash
+# List all backups
+velero backup get
+
+# Describe a backup (shows included resources, errors, warnings)
+velero backup describe <backup-name> --details
+
+# Download backup logs
+velero backup logs <backup-name>
+
+# Delete a backup
+velero backup delete <backup-name>
+
+# List all restores
+velero restore get
+
+# Describe a restore
+velero restore describe <restore-name> --details
+
+# Uninstall Velero
+helm uninstall velero -n velero
+kubectl delete namespace velero
+```
+
+---
+
+## Monitoring
+
+Velero exposes Prometheus metrics on port 8085. Add the following ServiceMonitor if using kube-prometheus-stack:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: velero
+  namespace: monitoring
+spec:
+  namespaceSelector:
+    matchNames: [velero]
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: velero
+  endpoints:
+    - port: monitoring
+      interval: 30s
+```
+
+Key metrics to alert on:
+- `velero_backup_failure_total` — number of failed backups
+- `velero_backup_last_status` — 1 = success, 0 = failure
+- `velero_restore_failure_total` — number of failed restores

--- a/platform/storage/velero/backup-schedule.yml
+++ b/platform/storage/velero/backup-schedule.yml
@@ -1,0 +1,100 @@
+# =============================================================================
+# Velero Backup Schedule — Daily backups of StatefulSet namespaces
+# =============================================================================
+# This Schedule creates a Backup every day at 02:00 UTC.
+# It targets namespaces that contain StatefulSet workloads (databases, etc.)
+#
+# Prerequisites:
+#   - Velero CLI and server installed (see README.md)
+#   - A BackupStorageLocation (BSL) configured
+#   - Volume snapshot provider configured (for PVC backups)
+# =============================================================================
+
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: daily-statefulset-backup
+  namespace: velero
+  labels:
+    app.kubernetes.io/name: velero
+    app.kubernetes.io/component: backup-schedule
+    backup.velero.io/schedule: daily
+spec:
+  # Cron expression: At 02:00 UTC every day.
+  # Format: minute hour day-of-month month day-of-week
+  schedule: "0 2 * * *"
+
+  # Template for each Backup resource created by this Schedule.
+  template:
+    # Namespaces to include in the backup.
+    # Add all namespaces that contain StatefulSet workloads (databases, etc.).
+    includedNamespaces:
+      - data
+      - multi-tier
+      - default
+
+    # Optionally exclude specific namespaces (e.g., monitoring, ingress-nginx).
+    excludedNamespaces:
+      - kube-system
+      - kube-public
+      - kube-node-lease
+      - cert-manager
+      - monitoring
+      - ingress-nginx
+
+    # Include all resource types in the backup.
+    includedResources:
+      - "*"
+
+    # Include cluster-scoped resources referenced by namespaced resources.
+    includeClusterResources: true
+
+    # Create volume snapshots for PersistentVolumes.
+    # Requires a compatible volume snapshot provider.
+    snapshotVolumes: true
+
+    # How long to retain the backup. After this, Velero deletes the backup
+    # from object storage automatically.
+    ttl: 720h0m0s
+
+    # StorageLocation — references the BackupStorageLocation configured during install.
+    # Leave empty to use the default BSL.
+    storageLocation: default
+
+    # VolumeSnapshotLocations — references the VolumeSnapshotLocation(s) to use.
+    volumeSnapshotLocations:
+      - default
+
+    # Labels applied to all Backup resources created by this Schedule.
+    labels:
+      schedule: daily-statefulset-backup
+      managed-by: velero
+
+    # Hooks — run commands inside pods before/after backup for consistency.
+    # Example: freeze MySQL before backup, thaw after.
+    hooks:
+      resources:
+        - name: mysql-freeze
+          includedNamespaces:
+            - data
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: mysql
+          pre:
+            - exec:
+                container: mysql
+                command:
+                  - /bin/bash
+                  - -c
+                  - mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "FLUSH TABLES WITH READ LOCK;"
+                onError: Fail
+                timeout: 30s
+          post:
+            - exec:
+                container: mysql
+                command:
+                  - /bin/bash
+                  - -c
+                  - mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "UNLOCK TABLES;"
+                onError: Continue
+                timeout: 30s

--- a/platform/storage/velero/restore-example.yml
+++ b/platform/storage/velero/restore-example.yml
@@ -1,0 +1,73 @@
+# =============================================================================
+# Velero Restore Example
+# =============================================================================
+# This Restore resource restores a specific namespace from a named backup.
+# Apply this manifest to trigger a restore operation.
+#
+# IMPORTANT: Before restoring, ensure:
+#   1. The target namespace does NOT already exist (or use --existing-resource-policy=update).
+#   2. Any conflicting resources (PVCs, Secrets) are deleted first.
+#   3. The BackupStorageLocation is accessible.
+#
+# Usage:
+#   kubectl apply -f restore-example.yml
+#   kubectl get restore -n velero
+#   kubectl describe restore restore-data-namespace -n velero
+# =============================================================================
+
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  # Give the restore a meaningful, unique name.
+  # Convention: restore-<namespace>-<date>
+  name: restore-data-namespace
+  namespace: velero
+  labels:
+    app.kubernetes.io/name: velero
+    app.kubernetes.io/component: restore
+spec:
+  # Reference the specific backup to restore from.
+  # To list available backups: velero backup get
+  # Or: kubectl get backup -n velero
+  backupName: daily-statefulset-backup-20260115020000
+
+  # Namespaces to restore (subset of what was backed up).
+  includedNamespaces:
+    - data
+
+  # Resource types to restore. Use "*" to restore all resource types.
+  includedResources:
+    - "*"
+
+  # Exclude resources that should not be restored (e.g., if they already exist
+  # and you only want to restore data volumes).
+  excludedResources:
+    - nodes
+    - events
+    - events.events.k8s.io
+    - backups.velero.io
+    - restores.velero.io
+    - resticrepositories.velero.io
+
+  # Restore PersistentVolumes (and their data) from volume snapshots.
+  # Set to false if you only want to restore Kubernetes objects, not data.
+  restorePVs: true
+
+  # Namespace mappings — restore resources from a namespace into a different namespace.
+  # Useful for cloning a production namespace into staging for testing.
+  # namespaceMapping:
+  #   data: data-restored
+
+  # How to handle resources that already exist in the cluster.
+  # Options: none (skip), update (patch existing resources)
+  existingResourcePolicy: none
+
+  # Label selector — restore only resources with specific labels.
+  # Useful for partial restores (e.g., only restore the MySQL StatefulSet).
+  # labelSelector:
+  #   matchLabels:
+  #     app.kubernetes.io/name: mysql
+
+  # Hooks — run commands after the restore completes (e.g., to warm caches).
+  hooks:
+    resources: []

--- a/setup/cloud/aks/README.md
+++ b/setup/cloud/aks/README.md
@@ -1,0 +1,272 @@
+# AKS Setup Guide
+
+This guide walks you through creating a production-grade Azure Kubernetes Service (AKS) cluster and deploying the kube-platform manifests.
+
+---
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Azure CLI (`az`) | >= 2.57.0 | [Install guide](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) |
+| kubectl | >= 1.32 | `az aks install-cli` |
+| Helm | >= 3.14 | [Install guide](https://helm.sh/docs/intro/install/) |
+
+### 1. Authenticate and configure az CLI
+
+```bash
+# Log in to Azure
+az login
+
+# Set your subscription
+az account set --subscription "YOUR_SUBSCRIPTION_ID"
+
+# Verify
+az account show
+```
+
+### 2. Set environment variables
+
+```bash
+export SUBSCRIPTION_ID="your-subscription-id"
+export RESOURCE_GROUP="kube-platform-rg"
+export LOCATION="eastus"
+export CLUSTER_NAME="kube-platform"
+export KUBERNETES_VERSION="1.32"
+export NODE_COUNT=3
+export NODE_VM_SIZE="Standard_D4s_v5"
+```
+
+---
+
+## Create a Resource Group
+
+```bash
+az group create \
+  --name "${RESOURCE_GROUP}" \
+  --location "${LOCATION}"
+```
+
+---
+
+## Create the AKS Cluster
+
+```bash
+az aks create \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CLUSTER_NAME}" \
+  --location "${LOCATION}" \
+  --kubernetes-version "${KUBERNETES_VERSION}" \
+  --node-count "${NODE_COUNT}" \
+  --min-count 1 \
+  --max-count 10 \
+  --enable-cluster-autoscaler \
+  --node-vm-size "${NODE_VM_SIZE}" \
+  --network-plugin azure \
+  --network-policy azure \
+  --enable-managed-identity \
+  --enable-oidc-issuer \
+  --enable-workload-identity \
+  --enable-addons monitoring \
+  --workspace-resource-id "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.OperationalInsights/workspaces/kube-platform-logs" \
+  --generate-ssh-keys \
+  --zones 1 2 3 \
+  --uptime-sla
+```
+
+### Key flag explanations
+
+| Flag | Purpose |
+|------|---------|
+| `--enable-cluster-autoscaler` | Scales node pool based on pending Pods |
+| `--network-plugin azure` | Azure CNI networking (required for advanced network policies) |
+| `--network-policy azure` | Enforce Kubernetes NetworkPolicy using Azure NPM |
+| `--enable-managed-identity` | System-assigned managed identity for the cluster (no credentials needed) |
+| `--enable-oidc-issuer` | Required for Azure Workload Identity |
+| `--enable-workload-identity` | Enables Azure Workload Identity (preferred over pod-managed identity) |
+| `--zones 1 2 3` | Spread nodes across 3 availability zones for HA |
+| `--uptime-sla` | 99.95% SLA (recommended for production) |
+
+---
+
+## Configure kubectl
+
+```bash
+# Download credentials and merge into ~/.kube/config
+az aks get-credentials \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CLUSTER_NAME}" \
+  --overwrite-existing
+
+# Verify connectivity
+kubectl get nodes
+kubectl cluster-info
+```
+
+---
+
+## Azure Workload Identity Setup
+
+Azure Workload Identity lets Kubernetes workloads authenticate to Azure services without storing credentials in Pods or Secrets. It replaces the older pod-managed identity (AAD Pod Identity) approach.
+
+```bash
+# Get the OIDC issuer URL
+OIDC_ISSUER=$(az aks show \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CLUSTER_NAME}" \
+  --query "oidcIssuerProfile.issuerUrl" \
+  --output tsv)
+
+# 1. Create an Azure Managed Identity
+az identity create \
+  --name kube-platform-identity \
+  --resource-group "${RESOURCE_GROUP}"
+
+CLIENT_ID=$(az identity show \
+  --name kube-platform-identity \
+  --resource-group "${RESOURCE_GROUP}" \
+  --query clientId \
+  --output tsv)
+
+# 2. Grant the identity permissions it needs
+#    (adjust roles based on what your workload accesses)
+az role assignment create \
+  --assignee "${CLIENT_ID}" \
+  --role "Key Vault Secrets User" \
+  --scope "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}"
+
+# 3. Create the federated credential (links K8s SA → Azure identity)
+az identity federated-credential create \
+  --name kube-platform-federated \
+  --identity-name kube-platform-identity \
+  --resource-group "${RESOURCE_GROUP}" \
+  --issuer "${OIDC_ISSUER}" \
+  --subject "system:serviceaccount:NAMESPACE:KUBERNETES_SA_NAME" \
+  --audiences api://AzureADTokenExchange
+
+# 4. Annotate the Kubernetes ServiceAccount
+kubectl annotate serviceaccount KUBERNETES_SA_NAME \
+  --namespace=NAMESPACE \
+  "azure.workload.identity/client-id=${CLIENT_ID}"
+```
+
+Your Pod spec must also include the label `azure.workload.identity/use: "true"`.
+
+---
+
+## Enable Addons
+
+### Azure Monitor / Container Insights
+
+```bash
+# Create Log Analytics Workspace (if not already done)
+az monitor log-analytics workspace create \
+  --resource-group "${RESOURCE_GROUP}" \
+  --workspace-name kube-platform-logs \
+  --location "${LOCATION}"
+
+WORKSPACE_ID=$(az monitor log-analytics workspace show \
+  --resource-group "${RESOURCE_GROUP}" \
+  --workspace-name kube-platform-logs \
+  --query id --output tsv)
+
+# Enable monitoring addon
+az aks enable-addons \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CLUSTER_NAME}" \
+  --addons monitoring \
+  --workspace-resource-id "${WORKSPACE_ID}"
+```
+
+### Application Gateway Ingress Controller (AGIC)
+
+```bash
+# Create a public IP for the Application Gateway
+az network public-ip create \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name kube-platform-agw-ip \
+  --sku Standard
+
+# Enable the ingress-appgw addon
+az aks enable-addons \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CLUSTER_NAME}" \
+  --addons ingress-appgw \
+  --appgw-name kube-platform-agw \
+  --appgw-subnet-cidr "10.225.0.0/16"
+```
+
+---
+
+## Apply This Repo's Manifests
+
+```bash
+# Clone the repo
+git clone https://github.com/sanskarpan/Kubernetes.git
+cd Kubernetes
+
+# Apply core manifests
+kubectl apply -k core/
+
+# Deploy with Helm
+helm install apache ./helm/apache --namespace web --create-namespace
+helm install node-app ./helm/node-app --namespace api --create-namespace
+helm install mysql ./helm/mysql --namespace data --create-namespace
+
+# Or deploy all with helmfile
+helmfile sync
+```
+
+---
+
+## Useful Commands
+
+```bash
+# List all AKS clusters in the subscription
+az aks list --output table
+
+# Scale the node pool
+az aks scale \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CLUSTER_NAME}" \
+  --node-count 5 \
+  --nodepool-name nodepool1
+
+# Upgrade the cluster to a new Kubernetes version
+az aks upgrade \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CLUSTER_NAME}" \
+  --kubernetes-version "${KUBERNETES_VERSION}" \
+  --yes
+
+# Stop the cluster (saves compute costs, keeps configuration)
+az aks stop \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CLUSTER_NAME}"
+
+# Start the cluster
+az aks start \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CLUSTER_NAME}"
+
+# Delete the cluster (DESTRUCTIVE)
+az aks delete \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CLUSTER_NAME}" \
+  --yes
+
+# Delete the resource group (deletes ALL resources including the cluster)
+az group delete \
+  --name "${RESOURCE_GROUP}" \
+  --yes
+```
+
+---
+
+## Cost Optimization Tips
+
+- Use **Spot node pools** for batch or fault-tolerant workloads.
+- Enable **Vertical Pod Autoscaler** to right-size resource requests.
+- Use **Azure Reserved Instances** for predictable baseline nodes.
+- Set **auto-stop schedules** for dev/staging clusters.
+- Enable **Cost Analysis** in the Azure portal to track per-namespace spend.

--- a/setup/cloud/gke/README.md
+++ b/setup/cloud/gke/README.md
@@ -1,0 +1,229 @@
+# GKE Setup Guide
+
+This guide walks you through creating a production-grade Google Kubernetes Engine (GKE) cluster and deploying the kube-platform manifests.
+
+---
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| gcloud CLI | >= 460.0.0 | [Install guide](https://cloud.google.com/sdk/docs/install) |
+| kubectl | >= 1.32 | `gcloud components install kubectl` |
+| Helm | >= 3.14 | [Install guide](https://helm.sh/docs/intro/install/) |
+
+### 1. Authenticate and configure gcloud
+
+```bash
+# Log in to Google Cloud
+gcloud auth login
+
+# Set your project
+gcloud config set project YOUR_PROJECT_ID
+
+# Enable required APIs
+gcloud services enable \
+  container.googleapis.com \
+  compute.googleapis.com \
+  iam.googleapis.com \
+  cloudresourcemanager.googleapis.com
+
+# Verify
+gcloud config list
+```
+
+### 2. Set environment variables
+
+```bash
+export PROJECT_ID="your-project-id"
+export REGION="us-central1"
+export ZONE="us-central1-a"
+export CLUSTER_NAME="kube-platform"
+export CLUSTER_VERSION="1.32"
+```
+
+---
+
+## Option A: GKE Autopilot (Recommended)
+
+Autopilot is a fully managed GKE mode where Google manages the node pool, scaling, and security. You pay per Pod resource request rather than per node.
+
+**Benefits:**
+- No node management (patching, scaling, bin-packing)
+- Built-in security hardening (Shielded Nodes, Workload Identity, node auto-provisioning)
+- Cost efficiency — pay only for what Pods request
+
+```bash
+gcloud container clusters create-auto "${CLUSTER_NAME}" \
+  --region="${REGION}" \
+  --release-channel="regular" \
+  --cluster-version="${CLUSTER_VERSION}" \
+  --workload-pool="${PROJECT_ID}.svc.id.goog" \
+  --project="${PROJECT_ID}"
+```
+
+> Note: Autopilot clusters require all workloads to comply with [Autopilot resource limits](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests).
+
+---
+
+## Option B: GKE Standard Cluster
+
+Use Standard mode when you need full control over node configuration, custom taints, or GPU/TPU nodes.
+
+```bash
+gcloud container clusters create "${CLUSTER_NAME}" \
+  --project="${PROJECT_ID}" \
+  --region="${REGION}" \
+  --release-channel="regular" \
+  --cluster-version="${CLUSTER_VERSION}" \
+  --machine-type="e2-standard-4" \
+  --num-nodes=3 \
+  --min-nodes=1 \
+  --max-nodes=10 \
+  --enable-autoscaling \
+  --enable-autorepair \
+  --enable-autoupgrade \
+  --workload-pool="${PROJECT_ID}.svc.id.goog" \
+  --enable-shielded-nodes \
+  --shielded-secure-boot \
+  --shielded-integrity-monitoring \
+  --enable-ip-alias \
+  --network="default" \
+  --subnetwork="default" \
+  --logging=SYSTEM,WORKLOAD \
+  --monitoring=SYSTEM \
+  --addons=HttpLoadBalancing,HorizontalPodAutoscaling,GcePersistentDiskCsiDriver
+```
+
+### Key flag explanations
+
+| Flag | Purpose |
+|------|---------|
+| `--release-channel=regular` | Automatic minor version upgrades (stable cadence) |
+| `--enable-autoscaling` | Cluster Autoscaler scales nodes based on demand |
+| `--workload-pool` | Enables Workload Identity (replaces static service account keys) |
+| `--enable-shielded-nodes` | Verified boot, vTPM, and integrity monitoring |
+| `--enable-ip-alias` | VPC-native networking (required for many addons) |
+| `--addons=GcePersistentDiskCsiDriver` | CSI driver for PersistentVolume support |
+
+---
+
+## Configure kubectl
+
+```bash
+# Download credentials and update ~/.kube/config
+gcloud container clusters get-credentials "${CLUSTER_NAME}" \
+  --region="${REGION}" \
+  --project="${PROJECT_ID}"
+
+# Verify connectivity
+kubectl get nodes
+kubectl cluster-info
+```
+
+---
+
+## Workload Identity Setup
+
+Workload Identity lets Kubernetes ServiceAccounts impersonate Google Cloud IAM service accounts without static JSON keys. This is the recommended approach for GCP API access from Pods.
+
+```bash
+# 1. Create a Google Cloud IAM service account
+gcloud iam service-accounts create kube-platform-sa \
+  --display-name="kube-platform workload identity SA" \
+  --project="${PROJECT_ID}"
+
+# 2. Grant the IAM SA the permissions it needs
+#    (adjust roles based on what your workload requires)
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:kube-platform-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/cloudsql.client"
+
+# 3. Allow the Kubernetes SA to impersonate the IAM SA
+gcloud iam service-accounts add-iam-policy-binding \
+  "kube-platform-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="serviceAccount:${PROJECT_ID}.svc.id.goog[NAMESPACE/KUBERNETES_SA_NAME]"
+
+# 4. Annotate the Kubernetes ServiceAccount
+kubectl annotate serviceaccount KUBERNETES_SA_NAME \
+  --namespace=NAMESPACE \
+  "iam.gke.io/gcp-service-account=kube-platform-sa@${PROJECT_ID}.iam.gserviceaccount.com"
+```
+
+---
+
+## Enable Cluster Addons
+
+### Config Connector (manage GCP resources via Kubernetes CRDs)
+
+```bash
+gcloud container clusters update "${CLUSTER_NAME}" \
+  --update-addons ConfigConnector=ENABLED \
+  --region="${REGION}"
+```
+
+### GKE Gateway API (next-gen Ingress)
+
+```bash
+# Enable Gateway API CRDs (already available on GKE 1.24+)
+gcloud container clusters update "${CLUSTER_NAME}" \
+  --gateway-api=standard \
+  --region="${REGION}"
+```
+
+---
+
+## Apply This Repo's Manifests
+
+```bash
+# Clone the repo
+git clone https://github.com/sanskarpan/Kubernetes.git
+cd Kubernetes
+
+# Apply core manifests
+kubectl apply -k core/
+
+# Deploy with Helm
+helm install apache ./helm/apache --namespace web --create-namespace
+helm install node-app ./helm/node-app --namespace api --create-namespace
+helm install mysql ./helm/mysql --namespace data --create-namespace
+
+# Or deploy all with helmfile
+helmfile sync
+```
+
+---
+
+## Useful Commands
+
+```bash
+# List all clusters in the project
+gcloud container clusters list --project="${PROJECT_ID}"
+
+# Resize the cluster
+gcloud container clusters resize "${CLUSTER_NAME}" \
+  --node-pool=default-pool \
+  --num-nodes=5 \
+  --region="${REGION}"
+
+# Upgrade the cluster to a new Kubernetes version
+gcloud container clusters upgrade "${CLUSTER_NAME}" \
+  --master \
+  --cluster-version="${CLUSTER_VERSION}" \
+  --region="${REGION}"
+
+# Delete the cluster (DESTRUCTIVE)
+gcloud container clusters delete "${CLUSTER_NAME}" \
+  --region="${REGION}" \
+  --project="${PROJECT_ID}"
+```
+
+---
+
+## Cost Optimization Tips
+
+- Use **Spot VMs** for non-critical workloads: add `--spot` to node pool creation.
+- Enable **Vertical Pod Autoscaler** to right-size resource requests.
+- Use **Committed Use Discounts** for predictable baseline workloads.
+- Set **resource requests** accurately — Autopilot bills based on requests.

--- a/setup/local/minikube/install.sh
+++ b/setup/local/minikube/install.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# install.sh — Idempotent installer for minikube and kubectl
+#
+# Usage:
+#   bash install.sh
+#
+# Override versions with environment variables:
+#   MINIKUBE_VERSION=1.34.0 KUBECTL_VERSION=1.32.0 bash install.sh
+#
+# Supported platforms:
+#   - Linux  (amd64 / arm64)
+#   - macOS  (amd64 / arm64 / Apple Silicon)
+#
+# This script is idempotent: it checks whether each tool is already installed
+# at the required version before attempting to install or upgrade it.
+#
+# Prerequisites:
+#   - Docker Desktop (macOS) or Docker Engine (Linux) must be running.
+#     Install Docker Desktop: https://www.docker.com/products/docker-desktop/
+# ==============================================================================
+
+set -euo pipefail
+
+# ---- Versions (override with env vars) ----------------------------------------
+MINIKUBE_VERSION="${MINIKUBE_VERSION:-1.34.0}"
+KUBECTL_VERSION="${KUBECTL_VERSION:-1.32.0}"
+KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.32.0}"
+
+# ---- Minikube start configuration --------------------------------------------
+MINIKUBE_DRIVER="${MINIKUBE_DRIVER:-docker}"
+MINIKUBE_CPUS="${MINIKUBE_CPUS:-4}"
+MINIKUBE_MEMORY="${MINIKUBE_MEMORY:-8192}"
+MINIKUBE_ADDONS="${MINIKUBE_ADDONS:-ingress,metrics-server}"
+MINIKUBE_PROFILE="${MINIKUBE_PROFILE:-kube-platform}"
+
+# ---- Platform detection -------------------------------------------------------
+ARCH="${ARCH:-$(uname -m)}"
+OS_RAW="${OS_RAW:-$(uname -s)}"
+OS="$(echo "$OS_RAW" | tr '[:upper:]' '[:lower:]')"
+
+# Normalize architecture names to match download URLs
+case "$ARCH" in
+  x86_64)  ARCH_NORM="amd64" ;;
+  aarch64) ARCH_NORM="arm64" ;;
+  arm64)   ARCH_NORM="arm64" ;;
+  *)
+    echo "[ERROR] Unsupported architecture: $ARCH"
+    echo "        Supported: x86_64, aarch64, arm64"
+    exit 1
+    ;;
+esac
+
+# ---- Color helpers ------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+log_info()    { printf "${CYAN}[INFO]${RESET}  %s\n" "$*"; }
+log_ok()      { printf "${GREEN}[OK]${RESET}    %s\n" "$*"; }
+log_warn()    { printf "${YELLOW}[WARN]${RESET}  %s\n" "$*"; }
+log_error()   { printf "${RED}[ERROR]${RESET} %s\n" "$*" >&2; }
+log_section() { printf "\n${BOLD}=== %s ===${RESET}\n" "$*"; }
+
+# ---- Helper: require a command -----------------------------------------------
+require() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    log_error "Required command not found: $1"
+    log_error "Install '$1' and re-run this script."
+    exit 1
+  fi
+}
+
+# ---- Helper: compare semver (returns 0 if $1 >= $2) --------------------------
+version_ge() {
+  [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+}
+
+# ---- Helper: install a binary from a URL to /usr/local/bin or ~/.local/bin ---
+install_binary() {
+  local name="$1"
+  local url="$2"
+  local tmp_path="/tmp/${name}"
+
+  log_info "Downloading ${name} from: ${url}"
+  curl -fsSL -o "${tmp_path}" "${url}"
+  chmod +x "${tmp_path}"
+
+  if [ "$OS" = "linux" ]; then
+    sudo mv "${tmp_path}" "/usr/local/bin/${name}"
+  else
+    # macOS
+    if [ -d "/usr/local/bin" ] && [ -w "/usr/local/bin" ]; then
+      mv "${tmp_path}" "/usr/local/bin/${name}"
+    else
+      mkdir -p "$HOME/.local/bin"
+      mv "${tmp_path}" "$HOME/.local/bin/${name}"
+      log_warn "Installed ${name} to ~/.local/bin/${name} — ensure this is on your PATH."
+    fi
+  fi
+
+  log_ok "${name} installed at: $(command -v "${name}")"
+}
+
+# ==============================================================================
+# SECTION 1: Docker (prerequisite check)
+# ==============================================================================
+
+check_docker() {
+  log_section "Docker (prerequisite check)"
+
+  if ! command -v docker >/dev/null 2>&1; then
+    if [ "$OS" = "darwin" ]; then
+      log_error "Docker not found. Install Docker Desktop:"
+      log_error "  https://www.docker.com/products/docker-desktop/"
+      log_error "  brew install --cask docker"
+    else
+      log_error "Docker not found. Install Docker Engine:"
+      log_error "  https://docs.docker.com/engine/install/"
+    fi
+    exit 1
+  fi
+
+  if ! docker info >/dev/null 2>&1; then
+    log_error "Docker is installed but not running."
+    log_error "Start Docker Desktop (macOS/Windows) or: sudo systemctl start docker (Linux)"
+    exit 1
+  fi
+
+  DOCKER_VER=$(docker version --format '{{.Client.Version}}' 2>/dev/null || echo "unknown")
+  log_ok "Docker is running: v${DOCKER_VER}"
+}
+
+# ==============================================================================
+# SECTION 2: minikube
+# ==============================================================================
+
+install_minikube() {
+  log_section "minikube"
+
+  # Build the download URL for the current OS and architecture.
+  # minikube releases: https://github.com/kubernetes/minikube/releases
+  if [ "$OS" = "darwin" ]; then
+    MINIKUBE_URL="https://github.com/kubernetes/minikube/releases/download/v${MINIKUBE_VERSION}/minikube-darwin-${ARCH_NORM}"
+  else
+    MINIKUBE_URL="https://github.com/kubernetes/minikube/releases/download/v${MINIKUBE_VERSION}/minikube-linux-${ARCH_NORM}"
+  fi
+
+  if command -v minikube >/dev/null 2>&1; then
+    INSTALLED_MINIKUBE=$(minikube version --short 2>/dev/null | tr -d 'v' || echo "0.0.0")
+    if version_ge "$INSTALLED_MINIKUBE" "$MINIKUBE_VERSION"; then
+      log_ok "minikube already installed: v${INSTALLED_MINIKUBE} (required: v${MINIKUBE_VERSION})"
+      return 0
+    else
+      log_warn "minikube v${INSTALLED_MINIKUBE} is older than required v${MINIKUBE_VERSION}. Upgrading..."
+    fi
+  else
+    log_info "minikube not found. Installing v${MINIKUBE_VERSION} (${OS}/${ARCH_NORM})..."
+  fi
+
+  install_binary "minikube" "$MINIKUBE_URL"
+}
+
+# ==============================================================================
+# SECTION 3: kubectl
+# ==============================================================================
+
+install_kubectl() {
+  log_section "kubectl"
+
+  KUBECTL_URL="https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/${OS}/${ARCH_NORM}/kubectl"
+
+  if command -v kubectl >/dev/null 2>&1; then
+    INSTALLED_KUBECTL=$(kubectl version --client --output=json 2>/dev/null \
+      | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['clientVersion']['gitVersion'].lstrip('v'))" \
+      2>/dev/null || echo "0.0.0")
+    if version_ge "$INSTALLED_KUBECTL" "$KUBECTL_VERSION"; then
+      log_ok "kubectl already installed: v${INSTALLED_KUBECTL} (required: v${KUBECTL_VERSION})"
+      return 0
+    else
+      log_warn "kubectl v${INSTALLED_KUBECTL} is older than required v${KUBECTL_VERSION}. Upgrading..."
+    fi
+  else
+    log_info "kubectl not found. Installing v${KUBECTL_VERSION} (${OS}/${ARCH_NORM})..."
+  fi
+
+  log_info "Downloading kubectl from: ${KUBECTL_URL}"
+  curl -fsSL -o /tmp/kubectl "$KUBECTL_URL"
+  chmod +x /tmp/kubectl
+
+  # Verify checksum
+  log_info "Verifying kubectl checksum..."
+  curl -fsSL -o /tmp/kubectl.sha256 "${KUBECTL_URL}.sha256"
+  (cd /tmp && echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check) \
+    || { log_error "kubectl checksum verification FAILED. Aborting."; exit 1; }
+
+  if [ "$OS" = "linux" ]; then
+    sudo mv /tmp/kubectl /usr/local/bin/kubectl
+  else
+    if [ -d "/usr/local/bin" ] && [ -w "/usr/local/bin" ]; then
+      mv /tmp/kubectl /usr/local/bin/kubectl
+    else
+      mkdir -p "$HOME/.local/bin"
+      mv /tmp/kubectl "$HOME/.local/bin/kubectl"
+      log_warn "Installed kubectl to ~/.local/bin/kubectl — ensure this is on your PATH."
+    fi
+  fi
+
+  log_ok "kubectl v${KUBECTL_VERSION} installed at: $(command -v kubectl)"
+}
+
+# ==============================================================================
+# SECTION 4: Start minikube cluster
+# ==============================================================================
+
+start_minikube() {
+  log_section "Starting minikube cluster"
+
+  # Check if the profile already exists and is running.
+  if minikube status --profile="${MINIKUBE_PROFILE}" >/dev/null 2>&1; then
+    MINIKUBE_STATUS=$(minikube status --profile="${MINIKUBE_PROFILE}" --format='{{.Host}}' 2>/dev/null || echo "Unknown")
+    if [ "$MINIKUBE_STATUS" = "Running" ]; then
+      log_ok "minikube profile '${MINIKUBE_PROFILE}' is already running."
+      return 0
+    else
+      log_warn "minikube profile '${MINIKUBE_PROFILE}' exists but is not running. Starting..."
+      minikube start --profile="${MINIKUBE_PROFILE}"
+      return 0
+    fi
+  fi
+
+  log_info "Creating minikube cluster with profile '${MINIKUBE_PROFILE}'..."
+  log_info "Configuration:"
+  log_info "  Driver:      ${MINIKUBE_DRIVER}"
+  log_info "  CPUs:        ${MINIKUBE_CPUS}"
+  log_info "  Memory:      ${MINIKUBE_MEMORY}MB"
+  log_info "  Kubernetes:  ${KUBERNETES_VERSION}"
+  log_info "  Addons:      ${MINIKUBE_ADDONS}"
+
+  minikube start \
+    --profile="${MINIKUBE_PROFILE}" \
+    --driver="${MINIKUBE_DRIVER}" \
+    --cpus="${MINIKUBE_CPUS}" \
+    --memory="${MINIKUBE_MEMORY}" \
+    --kubernetes-version="${KUBERNETES_VERSION}" \
+    --addons="${MINIKUBE_ADDONS}"
+
+  log_ok "minikube cluster '${MINIKUBE_PROFILE}' started successfully."
+}
+
+# ==============================================================================
+# SECTION 5: Configure kubectl context
+# ==============================================================================
+
+configure_kubectl() {
+  log_section "Configuring kubectl context"
+
+  # minikube automatically sets the kubectl context when it starts.
+  # Verify the context is set correctly.
+  CURRENT_CONTEXT=$(kubectl config current-context 2>/dev/null || echo "none")
+
+  if [ "$CURRENT_CONTEXT" = "${MINIKUBE_PROFILE}" ]; then
+    log_ok "kubectl context is already set to '${MINIKUBE_PROFILE}'."
+  else
+    log_info "Setting kubectl context to '${MINIKUBE_PROFILE}'..."
+    kubectl config use-context "${MINIKUBE_PROFILE}"
+    log_ok "kubectl context set to '${MINIKUBE_PROFILE}'."
+  fi
+}
+
+# ==============================================================================
+# SECTION 6: Verify cluster is ready
+# ==============================================================================
+
+verify_cluster() {
+  log_section "Verifying cluster readiness"
+
+  log_info "Waiting for all nodes to be Ready (timeout: 120s)..."
+  kubectl wait --for=condition=Ready nodes --all --timeout=120s
+
+  log_info "Cluster nodes:"
+  kubectl get nodes -o wide
+
+  log_info "Waiting for core system pods to be Running..."
+  kubectl wait --for=condition=Ready pods \
+    --all \
+    --namespace=kube-system \
+    --timeout=120s \
+    2>/dev/null || log_warn "Some kube-system pods are not yet Ready — this may be normal during startup."
+
+  # Verify the ingress addon if enabled
+  if echo "${MINIKUBE_ADDONS}" | grep -q "ingress"; then
+    log_info "Waiting for ingress-nginx controller..."
+    kubectl wait --for=condition=Ready pods \
+      --all \
+      --namespace=ingress-nginx \
+      --timeout=120s \
+      2>/dev/null || log_warn "ingress-nginx pods are not yet Ready."
+  fi
+
+  log_ok "Cluster is ready."
+}
+
+# ==============================================================================
+# MAIN
+# ==============================================================================
+
+main() {
+  log_section "kube-platform minikube installer"
+  log_info "Platform: ${OS}/${ARCH} (normalized: ${ARCH_NORM})"
+  log_info "Versions to install:"
+  log_info "  minikube:   v${MINIKUBE_VERSION}"
+  log_info "  kubectl:    v${KUBECTL_VERSION}"
+  log_info "  Kubernetes: ${KUBERNETES_VERSION}"
+  echo ""
+
+  check_docker
+  install_minikube
+  install_kubectl
+  start_minikube
+  configure_kubectl
+  verify_cluster
+
+  # ---- Summary ---------------------------------------------------------------
+  log_section "Installation Summary"
+
+  if command -v minikube >/dev/null 2>&1; then
+    log_ok "minikube  : $(minikube version --short)"
+  else
+    log_error "minikube  : not found"
+  fi
+
+  if command -v kubectl >/dev/null 2>&1; then
+    log_ok "kubectl   : $(kubectl version --client --short 2>/dev/null || kubectl version --client)"
+  else
+    log_error "kubectl   : not found"
+  fi
+
+  if command -v docker >/dev/null 2>&1; then
+    DOCKER_VER=$(docker version --format '{{.Client.Version}}' 2>/dev/null || echo "installed")
+    log_ok "docker    : v${DOCKER_VER}"
+  fi
+
+  echo ""
+  log_ok "minikube cluster '${MINIKUBE_PROFILE}' is running. Next steps:"
+  echo ""
+  echo "  1. Verify the cluster:"
+  echo "       kubectl get nodes"
+  echo "       kubectl get pods --all-namespaces"
+  echo ""
+  echo "  2. Access the minikube dashboard:"
+  echo "       minikube dashboard --profile=${MINIKUBE_PROFILE}"
+  echo ""
+  echo "  3. Get the minikube IP (for ingress):"
+  echo "       minikube ip --profile=${MINIKUBE_PROFILE}"
+  echo ""
+  echo "  4. Deploy this repo's manifests:"
+  echo "       kubectl apply -k core/"
+  echo ""
+  echo "  5. Deploy with Helm:"
+  echo "       helm install apache ./helm/apache -n web --create-namespace"
+  echo "       helm install node-app ./helm/node-app -n api --create-namespace"
+  echo "       helm install mysql ./helm/mysql -n data --create-namespace"
+  echo ""
+  echo "  6. Or deploy all with helmfile:"
+  echo "       helmfile sync"
+  echo ""
+  echo "  7. Stop the cluster when done:"
+  echo "       minikube stop --profile=${MINIKUBE_PROFILE}"
+  echo ""
+  echo "Or simply run:  make bootstrap"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

### Helm MySQL Chart
Full production-grade Helm chart for MySQL StatefulSet:
- `helm/mysql/Chart.yaml`, `values.yaml`, `values.schema.json`, `.helmignore`
- `helm/mysql/templates/` — `_helpers.tpl`, `statefulset.yaml`, `service.yaml`, `service-headless.yaml`, `secret.yaml`, `configmap.yaml`, `pdb.yaml`, `serviceaccount.yaml`, `NOTES.txt`

### Helm Chart Enhancements
- `helm/apache/templates/hooks/post-install-job.yaml` — post-install Job running smoke test
- `helm/apache/tests/deployment_test.yaml`, `service_test.yaml` — helm-unittest test suites
- `helm/node-app/tests/deployment_test.yaml`, `service_test.yaml` — helm-unittest test suites

### Helmfile
- `helmfile.yaml` — multi-chart orchestration with dev/staging/prod environments and per-release values overrides

### Cluster Setup
- `setup/local/minikube/install.sh` — idempotent Minikube installer with driver detection
- `setup/cloud/gke/README.md` — GKE cluster creation with Autopilot and node pool configuration
- `setup/cloud/aks/README.md` — AKS cluster creation with managed identity and addons

### Application Examples
- `examples/easyshop-kind/redis-deployment.yml`, `redis-service.yml`, `redis-configmap.yml` — Redis cache layer for EasyShop
- `examples/multi-tier/` — 15-file production multi-tier app (frontend + backend + database + cache + ingress + network-policy + HPA + PDB)
- `examples/cert-manager/cluster-issuer.yml`, `ingress-with-cert.yml`, `README.md` — Let's Encrypt TLS with cert-manager

### Backup & DR
- `platform/storage/velero/backup-schedule.yml` — Velero Schedule for nightly namespace backups
- `platform/storage/velero/restore-example.yml` — Velero Restore from a named backup
- `platform/storage/velero/README.md` — Velero installation and backup/restore workflow

## Issues closed

Closes #1
Closes #4
Closes #55
Closes #56
Closes #57
Closes #58
Closes #71
Closes #72
Closes #73
Closes #88
Closes #91

## Test plan

- [ ] `helm lint helm/mysql/` passes
- [ ] `helm template helm/mysql/` renders without errors
- [ ] `helm unittest helm/apache/` passes
- [ ] `helm unittest helm/node-app/` passes
- [ ] `helmfile lint` passes
- [ ] `shellcheck setup/local/minikube/install.sh` passes
- [ ] All example manifests pass yamllint

🤖 Generated with [Claude Code](https://claude.com/claude-code)